### PR TITLE
Reuse jenkins library gradle config

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,17 +1,17 @@
 #!groovy
-
 @Library("Infrastructure")
+import uk.gov.hmcts.contino.GradleBuilder
 
 def type = "java"
 def product = "bulk-scan"
 def component = "orchestrator"
 
 def channel = '#rpe-build-notices'
-
+GradleBuilder builder = new GradleBuilder(this, product)
 
 withPipeline(type, product, component) {
   after('test') {
-    sh './gradlew integration'
+    builder.gradle('integration')
   }
 
   enableDockerBuild()


### PR DESCRIPTION
### JIRA link (if applicable) ###
none


### Change description ###
Reuse the gradle config in the jenkins-library so we stay in sync


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
