### PR TITLE
[PREVIEW] Fix instantiation of bulk scan processor client

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/AppConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/AppConfiguration.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.bulkscanprocessorclient.client.BulkScanProcessorClient;
+
+@Configuration
+public class AppConfiguration {
+
+    @Bean
+    public BulkScanProcessorClient envelopeService(
+        @Value("${bulk-scan-processor-url}") String bulkScanProcessorUrl
+    ) {
+        return new BulkScanProcessorClient(
+            bulkScanProcessorUrl,
+            () -> "s2s_token" // TODO: use s2s client to get token
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/bulkscanprocessorclient/client/BulkScanProcessorClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/bulkscanprocessorclient/client/BulkScanProcessorClient.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.bulkscanprocessorclie
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.bulkscanprocessorclient.exceptions.ReadEnvelopeException;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/bulkscanprocessorclient/client/BulkScanProcessorClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/bulkscanprocessorclient/client/BulkScanProcessorClient.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.bulkscanprocessorclien
 
 import java.util.function.Supplier;
 
-@Service
 public class BulkScanProcessorClient {
 
     private final RestTemplate restTemplate = new RestTemplate();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,3 +9,5 @@ management:
 spring:
   application:
     name: Bulk Scan Orchestrator
+
+bulk-scan-processor-url: ${BULK_SCAN_PROCESSOR_URL:}


### PR DESCRIPTION
It was marked with the `@Service` annotation so Spring attempted to create it at application start (but there was no `bulkScanProcessorUrl` to use in constructor)