### PR TITLE
[PREVIEW] RPE-715: refactored the GetEnvelopeTest to use the shaded Wiremock and pass locally.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,7 @@ dependencies {
   compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.7'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
-  testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.18.0'
+  testCompile group: 'com.github.tomakehurst', name: 'wiremock-standalone', version: '2.18.0'
   testCompile group: 'com.typesafe', name: 'config', version: '1.3.3'
 
   integrationTestCompile sourceSets.main.runtimeClasspath

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -12,128 +12,15 @@
   <!-- this is for the TEST jar wiremock-standalone -->
   <suppress>
     <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-security:9.2.24.v20180105)
+       file name: wiremock-standalone-2..0.jar.
+       This is only used for TESTING purposes.
    ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-security:.*$</gav>
-    <cpe>cpe:/a:eclipse:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-security:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-security:.*$</gav>
-    <cpe>cpe:/a:jetty:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-server:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-server:.*$</gav>
-    <cpe>cpe:/a:eclipse:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-server:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-server:.*$</gav>
-    <cpe>cpe:/a:jetty:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-servlets:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-servlets:.*$</gav>
-    <cpe>cpe:/a:eclipse:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-servlets:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-servlets:.*$</gav>
-    <cpe>cpe:/a:jetty:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: com.fasterxml.jackson.core:jackson-databind:2.8.11)
-   ]]></notes>
-    <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
-    <cpe>cpe:/a:fasterxml:jackson-databind</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: com.fasterxml.jackson.core:jackson-databind:2.8.11)
-   ]]></notes>
-    <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
-    <cpe>cpe:/a:fasterxml:jackson</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-http:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-http:.*$</gav>
-    <cpe>cpe:/a:eclipse:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-http:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-http:.*$</gav>
-    <cpe>cpe:/a:jetty:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-continuation:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-continuation:.*$</gav>
-    <cpe>cpe:/a:eclipse:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-continuation:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-continuation:.*$</gav>
-    <cpe>cpe:/a:jetty:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-xml:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-xml:.*$</gav>
-    <cpe>cpe:/a:eclipse:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-xml:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-xml:.*$</gav>
-    <cpe>cpe:/a:jetty:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-util:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-util:.*$</gav>
-    <cpe>cpe:/a:eclipse:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-util:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-util:.*$</gav>
-    <cpe>cpe:/a:jetty:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-webapp:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-webapp:.*$</gav>
-    <cpe>cpe:/a:eclipse:jetty</cpe>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-servlet:9.2.24.v20180105)
-   ]]></notes>
-    <gav regex="true">^org\.eclipse\.jetty:jetty-servlet:.*$</gav>
-    <cpe>cpe:/a:eclipse:jetty</cpe>
+    <filePath regex="true">.*wiremock-standalone-2\.18\.0\.jar.*</filePath>
+    <cve>CVE-2017-7656</cve>
+    <cve>CVE-2017-7657</cve>
+    <cve>CVE-2017-7658</cve>
+    <cve>CVE-2017-9735</cve>
+    <cve>CVE-2018-5968</cve>
+    <cve>CVE-2018-7489</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,7 +15,7 @@
        file name: wiremock-standalone-2..0.jar.
        This is only used for TESTING purposes.
    ]]></notes>
-    <filePath regex="true">.*wiremock-standalone-2\.18\.0\.jar.*</filePath>
+    <filePath regex="true">.*wiremock-standalone-.*\.jar.*</filePath>
     <cve>CVE-2017-7656</cve>
     <cve>CVE-2017-7657</cve>
     <cve>CVE-2017-7658</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -9,4 +9,131 @@
     <cve>CVE-2011-1068</cve>
   </suppress>
 
+  <!-- this is for the TEST jar wiremock-standalone -->
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-security:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-security:.*$</gav>
+    <cpe>cpe:/a:eclipse:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-security:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-security:.*$</gav>
+    <cpe>cpe:/a:jetty:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-server:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-server:.*$</gav>
+    <cpe>cpe:/a:eclipse:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-server:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-server:.*$</gav>
+    <cpe>cpe:/a:jetty:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-servlets:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-servlets:.*$</gav>
+    <cpe>cpe:/a:eclipse:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-servlets:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-servlets:.*$</gav>
+    <cpe>cpe:/a:jetty:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: com.fasterxml.jackson.core:jackson-databind:2.8.11)
+   ]]></notes>
+    <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+    <cpe>cpe:/a:fasterxml:jackson-databind</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: com.fasterxml.jackson.core:jackson-databind:2.8.11)
+   ]]></notes>
+    <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+    <cpe>cpe:/a:fasterxml:jackson</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-http:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-http:.*$</gav>
+    <cpe>cpe:/a:eclipse:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-http:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-http:.*$</gav>
+    <cpe>cpe:/a:jetty:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-continuation:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-continuation:.*$</gav>
+    <cpe>cpe:/a:eclipse:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-continuation:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-continuation:.*$</gav>
+    <cpe>cpe:/a:jetty:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-xml:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-xml:.*$</gav>
+    <cpe>cpe:/a:eclipse:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-xml:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-xml:.*$</gav>
+    <cpe>cpe:/a:jetty:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-util:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-util:.*$</gav>
+    <cpe>cpe:/a:eclipse:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-util:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-util:.*$</gav>
+    <cpe>cpe:/a:jetty:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-webapp:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-webapp:.*$</gav>
+    <cpe>cpe:/a:eclipse:jetty</cpe>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: wiremock-standalone-2.18.0.jar (shaded: org.eclipse.jetty:jetty-servlet:9.2.24.v20180105)
+   ]]></notes>
+    <gav regex="true">^org\.eclipse\.jetty:jetty-servlet:.*$</gav>
+    <cpe>cpe:/a:eclipse:jetty</cpe>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###
-  added the standalone jar to remove transitive dependencies of wiremock (was failing to run under intelliJ)
- minor refactor of the `GetEnvelopeTest` test to allow the it to run under intelliJ (run all tests)
```
[ ] Yes
[ x ] No
```
