### PR TITLE
Handle test messages

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeProcessor.java
@@ -13,8 +13,12 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.bulkscanprocessorclien
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.ReceiverProvider;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.exceptions.ConnectionException;
 
+import java.util.Objects;
+
 @Service
 public class EnvelopeProcessor {
+    public static final String TEST_MSG_LABEL = "test";
+
     private static final Logger logger = LoggerFactory.getLogger(EnvelopeProcessor.class);
 
     private final ReceiverProvider receiverProvider;
@@ -48,8 +52,12 @@ public class EnvelopeProcessor {
         throws InterruptedException, ServiceBusException {
 
         try {
-            Envelope envelope = bulkScanProcessorClient.getEnvelopeById(msg.getMessageId()); // NOPMD
-            // TODO: use envelop data to interact with CCD
+            if (Objects.equals(msg.getLabel(), TEST_MSG_LABEL)) {
+                logger.info("Received test message");
+            } else {
+                Envelope envelope = bulkScanProcessorClient.getEnvelopeById(msg.getMessageId()); // NOPMD
+                // TODO: use envelop data to interact with CCD
+            }
             messageReceiver.complete(msg.getLockToken());
         } catch (ReadEnvelopeException exc) {
             logger.error("Unable to read envelope with ID: " + exc.envelopeId, exc);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeProcessorTest.java
@@ -110,4 +110,23 @@ public class EnvelopeProcessorTest {
         // then
         verify(receiver, never()).complete(any());
     }
+
+    @Test
+    public void should_not_read_envelopes_for_test_queue_messages() throws Exception {
+        // given
+        UUID lockToken = UUID.randomUUID();
+        given(someMessage.getLockToken()).willReturn(lockToken);
+        given(someMessage.getLabel()).willReturn(EnvelopeProcessor.TEST_MSG_LABEL);
+
+        given(receiver.receive())
+            .willReturn(someMessage)
+            .willReturn(null);
+
+        // when
+        processor.run();
+
+        // then
+        verify(receiver).complete(eq(lockToken));
+        verify(bulkScanProcessorClient, never()).getEnvelopeById(any());
+    }
 }


### PR DESCRIPTION
To be used in functional / smoke tests.

Use message label to determine whether an envelope should be read from the core service.