### PR TITLE
Introduce factory for case record creator

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseDataCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseDataCreator.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model;
+
+import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
+import uk.gov.hmcts.reform.ccd.client.model.Classification;
+
+public interface CaseDataCreator {
+
+    CaseDataContent createDataContent(
+        Classification classification,
+        String eventToken,
+        boolean ignoreWarning
+    );
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseRecord.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model;
+
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+public interface CaseRecord extends CaseDataCreator {
+
+    @FunctionalInterface
+    interface Construct {
+        CaseDataCreator apply(Envelope envelope, CaseDetails caseDetails);
+    }
+
+    enum Record {
+        EXCEPTION_RECORD,
+        SUPPLEMENTARY_EVIDENCE,
+    }
+
+    Record getCaseRecordIdentifier();
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseRecordFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseRecordFactory.java
@@ -1,11 +1,12 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model;
 
+import com.google.common.collect.ImmutableMap;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.caserecord.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.caserecord.SupplementaryEvidenceRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.CaseRecord.Construct;
@@ -13,12 +14,10 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.CaseR
 
 public final class CaseRecordFactory {
 
-    private static final Map<Record, Construct> AVAILABLE_MODELS = new HashMap<>();
-
-    static {
-        AVAILABLE_MODELS.put(Record.EXCEPTION_RECORD, ExceptionRecord::new);
-        AVAILABLE_MODELS.put(Record.SUPPLEMENTARY_EVIDENCE, SupplementaryEvidenceRecord::new);
-    }
+    private static final Map<Record, Construct> AVAILABLE_MODELS = new EnumMap<>(ImmutableMap.of(
+        Record.EXCEPTION_RECORD, ExceptionRecord::new,
+        Record.SUPPLEMENTARY_EVIDENCE, SupplementaryEvidenceRecord::new
+    ));
 
     public static CaseDataCreator getCaseDataCreator(Envelope envelope, CaseDetails caseDetails) {
         Record record;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseRecordFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseRecordFactory.java
@@ -19,12 +19,12 @@ public final class CaseRecordFactory {
         Record.SUPPLEMENTARY_EVIDENCE, SupplementaryEvidenceRecord::new
     ));
 
-    public static CaseDataCreator getCaseDataCreator(Envelope envelope, CaseDetails caseDetails) {
+    public static CaseDataCreator getCaseDataCreator(Envelope envelope, CaseDetails existingCase) {
         Record record;
 
         switch (envelope.classification) {
             case SUPPLEMENTARY_EVIDENCE:
-                record = Record.SUPPLEMENTARY_EVIDENCE;
+                record = existingCase == null ? Record.EXCEPTION_RECORD : Record.SUPPLEMENTARY_EVIDENCE;
 
                 break;
             case EXCEPTION:
@@ -35,7 +35,7 @@ public final class CaseRecordFactory {
                 break;
         }
 
-        return AVAILABLE_MODELS.get(record).apply(envelope, caseDetails);
+        return AVAILABLE_MODELS.get(record).apply(envelope, existingCase);
     }
 
     private CaseRecordFactory() {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseRecordFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseRecordFactory.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model;
+
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.caserecord.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.caserecord.SupplementaryEvidenceRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.CaseRecord.Construct;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.CaseRecord.Record;
+
+public final class CaseRecordFactory {
+
+    private static final Map<Record, Construct> AVAILABLE_MODELS = new HashMap<>();
+
+    static {
+        AVAILABLE_MODELS.put(Record.EXCEPTION_RECORD, ExceptionRecord::new);
+        AVAILABLE_MODELS.put(Record.SUPPLEMENTARY_EVIDENCE, SupplementaryEvidenceRecord::new);
+    }
+
+    public static CaseDataCreator getCaseDataCreator(Envelope envelope, CaseDetails caseDetails) {
+        Record record;
+
+        switch (envelope.classification) {
+            case SUPPLEMENTARY_EVIDENCE:
+                record = Record.SUPPLEMENTARY_EVIDENCE;
+
+                break;
+            case EXCEPTION:
+            case NEW_APPLICATION:
+            default:
+                record = Record.EXCEPTION_RECORD;
+
+                break;
+        }
+
+        return AVAILABLE_MODELS.get(record).apply(envelope, caseDetails);
+    }
+
+    private CaseRecordFactory() {
+        // utility class constructor
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/caserecord/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/caserecord/ExceptionRecord.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.caserecord;
+
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.CaseRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.ccd.client.model.Classification;
+
+public class ExceptionRecord implements CaseRecord {
+
+    private final Envelope envelope;
+    private final CaseDetails caseDetails;
+
+    public ExceptionRecord(Envelope envelope, CaseDetails caseDetails) {
+        this.envelope = envelope;
+        this.caseDetails = caseDetails;
+    }
+
+    @Override
+    public CaseDataContent createDataContent(
+        Classification classification,
+        String eventToken,
+        boolean ignoreWarning
+    ) {
+        return null;
+    }
+
+    @Override
+    public Record getCaseRecordIdentifier() {
+        return Record.EXCEPTION_RECORD;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/caserecord/SupplementaryEvidenceRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/caserecord/SupplementaryEvidenceRecord.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.caserecord;
+
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.CaseRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.ccd.client.model.Classification;
+
+public class SupplementaryEvidenceRecord implements CaseRecord {
+
+    private final Envelope envelope;
+    private final CaseDetails caseDetails;
+
+    public SupplementaryEvidenceRecord(Envelope envelope, CaseDetails caseDetails) {
+        this.envelope = envelope;
+        this.caseDetails = caseDetails;
+    }
+
+    @Override
+    public CaseDataContent createDataContent(
+        Classification classification,
+        String eventToken,
+        boolean ignoreWarning
+    ) {
+        return null;
+    }
+
+    @Override
+    public Record getCaseRecordIdentifier() {
+        return Record.SUPPLEMENTARY_EVIDENCE;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseRecordFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseRecordFactoryTest.java
@@ -1,0 +1,66 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.caserecord.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.caserecord.SupplementaryEvidenceRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CaseRecordFactoryTest {
+
+    private static final String ENVELOPE_ID = "id";
+    private static final String ENVELOPE_CASE_REF = "caseRef";
+    private static final String ENVELOPE_JURISDICTION = "jurisdiction";
+    private static final String ENVELOPE_ZIP_FILE_NAME = "zip";
+
+    @Test
+    public void should_get_supplementary_evidence_record() {
+        // given
+        Envelope envelope = getDummyEnvelope(Classification.SUPPLEMENTARY_EVIDENCE);
+
+        // when
+        CaseDataCreator creator = CaseRecordFactory.getCaseDataCreator(envelope, null);
+
+        // then
+        assertThat(creator)
+            .isInstanceOf(SupplementaryEvidenceRecord.class)
+            .extracting("caseRecordIdentifier")
+            .containsOnly(CaseRecord.Record.SUPPLEMENTARY_EVIDENCE);
+    }
+
+    // can be separated once cleared up about classifications and case creation in general
+    @Test
+    public void should_get_exception_record() {
+        // given
+        Envelope envelope1 = getDummyEnvelope(Classification.EXCEPTION);
+        Envelope envelope2 = getDummyEnvelope(Classification.NEW_APPLICATION);
+
+        // when
+        CaseDataCreator creator1 = CaseRecordFactory.getCaseDataCreator(envelope1, null);
+        CaseDataCreator creator2 = CaseRecordFactory.getCaseDataCreator(envelope2, null);
+
+        // then
+        assertThat(creator1)
+            .isInstanceOf(ExceptionRecord.class)
+            .extracting("caseRecordIdentifier")
+            .containsOnly(CaseRecord.Record.EXCEPTION_RECORD);
+        assertThat(creator2)
+            .isInstanceOf(ExceptionRecord.class)
+            .extracting("caseRecordIdentifier")
+            .containsOnly(CaseRecord.Record.EXCEPTION_RECORD);
+    }
+
+    private Envelope getDummyEnvelope(Classification classification) {
+        return new Envelope(
+            ENVELOPE_ID,
+            ENVELOPE_CASE_REF,
+            ENVELOPE_JURISDICTION,
+            ENVELOPE_ZIP_FILE_NAME,
+            classification,
+            emptyList()
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseRecordFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/CaseRecordFactoryTest.java
@@ -5,9 +5,11 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.caserecord.E
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.caserecord.SupplementaryEvidenceRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class CaseRecordFactoryTest {
 
@@ -22,13 +24,28 @@ public class CaseRecordFactoryTest {
         Envelope envelope = getDummyEnvelope(Classification.SUPPLEMENTARY_EVIDENCE);
 
         // when
-        CaseDataCreator creator = CaseRecordFactory.getCaseDataCreator(envelope, null);
+        CaseDataCreator creator = CaseRecordFactory.getCaseDataCreator(envelope, mock(CaseDetails.class));
 
         // then
         assertThat(creator)
             .isInstanceOf(SupplementaryEvidenceRecord.class)
             .extracting("caseRecordIdentifier")
             .containsOnly(CaseRecord.Record.SUPPLEMENTARY_EVIDENCE);
+    }
+
+    @Test
+    public void should_get_exception_record_when_case_is_empty() {
+        // given
+        Envelope envelope = getDummyEnvelope(Classification.SUPPLEMENTARY_EVIDENCE);
+
+        // when
+        CaseDataCreator creator = CaseRecordFactory.getCaseDataCreator(envelope, null);
+
+        // then
+        assertThat(creator)
+            .isInstanceOf(ExceptionRecord.class)
+            .extracting("caseRecordIdentifier")
+            .containsOnly(CaseRecord.Record.EXCEPTION_RECORD);
     }
 
     // can be separated once cleared up about classifications and case creation in general

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/caserecord/ExceptionRecordTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/caserecord/ExceptionRecordTest.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.caserecord;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.CaseDataCreator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.ccd.client.model.Classification.PRIVATE;
+
+// todo placeholder to update unit test once record is implemented
+public class ExceptionRecordTest {
+
+    @Test
+    public void should_create_case_data_content() {
+        // given
+        Envelope envelope = new Envelope(
+            "id",
+            "caseRef",
+            "jurisdiction",
+            "zip",
+            Classification.EXCEPTION,
+            Collections.emptyList()
+        );
+        CaseDataCreator creator = new ExceptionRecord(envelope, null);
+
+        // when
+        CaseDataContent dataContent = creator.createDataContent(PRIVATE, "eventToken", true);
+
+        // then
+        assertThat(dataContent).isNull();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/caserecord/SupplementaryEvidenceRecordTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/model/caserecord/SupplementaryEvidenceRecordTest.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.caserecord;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.model.CaseDataCreator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.ccd.client.model.Classification.PRIVATE;
+
+// todo placeholder to update unit test once record is implemented
+public class SupplementaryEvidenceRecordTest {
+
+    @Test
+    public void should_create_case_data_content() {
+        // given
+        Envelope envelope = new Envelope(
+            "id",
+            "caseRef",
+            "jurisdiction",
+            "zip",
+            Classification.SUPPLEMENTARY_EVIDENCE,
+            Collections.emptyList()
+        );
+        CaseDataCreator creator = new SupplementaryEvidenceRecord(envelope, null);
+
+        // when
+        CaseDataContent dataContent = creator.createDataContent(PRIVATE, "eventToken", true);
+
+        // then
+        assertThat(dataContent).isNull();
+    }
+}


### PR DESCRIPTION
### Change description ###

Proposition of abstraction of case record creation used in submitting evidence to CCD. API accepts `CaseDataContent` so there is a separate interface holding just that information. For internal orchestrator knowledge - a separate `CaseRecord` interface is in place holding information about available `Record` and common `Construct` to be **only** used in privately by inheritance.

Factory privately constructs collection of available `Record`s by `Construct` reference only and each time builds up new `CaseDataContent` aware `Record` instance to be used in event publisher.

The exact fields to construct are subject to change once case records are actually created and successfully pushed to CCD. This PR establishes separation as a proposal

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
