### PR TITLE
RPE-715: refactoring MessageProcessor into EnvelopeEventProcessor: IMessageHandler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,11 +81,13 @@ pmd {
 }
 
 jacocoTestReport {
+  dependsOn test,integration
   executionData(test, integration)
   reports {
     xml.enabled = true
     csv.enabled = false
-    xml.destination = file("${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml")
+    html.destination file("${buildDir}/reports/jacoco/html")
+    xml.destination  file("${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml")
   }
 }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -24,8 +24,12 @@ public class EnvelopeEventProcessor implements IMessageHandler {
          * Maybe consider using Netflix's RxJava too (much simpler than CompletableFuture).
          */
         CompletableFuture<Void> completableFuture = new CompletableFuture<>();
-        process(message);
-        completableFuture.complete(null);
+        try {
+            process(message);
+            completableFuture.complete(null);
+        } catch (Throwable t) {
+            completableFuture.completeExceptionally(t);
+        }
         return completableFuture;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services;
+
+import com.microsoft.azure.servicebus.ExceptionPhase;
+import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.IMessageHandler;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.bulkscanprocessorclient.client.BulkScanProcessorClient;
+
+import java.util.concurrent.CompletableFuture;
+
+@Component
+public class EnvelopeEventProcessor implements IMessageHandler {
+    private BulkScanProcessorClient bulkScanProcessorClient;
+
+    public EnvelopeEventProcessor(BulkScanProcessorClient bulkScanProcessorClient) {
+        this.bulkScanProcessorClient = bulkScanProcessorClient;
+    }
+
+    @Override
+    public CompletableFuture<Void> onMessageAsync(IMessage message) {
+        /*
+         * NOTE: this is done here instead of offloading to the forkJoin pool "CompletableFuture.runAsync()"
+         * because we probably should think about a threading model before doing this.
+         * Maybe consider using Netflix's RxJava too (much simpler than CompletableFuture).
+         */
+        CompletableFuture<Void> completableFuture = new CompletableFuture<>();
+        process(message);
+        completableFuture.complete(null);
+        return completableFuture;
+    }
+
+    private void process(IMessage message) {
+        bulkScanProcessorClient.getEnvelopeById(message.getMessageId());
+    }
+
+    @Override
+    public void notifyException(Throwable exception, ExceptionPhase phase) {
+        //No exceptions expected until we use the azure API
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services;
+
+import com.microsoft.azure.servicebus.IMessage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.bulkscanprocessorclient.client.BulkScanProcessorClient;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EnvelopeEventProcessorTest {
+
+    @Mock
+    BulkScanProcessorClient bulkScanProcessorClient;
+
+    private EnvelopeEventProcessor envelopeEventProcessor;
+
+    @Mock
+    private IMessage someMessage;
+    private static final String MSG_ID = "hello!";
+
+    @Before
+    public void before() {
+        envelopeEventProcessor = new EnvelopeEventProcessor(bulkScanProcessorClient);
+    }
+
+    @Test
+    public void should_use_queue_message_id_to_read_envelope() throws ExecutionException, InterruptedException {
+        //given
+        given(someMessage.getMessageId()).willReturn(MSG_ID);
+
+        // when
+        envelopeEventProcessor.onMessageAsync(someMessage).get();
+
+        // then
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(bulkScanProcessorClient).getEnvelopeById(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue()).isEqualTo(MSG_ID);
+    }
+
+    @Test
+    public void should_not_do_anything_in_notify() {
+        // when
+        envelopeEventProcessor.notifyException(null, null);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/MessageProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/MessageProcessorTest.java
@@ -2,41 +2,62 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services;
 
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IMessageReceiver;
+import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.bulkscanprocessorclient.client.BulkScanProcessorClient;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.bulkscanprocessorclient.exceptions.ReadEnvelopeException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.ReceiverProvider;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.MessageProcessor.TEST_MSG_LABEL;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MessageProcessorTest {
+    @Mock
+    private ReceiverProvider receiverProvider;
+    @Mock
+    private IMessage someMessage;
+    @Mock
+    private IMessageReceiver receiver;
+    @Mock
+    private EnvelopeEventProcessor envelopeEventProcessor;
 
-    @Mock private BulkScanProcessorClient bulkScanProcessorClient;
-    @Mock private ReceiverProvider receiverProvider;
-
-    @Mock private IMessage someMessage;
-    @Mock private IMessageReceiver receiver;
-
-    private MessageProcessor processor;
+    private MessageProcessor messageProcessor;
 
     @Before
-    public void setUp() throws Exception {
-        this.processor = new MessageProcessor(receiverProvider, bulkScanProcessorClient);
+    public void setUp() {
+        CompletableFuture<Void> value = new CompletableFuture<>();
+        value.complete(null);
+        when(this.envelopeEventProcessor.onMessageAsync(someMessage)).thenReturn(value);
+        this.messageProcessor = new MessageProcessor(receiverProvider, envelopeEventProcessor);
         given(receiverProvider.get()).willReturn(receiver);
+    }
+
+    @Test
+    public void should_handle_exceptions_off_receiver_get()
+        throws ServiceBusException, InterruptedException {
+        // given
+        given(receiverProvider.get()).willThrow(new RuntimeException());
+
+        // when
+        messageProcessor.run();
+
+        // then
+        verify(envelopeEventProcessor, times(0)).onMessageAsync(someMessage);
+        verify(receiver, times(0)).receive();
     }
 
     @Test
@@ -49,33 +70,24 @@ public class MessageProcessorTest {
             .willReturn(null);
 
         // when
-        processor.run();
+        messageProcessor.run();
 
         // then
-        verify(bulkScanProcessorClient, times(2)).getEnvelopeById(any());
+        verify(envelopeEventProcessor, times(2)).onMessageAsync(someMessage);
         verify(receiver, times(3)).receive();
     }
 
+
     @Test
-    public void should_use_queue_message_id_to_read_envelope() throws Exception {
-        // given
-        final String msgId = "hello!";
-        given(someMessage.getMessageId())
-            .willReturn(msgId);
-
-        given(receiver.receive())
-            .willReturn(someMessage)
-            .willReturn(null);
-
-        // when
-        processor.run();
-
-        // then
-        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
-        verify(bulkScanProcessorClient).getEnvelopeById(argumentCaptor.capture());
-
-        assertThat(argumentCaptor.getValue()).isEqualTo(msgId);
+    public void should_handle_interruptedException_completable_correctly() throws Exception {
+        testCompletable(interruptedExceptionCompletable());
     }
+
+    @Test
+    public void should_handle_runtimeException_completable_correctly() throws Exception {
+        testCompletable(runtimeExceptionCompletable());
+    }
+
 
     @Test
     public void should_complete_message_after_it_is_successfully_processed() throws Exception {
@@ -88,27 +100,10 @@ public class MessageProcessorTest {
             .willReturn(null);
 
         // when
-        processor.run();
+        messageProcessor.run();
 
         // then
         verify(receiver).complete(eq(lockToken));
-    }
-
-    @Test
-    public void should_not_complete_message_if_envelope_cannot_be_read() throws Exception {
-        // given
-        given(bulkScanProcessorClient.getEnvelopeById(any()))
-            .willThrow(ReadEnvelopeException.class);
-
-        given(receiver.receive())
-            .willReturn(someMessage)
-            .willReturn(null);
-
-        // when
-        processor.run();
-
-        // then
-        verify(receiver, never()).complete(any());
     }
 
     @Test
@@ -116,17 +111,46 @@ public class MessageProcessorTest {
         // given
         UUID lockToken = UUID.randomUUID();
         given(someMessage.getLockToken()).willReturn(lockToken);
-        given(someMessage.getLabel()).willReturn(MessageProcessor.TEST_MSG_LABEL);
+        given(someMessage.getLabel()).willReturn(TEST_MSG_LABEL);
 
         given(receiver.receive())
             .willReturn(someMessage)
             .willReturn(null);
 
         // when
-        processor.run();
+        messageProcessor.run();
 
         // then
         verify(receiver).complete(eq(lockToken));
-        verify(bulkScanProcessorClient, never()).getEnvelopeById(any());
+        verify(envelopeEventProcessor, never()).onMessageAsync(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CompletableFuture<Void> interruptedExceptionCompletable()
+        throws ExecutionException, InterruptedException {
+        CompletableFuture<Void> mock = (CompletableFuture<Void>) mock(CompletableFuture.class);
+        when(mock.get()).thenThrow(new InterruptedException());
+        return mock;
+    }
+
+    private static CompletableFuture<Void> runtimeExceptionCompletable() {
+        CompletableFuture<Void> value = new CompletableFuture<>();
+        value.completeExceptionally(new RuntimeException());
+        return value;
+    }
+
+
+    private void testCompletable(CompletableFuture<Void> completable) throws Exception {
+        given(envelopeEventProcessor.onMessageAsync(someMessage)).willReturn(completable);
+        given(receiver.receive())
+            .willReturn(someMessage)
+            .willReturn(someMessage)
+            .willReturn(null);
+
+        // when
+        messageProcessor.run();
+
+        // then
+        verify(receiver, never()).complete(any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/MessageProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/MessageProcessorTest.java
@@ -26,14 +26,10 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.MessageProcesso
 
 @RunWith(MockitoJUnitRunner.class)
 public class MessageProcessorTest {
-    @Mock
-    private ReceiverProvider receiverProvider;
-    @Mock
-    private IMessage someMessage;
-    @Mock
-    private IMessageReceiver receiver;
-    @Mock
-    private EnvelopeEventProcessor envelopeEventProcessor;
+    @Mock private ReceiverProvider receiverProvider;
+    @Mock private IMessage someMessage;
+    @Mock private IMessageReceiver receiver;
+    @Mock private EnvelopeEventProcessor envelopeEventProcessor;
 
     private MessageProcessor messageProcessor;
 


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/RPE-715

Change description
Extracted out the Envelope processor part out into new class and rename the current EnvelopeProcessor to the Message Processor to indicate the message layer processing ( scheduled loop)
Also refactored to the Azure API IMessageHandler to help with future refactoring to use the Azure sdk for the Azure ServiceBus.
Note: Im not too sure about all the Completable futures used. Id personally prefer using RxJava for the Async bits but this is a quick first working draft.

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x ] No