### PR TITLE
Support adding supplementary evidence based on queue messages

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CaseRetrievalTest.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CaseRetrievalTest.kt
@@ -9,6 +9,7 @@ import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -18,6 +19,8 @@ import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.util.SocketUtils
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticatorFactory
+import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi
 import java.io.File
 import java.util.concurrent.TimeUnit
 
@@ -30,8 +33,8 @@ import java.util.concurrent.TimeUnit
     "core_case_data.api.url=${TestUrls.wiremockUrls.CORE_CASE_DATA_URL}",
     "idam.s2s-auth.url=${TestUrls.wiremockUrls.IDAM_S2S_URL}",
     "idam.api.url=${TestUrls.wiremockUrls.IDAM_API_URL}",
-    "idam.users.sscs.username=bulkscanorchestrator+systemupdate@gmail.com",
-    "idam.users.sscs.password=Password12",
+    "idam.users.bulkscan.username=bulkscan+ccd@gmail.com",
+    "idam.users.bulkscan.password=Password12",
     "queue.read-interval=100"
 ])
 @AutoConfigureWireMock
@@ -43,7 +46,7 @@ class CaseRetrievalTest {
         }
 
         val USER_ID = "32"
-        val JURIDICTION = "SSCS"
+        val JURIDICTION = "BULKSCAN"
         val CASE_TYPE = CaseRetriever.CASE_TYPE_ID
         val CASE_REF = "1537879748168579"
 
@@ -51,27 +54,26 @@ class CaseRetrievalTest {
             "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE}/cases/${CASE_REF}"
     }
 
-    private val mockMessage = Message(File("src/test/resources/envelopes/example.json").readText())
-
     @Autowired
     private lateinit var server: WireMockServer
 
     @Autowired
