### PR TITLE
Enable more endpoints

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,9 +3,9 @@ server:
 
 management:
   endpoints:
-    exposure:
-      include: '*'
     web:
+      exposure:
+        include: '*'
       base-path: /
   endpoint:
     health:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,8 +3,13 @@ server:
 
 management:
   endpoints:
+    exposure:
+      include: '*'
     web:
       base-path: /
+  endpoint:
+    health:
+      show-details: always
 
 spring:
   application:


### PR DESCRIPTION
### Change description ###
In spring boot 2 only health and info are enabled by default,
There's lots more useful endpoints that make debugging a lot easier.

Things like changing log levels at runtime, checking configuration properties or environment variables
See a list here:
https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
