### PR TITLE
Gitignore application-default.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 *.ipr
 
 .DS_store
+/src/main/resources/application-default.yaml


### PR DESCRIPTION
File can be used to override config in `application.yaml` (for local development for example)