-    private lateinit var mockReceiver: IMessageReceiver
+    private lateinit var factory: CcdAuthenticatorFactory
+
+    @Autowired
+    private lateinit var coreCaseDataApi: CoreCaseDataApi
+
+    private lateinit var caseRetriever: CaseRetriever
 
     @BeforeEach
     fun before() {
-        `when`(mockReceiver.receive()).thenReturn(mockMessage, null)
+        caseRetriever = CaseRetriever(factory, coreCaseDataApi)
     }
 
     @Test
     fun `Should call to retrieve the case from ccd`() {
-        await()
-            .atMost(5, TimeUnit.SECONDS)
-            .ignoreExceptions()
-            .until {
-                server.verify(getRequestedFor(urlEqualTo(retrieveCase())))
-                true
-            }
+        caseRetriever.retrieve(JURIDICTION, CASE_REF)
+
+        server.verify(getRequestedFor(urlEqualTo(retrieveCase())))
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetriever.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetriever.java
@@ -11,6 +11,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Service
 public class CaseRetriever {
+
     public static final String CASE_TYPE_ID = "Bulk_Scanned";
 
     private static final Logger log = LoggerFactory.getLogger(CaseRetriever.class);
@@ -32,7 +33,7 @@ public class CaseRetriever {
             CaseDetails caseDetails = coreCaseDataApi.readForCaseWorker(
                 authenticator.getUserToken(),
                 authenticator.getServiceToken(),
-                authenticator.userDetails.getId(),
+                authenticator.getUserDetails().getId(),
                 jurisdiction,
                 CASE_TYPE_ID,
                 caseRef

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetriever.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetriever.java
@@ -20,7 +20,7 @@ public class CaseRetriever {
 
     private final CoreCaseDataApi coreCaseDataApi;
 
-    CaseRetriever(CcdAuthenticatorFactory factory, CoreCaseDataApi coreCaseDataApi) {
+    public CaseRetriever(CcdAuthenticatorFactory factory, CoreCaseDataApi coreCaseDataApi) {
         this.factory = factory;
         this.coreCaseDataApi = coreCaseDataApi;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticator.java
@@ -5,7 +5,7 @@ import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import java.util.function.Supplier;
 
 public class CcdAuthenticator {
-    final UserDetails userDetails;
+    private final UserDetails userDetails;
     private final Supplier<String> serviceTokenSupplier;
     private final Supplier<String> userTokenSupplier;
 
@@ -34,4 +34,7 @@ public class CcdAuthenticator {
         return this.serviceTokenSupplier.get();
     }
 
+    public UserDetails getUserDetails() {
+        return this.userDetails;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticatorFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticatorFactory.java
@@ -10,7 +10,7 @@ import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
 @Service
 @EnableConfigurationProperties(JurisdictionToUserMapping.class)
-class CcdAuthenticatorFactory {
+public class CcdAuthenticatorFactory {
     private final AuthTokenGenerator s2sTokenGenerator;
     private final IdamClient idamClient;
     private final JurisdictionToUserMapping users;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/SupplementaryEvidenceCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/SupplementaryEvidenceCreator.java
@@ -38,7 +38,7 @@ public class SupplementaryEvidenceCreator {
         StartEventResponse startEventResponse =
             startEvent(info, envelope.jurisdiction, envelope.caseRef);
 
-        log.info("Started {} event for case {}", startEventResponse.getEventId(), envelope.caseRef);
+        log.debug("Started {} event for case {}", startEventResponse.getEventId(), envelope.caseRef);
 
         CaseDataContent caseDataContent = prepareCaseDataContent(
             startEventResponse.getToken(),
@@ -47,7 +47,7 @@ public class SupplementaryEvidenceCreator {
 
         submitEvent(info, envelope.jurisdiction, envelope.caseRef, caseDataContent);
 
-        log.info("Submitted {} event for case {}", startEventResponse.getEventId(), envelope.caseRef);
+        log.debug("Submitted {} event for case {}", startEventResponse.getEventId(), envelope.caseRef);
     }
 
     private CaseDataContent prepareCaseDataContent(
@@ -59,7 +59,6 @@ public class SupplementaryEvidenceCreator {
             .event(Event.builder()
                 .id(EVENT_TYPE_ID)
                 .summary("Attach scanned documents")
-                .description("Attach scanned documents")
                 .build())
             .data(supplementaryEvidence)
             .build();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/SupplementaryEvidenceCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/SupplementaryEvidenceCreator.java
@@ -1,0 +1,101 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.SupplementaryEvidence;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.SupplementaryEvidenceMapper;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
+import uk.gov.hmcts.reform.ccd.client.model.Event;
+import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
+
+@Service
+public class SupplementaryEvidenceCreator {
+
+    private static final Logger log = LoggerFactory.getLogger(SupplementaryEvidenceCreator.class);
+
+    private static final String CASE_TYPE_ID = "Bulk_Scanned";
+    private static final String EVENT_TYPE_ID = "attachScannedDocs";
+
+    private final CcdAuthenticatorFactory authenticatorFactory;
+    private final CoreCaseDataApi coreCaseDataApi;
+
+    SupplementaryEvidenceCreator(
+        CcdAuthenticatorFactory authenticatorFactory,
+        CoreCaseDataApi coreCaseDataApi
+    ) {
+        this.authenticatorFactory = authenticatorFactory;
+        this.coreCaseDataApi = coreCaseDataApi;
+    }
+
+    public void createSupplementaryEvidence(Envelope envelope) {
+        log.info("Creating supplementary evidence for case {}", envelope.caseRef);
+
+        CcdAuthenticator info = authenticatorFactory.createForJurisdiction(envelope.jurisdiction);
+
+        StartEventResponse startEventResponse =
+            startEvent(info, envelope.jurisdiction, envelope.caseRef);
+
+        log.info("Started {} event for case {}", startEventResponse.getEventId(), envelope.caseRef);
+
+        CaseDataContent caseDataContent = prepareCaseDataContent(
+            startEventResponse.getToken(),
+            SupplementaryEvidenceMapper.fromEnvelope(envelope)
+        );
+
+        submitEvent(info, envelope.jurisdiction, envelope.caseRef, caseDataContent);
+
+        log.info("Submitted {} event for case {}", startEventResponse.getEventId(), envelope.caseRef);
+    }
+
+    private CaseDataContent prepareCaseDataContent(
+        String eventToken,
+        SupplementaryEvidence supplementaryEvidence
+    ) {
+        return CaseDataContent.builder()
+            .eventToken(eventToken)
+            .event(Event.builder()
+                .id(EVENT_TYPE_ID)
+                .summary("Attach scanned documents")
+                .description("Attach scanned documents")
+                .build())
+            .data(supplementaryEvidence)
+            .build();
+    }
+
+    private StartEventResponse startEvent(
+        CcdAuthenticator authenticator,
+        String jurisdiction,
+        String caseRef
+    ) {
+        return coreCaseDataApi.startEventForCaseWorker(
+            authenticator.getUserToken(),
+            authenticator.getServiceToken(),
+            authenticator.getUserDetails().getId(),
+            jurisdiction,
+            CASE_TYPE_ID,
+            caseRef,
+            EVENT_TYPE_ID
+        );
+    }
+
+    private void submitEvent(
+        CcdAuthenticator authenticator,
+        String jurisdiction,
+        String caseRef,
+        CaseDataContent caseDataContent
+    ) {
+        coreCaseDataApi.submitEventForCaseWorker(
+            authenticator.getUserToken(),
+            authenticator.getServiceToken(),
+            authenticator.getUserDetails().getId(),
+            jurisdiction,
+            CASE_TYPE_ID,
+            caseRef,
+            true,
+            caseDataContent
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/SupplementaryEvidenceCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/SupplementaryEvidenceCreator.java
@@ -33,10 +33,11 @@ public class SupplementaryEvidenceCreator {
     public void createSupplementaryEvidence(Envelope envelope) {
         log.info("Creating supplementary evidence for case {}", envelope.caseRef);
 
-        CcdAuthenticator info = authenticatorFactory.createForJurisdiction(envelope.jurisdiction);
+        CcdAuthenticator authenticator =
+            authenticatorFactory.createForJurisdiction(envelope.jurisdiction);
 
         StartEventResponse startEventResponse =
-            startEvent(info, envelope.jurisdiction, envelope.caseRef);
+            startEvent(authenticator, envelope.jurisdiction, envelope.caseRef);
 
         log.debug("Started {} event for case {}", startEventResponse.getEventId(), envelope.caseRef);
 
@@ -45,7 +46,7 @@ public class SupplementaryEvidenceCreator {
             SupplementaryEvidenceMapper.fromEnvelope(envelope)
         );
 
-        submitEvent(info, envelope.jurisdiction, envelope.caseRef, caseDataContent);
+        submitEvent(authenticator, envelope.jurisdiction, envelope.caseRef, caseDataContent);
 
         log.debug("Submitted {} event for case {}", startEventResponse.getEventId(), envelope.caseRef);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator;
 
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticator;
@@ -51,16 +54,36 @@ public class SampleData {
         .caseTypeId(CASE_TYPE_ID)
         .build();
 
+    public static final ObjectMapper objectMapper;
+
+    static {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+    }
+
     public static byte[] exampleJson = fromFile("envelopes/example.json").getBytes();
 
+    public static byte[] envelopeJson() {
+        return envelopeJson(Classification.SUPPLEMENTARY_EVIDENCE, CASE_REF);
+    }
+
     public static byte[] envelopeJson(String caseRef) {
+        return envelopeJson(Classification.SUPPLEMENTARY_EVIDENCE, caseRef);
+    }
+
+    public static byte[] envelopeJson(Classification classification) {
+        return envelopeJson(classification, CASE_REF);
+    }
+
+    public static byte[] envelopeJson(Classification classification, String caseRef) {
         try {
             return new JSONObject()
                 .put("id", "eb9c3598-35fc-424e-b05a-902ee9f11d56")
                 .put("case_ref", caseRef)
                 .put("jurisdiction", JURSIDICTION)
                 .put("zip_file_name", "zip-file-test.zip")
-                .put("classification", Classification.NEW_APPLICATION)
+                .put("classification", classification)
                 .put("documents", new JSONArray()
                     .put(new JSONObject()
                         .put("file_name", "hello.pdf")
@@ -74,10 +97,7 @@ public class SampleData {
         } catch (Exception e) {
             throw new RuntimeException("Could not make envelopeJson", e);
         }
-    }
 
-    public static byte[] envelopeJson() {
-        return envelopeJson(CASE_REF);
     }
 
     public static String fromFile(String file) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -123,6 +123,7 @@ public class EnvelopeEventProcessorTest {
         // when
         processor.onMessageAsync(someMessage);
 
+        // then
         verifyNoMoreInteractions(supplementaryEvidenceCreator);
     }
 
@@ -134,6 +135,7 @@ public class EnvelopeEventProcessorTest {
         // when
         processor.onMessageAsync(someMessage);
 
+        // then
         verifyNoMoreInteractions(supplementaryEvidenceCreator);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -4,40 +4,37 @@ import com.microsoft.azure.servicebus.IMessage;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.SupplementaryEvidenceCreator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.CASE_REF;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.JURSIDICTION;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.THE_CASE;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelopeJson;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.objectMapper;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EnvelopeEventProcessorTest {
     @Mock
     private IMessage someMessage;
     @Mock
-    private CaseRetriever caseRetriever;
-    @Mock
-    private CcdAuthenticator authInfo;
+    private SupplementaryEvidenceCreator supplementaryEvidenceCreator;
 
     private EnvelopeEventProcessor processor;
 
     @Before
     public void before() throws Exception {
-        processor = new EnvelopeEventProcessor(caseRetriever);
-        when(caseRetriever.retrieve(eq(JURSIDICTION), eq(CASE_REF)))
-            .thenReturn(THE_CASE);
+        processor = new EnvelopeEventProcessor(supplementaryEvidenceCreator);
         given(someMessage.getBody()).willReturn(envelopeJson());
     }
 
@@ -87,8 +84,10 @@ public class EnvelopeEventProcessorTest {
     @Test
     public void should_return_exceptionally_completed_future_if_exception_is_thrown() throws Exception {
         // given
-        given(someMessage.getBody()).willReturn(envelopeJson());
-        given(caseRetriever.retrieve(any(), any())).willThrow(new RuntimeException());
+        given(someMessage.getBody())
+            .willReturn(envelopeJson(Classification.SUPPLEMENTARY_EVIDENCE));
+
+        willThrow(new RuntimeException()).given(supplementaryEvidenceCreator).createSupplementaryEvidence(any());
 
         // when
         CompletableFuture<Void> result = processor.onMessageAsync(someMessage);
@@ -97,4 +96,44 @@ public class EnvelopeEventProcessorTest {
         assertThat(result.isCompletedExceptionally()).isTrue();
     }
 
+    @Test
+    public void should_handle_messages_with_supplementary_evidence_classification() throws Exception {
+        // given
+        given(someMessage.getBody())
+            .willReturn(envelopeJson(Classification.SUPPLEMENTARY_EVIDENCE));
+
+        // when
+        processor.onMessageAsync(someMessage);
+
+        // then
+        ArgumentCaptor<Envelope> envelopeCaptor = ArgumentCaptor.forClass(Envelope.class);
+        verify(supplementaryEvidenceCreator).createSupplementaryEvidence(envelopeCaptor.capture());
+
+        Envelope expectedEnvelope = objectMapper.readValue(someMessage.getBody(), Envelope.class);
+
+        assertThat(envelopeCaptor.getValue())
+            .isEqualToComparingFieldByFieldRecursively(expectedEnvelope);
+    }
+
+    @Test
+    public void should_not_process_messages_with_new_application_classification() throws Exception {
+        // given
+        given(someMessage.getBody()).willReturn(envelopeJson(Classification.NEW_APPLICATION));
+
+        // when
+        processor.onMessageAsync(someMessage);
+
+        verifyNoMoreInteractions(supplementaryEvidenceCreator);
+    }
+
+    @Test
+    public void should_not_process_messages_with_exception_classification() throws Exception {
+        // given
+        given(someMessage.getBody()).willReturn(envelopeJson(Classification.EXCEPTION));
+
+        // when
+        processor.onMessageAsync(someMessage);
+
+        verifyNoMoreInteractions(supplementaryEvidenceCreator);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticatorFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticatorFactoryTest.java
@@ -49,7 +49,7 @@ public class CcdAuthenticatorFactoryTest {
 
         assertThat(authenticator.getServiceToken()).isEqualTo(SERVICE_TOKEN);
         assertThat(authenticator.getUserToken()).isEqualTo(USER_TOKEN);
-        assertThat(authenticator.userDetails.getId()).isEqualTo(USER_ID);
+        assertThat(authenticator.getUserDetails().getId()).isEqualTo(USER_ID);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/SupplementaryEvidenceCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/SupplementaryEvidenceCreatorTest.java
@@ -15,13 +15,10 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.AUTH_DETAILS;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.SERVICE_TOKEN;
@@ -66,24 +63,6 @@ public class SupplementaryEvidenceCreatorTest {
         verifyEventSubmitted(envelope, eventToken);
     }
 
-    @Test
-    public void createSupplementaryEvidence_does_not_submit_event_when_starting_fails() {
-        Exception expectedException = new RuntimeException("test exception");
-
-        willThrow(expectedException)
-            .given(coreCaseDataApi)
-            .startEventForCaseWorker(any(), any(), any(), any(), any(), any(), any());
-
-        Throwable actualException = catchThrowable(
-            () -> creator.createSupplementaryEvidence(SampleData.envelope(1))
-        );
-
-        assertThat(actualException).isSameAs(expectedException);
-
-        verify(coreCaseDataApi, never())
-            .submitEventForCaseWorker(any(), any(), any(), any(), any(), any(), eq(true), any());
-    }
-
     private void assertCaseDataContentHasRightData(
         CaseDataContent caseDataContent,
         String eventToken,
@@ -92,7 +71,6 @@ public class SupplementaryEvidenceCreatorTest {
         assertThat(caseDataContent.getEventToken()).isEqualTo(eventToken);
         assertThat(caseDataContent.getEvent().getId()).isEqualTo(EVENT_TYPE_ID);
         assertThat(caseDataContent.getEvent().getSummary()).isEqualTo("Attach scanned documents");
-        assertThat(caseDataContent.getEvent().getDescription()).isEqualTo("Attach scanned documents");
 
         SupplementaryEvidence supplementaryEvidence = SupplementaryEvidenceMapper.fromEnvelope(envelope);
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/SupplementaryEvidenceCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/SupplementaryEvidenceCreatorTest.java
@@ -1,0 +1,131 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.SupplementaryEvidence;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.SupplementaryEvidenceMapper;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
+import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.AUTH_DETAILS;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.SERVICE_TOKEN;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_DETAILS;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_TOKEN;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SupplementaryEvidenceCreatorTest {
+
+    private static final String CASE_TYPE_ID = "Bulk_Scanned";
+    private static final String EVENT_TYPE_ID = "attachScannedDocs";
+
+    @Mock
+    private CcdAuthenticatorFactory authenticatorFactory;
+
+    @Mock
+    private CoreCaseDataApi coreCaseDataApi;
+
+    private SupplementaryEvidenceCreator creator;
+
+    @Before
+    public void setUp() {
+        given(authenticatorFactory.createForJurisdiction(any())).willReturn(AUTH_DETAILS);
+
+        creator = new SupplementaryEvidenceCreator(authenticatorFactory, coreCaseDataApi);
+    }
+
+    @Test
+    public void createSupplementaryEvidence_starts_and_submits_event() {
+        Envelope envelope = SampleData.envelope(2);
+        String eventToken = "token123";
+
+        StartEventResponse startEventResponse = mock(StartEventResponse.class);
+        given(startEventResponse.getToken()).willReturn(eventToken);
+
+        given(coreCaseDataApi.startEventForCaseWorker(any(), any(), any(), any(), any(), any(), any()))
+            .willReturn(startEventResponse);
+
+        creator.createSupplementaryEvidence(envelope);
+
+        verifyEventStarted(envelope);
+        verifyEventSubmitted(envelope, eventToken);
+    }
+
+    @Test
+    public void createSupplementaryEvidence_does_not_submit_event_when_starting_fails() {
+        Exception expectedException = new RuntimeException("test exception");
+
+        willThrow(expectedException)
+            .given(coreCaseDataApi)
+            .startEventForCaseWorker(any(), any(), any(), any(), any(), any(), any());
+
+        Throwable actualException = catchThrowable(
+            () -> creator.createSupplementaryEvidence(SampleData.envelope(1))
+        );
+
+        assertThat(actualException).isSameAs(expectedException);
+
+        verify(coreCaseDataApi, never())
+            .submitEventForCaseWorker(any(), any(), any(), any(), any(), any(), eq(true), any());
+    }
+
+    private void assertCaseDataContentHasRightData(
+        CaseDataContent caseDataContent,
+        String eventToken,
+        Envelope envelope
+    ) {
+        assertThat(caseDataContent.getEventToken()).isEqualTo(eventToken);
+        assertThat(caseDataContent.getEvent().getId()).isEqualTo(EVENT_TYPE_ID);
+        assertThat(caseDataContent.getEvent().getSummary()).isEqualTo("Attach scanned documents");
+        assertThat(caseDataContent.getEvent().getDescription()).isEqualTo("Attach scanned documents");
+
+        SupplementaryEvidence supplementaryEvidence = SupplementaryEvidenceMapper.fromEnvelope(envelope);
+
+        assertThat(caseDataContent.getData()).isEqualToComparingFieldByFieldRecursively(supplementaryEvidence);
+    }
+
+    private void verifyEventStarted(Envelope envelope) {
+        verify(coreCaseDataApi).startEventForCaseWorker(
+            USER_TOKEN,
+            SERVICE_TOKEN,
+            USER_DETAILS.getId(),
+            envelope.jurisdiction,
+            CASE_TYPE_ID,
+            envelope.caseRef,
+            EVENT_TYPE_ID
+        );
+    }
+
+    private void verifyEventSubmitted(Envelope envelope, String eventToken) {
+        ArgumentCaptor<CaseDataContent> caseDataContentCaptor =
+            ArgumentCaptor.forClass(CaseDataContent.class);
+
+        verify(coreCaseDataApi).submitEventForCaseWorker(
+            eq(USER_TOKEN),
+            eq(SERVICE_TOKEN),
+            eq(USER_DETAILS.getId()),
+            eq(envelope.jurisdiction),
+            eq(CASE_TYPE_ID),
+            eq(envelope.caseRef),
+            eq(true),
+            caseDataContentCaptor.capture()
+        );
+
+        assertCaseDataContentHasRightData(caseDataContentCaptor.getValue(), eventToken, envelope);
+    }
+}

--- a/src/test/resources/example1.json
+++ b/src/test/resources/example1.json
@@ -1,0 +1,16 @@
+{
+  "id": "0192",
+  "case_ref": "1538983472742457",
+  "jurisdiction": "BULKSCAN",
+  "classification": "SUPPLEMENTARY_EVIDENCE",
+  "zip_file_name": "zip-file-test.zip",
+  "documents": [
+    {
+      "file_name": "testfilename",
+      "control_number": "1234",
+      "type": "other",
+      "scanned_at": "2018-01-01T12:34:56.123Z",
+      "url": "http://test-url"
+    }
+  ]
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-657

### Change description ###

Support adding supplementary evidence based on queue messages. Not included here:
- functional and integration tests (coming...)
- extracting common interface for event creators (too early)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
