### PR TITLE
[PREVIEW] Read envelope data from the queue

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ReadFromTheQueueTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ReadFromTheQueueTest.java
@@ -8,12 +8,16 @@ import com.microsoft.azure.servicebus.ReceiveMode;
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.MessageProcessor;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 import java.util.UUID;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReadFromTheQueueTest {
@@ -44,7 +48,7 @@ public class ReadFromTheQueueTest {
         // given
         Message message = new Message();
         message.setMessageId(UUID.randomUUID().toString());
-        message.setLabel(MessageProcessor.TEST_MSG_LABEL);
+        message.setBody(SampleData.envelopeJson().getBytes());
 
         // when
         writeClient.send(message);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ReadFromTheQueueTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ReadFromTheQueueTest.java
@@ -8,16 +8,11 @@ import com.microsoft.azure.servicebus.ReceiveMode;
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 import java.util.UUID;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReadFromTheQueueTest {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -4,6 +4,8 @@ import com.microsoft.azure.servicebus.ExceptionPhase;
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IMessageHandler;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.EnvelopeParser;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -19,7 +21,8 @@ public class EnvelopeEventProcessor implements IMessageHandler {
          */
         CompletableFuture<Void> completableFuture = new CompletableFuture<>();
         try {
-            // TODO: handle message
+            Envelope envelope = EnvelopeParser.parse(message.getBody());
+            // TODO: use data from envelope to call CCD
             completableFuture.complete(null);
         } catch (Throwable t) {
             completableFuture.completeExceptionally(t);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
+
+import static java.util.Arrays.asList;
+
+public class SampleData {
+
+    public static String envelopeJson() throws Exception {
+        return new JSONObject()
+            .put("id", "")
+            .put("case_ref", "eb9c3598-35fc-424e-b05a-902ee9f11d56")
+            .put("jurisdiction", "SSCS")
+            .put("classification", Classification.NEW_APPLICATION)
+            .put("doc_urls", new JSONArray(asList("a", "b")))
+            .toString();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -17,4 +17,8 @@ public class SampleData {
             .put("doc_urls", new JSONArray(asList("a", "b")))
             .toString();
     }
+
+    private SampleData() {
+        // util class
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -10,8 +10,8 @@ public class SampleData {
 
     public static String envelopeJson() throws Exception {
         return new JSONObject()
-            .put("id", "")
-            .put("case_ref", "eb9c3598-35fc-424e-b05a-902ee9f11d56")
+            .put("id", "eb9c3598-35fc-424e-b05a-902ee9f11d56")
+            .put("case_ref", "ABC123")
             .put("jurisdiction", "SSCS")
             .put("classification", Classification.NEW_APPLICATION)
             .put("doc_urls", new JSONArray(asList("a", "b")))

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -6,10 +6,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData;
 
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EnvelopeEventProcessorTest {
@@ -24,13 +26,29 @@ public class EnvelopeEventProcessorTest {
     }
 
     @Test
-    public void should_return_completed_future_if_everything_went_fine() {
+    public void should_return_completed_future_if_everything_went_fine() throws Exception {
+        // given
+        given(someMessage.getBody()).willReturn(SampleData.envelopeJson().getBytes());
+
         // when
         CompletableFuture<Void> result = processor.onMessageAsync(someMessage);
 
         // then
         assertThat(result.isDone()).isTrue();
         assertThat(result.isCompletedExceptionally()).isFalse();
+    }
+
+    @Test
+    public void should_return_exceptionally_completed_future_if_queue_message_contains_invalid_envelope() {
+        // given
+        given(someMessage.getBody())
+            .willReturn("foo".getBytes());
+
+        // when
+        CompletableFuture<Void> result = processor.onMessageAsync(someMessage);
+
+        // then
+        assertThat(result.isCompletedExceptionally()).isTrue();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/MessageProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/MessageProcessorTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.MessageProcessor.TEST_MSG_LABEL;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MessageProcessorTest {
@@ -100,25 +99,6 @@ public class MessageProcessorTest {
 
         // then
         verify(receiver).complete(eq(lockToken));
-    }
-
-    @Test
-    public void should_not_read_envelopes_for_test_queue_messages() throws Exception {
-        // given
-        UUID lockToken = UUID.randomUUID();
-        given(someMessage.getLockToken()).willReturn(lockToken);
-        given(someMessage.getLabel()).willReturn(TEST_MSG_LABEL);
-
-        given(receiver.receive())
-            .willReturn(someMessage)
-            .willReturn(null);
-
-        // when
-        messageProcessor.run();
-
-        // then
-        verify(receiver).complete(eq(lockToken));
-        verify(envelopeEventProcessor, never()).onMessageAsync(any());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Note that test label is no longer used (it was previously used to prevent making calls to core service, now queue message has everything it needs)