### PR TITLE
Fix reference to is_preview local variable

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -51,5 +51,5 @@ resource "azurerm_key_vault_secret" "queue_send_connection_string" {
   name      = "envelope-queue-send-conn-string"
   value     = "${module.queue.primary_send_connection_string}"
   vault_uri = "${local.keyVaultUri}"
-  count     = "${is_preview ? "0": "1"}"
+  count     = "${local.is_preview ? "0": "1"}"
 }


### PR DESCRIPTION
### Change description ###

Fix reference to is_preview local variable in terraform code.

Successful build on sprod: https://sandbox-build.platform.hmcts.net/job/HMCTS/job/bulk-scan-orchestrator/job/fix%252Fis-preview/2/

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
