### PR TITLE
adding junit 5 to orchestrator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,6 @@ def versions = [
 
 dependencies {
   compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8'
-  compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: versions.springBoot

--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,6 @@ dependencies {
   testCompile group: 'org.junit.vintage', name: 'junit-vintage-engine', version: versions.junit
 
   annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
-
   integrationTestCompile sourceSets.main.runtimeClasspath
   integrationTestCompile sourceSets.test.runtimeClasspath
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,11 @@ sourceSets {
   }
 }
 
-tasks.withType(JavaCompile) {
+test {
+  useJUnitPlatform()
+}
+
+compileJava {
   options.compilerArgs << "-Xlint:unchecked" << "-Werror"
 }
 
@@ -61,14 +65,21 @@ compileTestKotlin {
   }
 }
 
+configurations {
+  integrationTestCompile.extendsFrom testCompile
+  integrationTestRuntime.extendsFrom testRuntime
+}
+
 task functional(type: Test, description: 'Runs the functional tests.', group: 'Verification') {
   testClassesDirs = sourceSets.functionalTest.output.classesDirs
   classpath = sourceSets.functionalTest.runtimeClasspath
+  useJUnitPlatform()
 }
 
 task integration(type: Test, description: 'Runs the integration tests.', group: 'Verification') {
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
+  useJUnitPlatform()
 }
 
 task smoke(type: Test) {
@@ -93,13 +104,13 @@ pmd {
 }
 
 jacocoTestReport {
-  dependsOn test,integration
+  dependsOn test, integration
   executionData(test, integration)
   reports {
     xml.enabled = true
     csv.enabled = false
     html.destination file("${buildDir}/reports/jacoco/html")
-    xml.destination  file("${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml")
+    xml.destination file("${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml")
   }
 }
 
@@ -146,13 +157,15 @@ repositories {
 // it is important to specify logback classic and core packages explicitly as libraries like spring boot
 // enforces it's own (older) version which is not recommended.
 def versions = [
-  reformLogging: '3.0.2',
-  springBoot: springBoot.class.package.implementationVersion,
-  springfoxSwagger: '2.9.2'
+  reformLogging   : '3.0.2',
+  springBoot      : springBoot.class.package.implementationVersion,
+  springfoxSwagger: '2.9.2',
+  junit           : '5.3.1'
 ]
 
 dependencies {
-  compile group: 'org.jetbrains.kotlin', name:'kotlin-stdlib-jdk8'
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8'
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: versions.springBoot
@@ -169,13 +182,20 @@ dependencies {
 
   compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.7'
 
-  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
-  testCompile group: 'com.typesafe', name: 'config', version: '1.3.3'
-
   annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
+
+
+  testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot)
+  testCompile group: 'com.typesafe', name: 'config', version: '1.3.3'
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
+  testCompile group: 'org.junit.vintage', name: 'junit-vintage-engine', version: versions.junit
+
 
   integrationTestCompile sourceSets.main.runtimeClasspath
   integrationTestCompile sourceSets.test.runtimeClasspath
+  integrationTestRuntimeClasspath sourceSets.test.runtimeClasspath
 
   functionalTestCompile sourceSets.main.runtimeClasspath
   functionalTestCompile sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -46,11 +46,7 @@ sourceSets {
   }
 }
 
-test {
-  useJUnitPlatform()
-}
-
-compileJava {
+tasks.withType(JavaCompile) {
   options.compilerArgs << "-Xlint:unchecked" << "-Werror"
 }
 
@@ -65,9 +61,8 @@ compileTestKotlin {
   }
 }
 
-configurations {
-  integrationTestCompile.extendsFrom testCompile
-  integrationTestRuntime.extendsFrom testRuntime
+test {
+  useJUnitPlatform()
 }
 
 task functional(type: Test, description: 'Runs the functional tests.', group: 'Verification') {
@@ -192,10 +187,10 @@ dependencies {
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
   testCompile group: 'org.junit.vintage', name: 'junit-vintage-engine', version: versions.junit
 
+  annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
 
   integrationTestCompile sourceSets.main.runtimeClasspath
   integrationTestCompile sourceSets.test.runtimeClasspath
-  integrationTestRuntimeClasspath sourceSets.test.runtimeClasspath
 
   functionalTestCompile sourceSets.main.runtimeClasspath
   functionalTestCompile sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,6 @@ dependencies {
 
   annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
 
-
   testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot)
   testCompile group: 'com.typesafe', name: 'config', version: '1.3.3'
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit

--- a/build.gradle
+++ b/build.gradle
@@ -176,9 +176,7 @@ dependencies {
 
   compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.7'
 
-  annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
-
-  testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot)
+  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
   testCompile group: 'com.typesafe', name: 'config', version: '1.3.3'
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
@@ -186,6 +184,7 @@ dependencies {
   testCompile group: 'org.junit.vintage', name: 'junit-vintage-engine', version: versions.junit
 
   annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
+
   integrationTestCompile sourceSets.main.runtimeClasspath
   integrationTestCompile sourceSets.test.runtimeClasspath
 


### PR DESCRIPTION
### Change description ###
To help simplify the integration tests I have included the junit 5 dependencies 
(also allows kotlinTest in the future)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
