### PR TITLE
Update case details for ccd event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/CaseData.java
@@ -1,0 +1,4 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd;
+
+public interface CaseData {
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public class ExceptionRecord {
+public class ExceptionRecord implements CaseData {
 
     @JsonProperty("journeyClassification")
     public final String classification;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/SupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/SupplementaryEvidence.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-public class SupplementaryEvidence {
+public class SupplementaryEvidence implements CaseData {
 
     @JsonProperty("scannedDocuments")
     public final List<CcdCollectionElement<ScannedDocument>> scannedDocuments;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -12,7 +12,7 @@ public class ExceptionRecordMapper extends ModelMapper<ExceptionRecord> {
     }
 
     @Override
-    public ExceptionRecord fromEnvelope(Envelope envelope) {
+    public ExceptionRecord mapEnvelope(Envelope envelope) {
         return new ExceptionRecord(
             envelope.classification.name(),
             envelope.poBox,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -1,54 +1,25 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers;
 
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdCollectionElement;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdDocument;
+import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ExceptionRecord;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
+@Component
+public class ExceptionRecordMapper extends ModelMapper<ExceptionRecord> {
 
-import static java.util.stream.Collectors.toList;
-
-public final class ExceptionRecordMapper {
-
-    private ExceptionRecordMapper() {
-        // utility class
+    public ExceptionRecordMapper() {
+        // empty mapper construct
     }
 
-    public static ExceptionRecord fromEnvelope(Envelope envelope) {
-        List<CcdCollectionElement<ScannedDocument>> scannedDocuments =
-            envelope
-                .documents
-                .stream()
-                .map(document -> new CcdCollectionElement<>(fromEnvelopeDocument(document)))
-                .collect(toList());
-
+    @Override
+    public ExceptionRecord fromEnvelope(Envelope envelope) {
         return new ExceptionRecord(
             envelope.classification.name(),
             envelope.poBox,
             envelope.jurisdiction,
             getLocalDateTime(envelope.deliveryDate),
             getLocalDateTime(envelope.openingDate),
-            scannedDocuments
+            mapDocuments(envelope.documents)
         );
-    }
-
-    private static ScannedDocument fromEnvelopeDocument(Document document) {
-        return new ScannedDocument(
-            document.fileName,
-            document.controlNumber,
-            document.type,
-            document.scannedAt.atZone(ZoneId.systemDefault()).toLocalDate(),
-            new CcdDocument(document.url)
-        );
-    }
-
-    private static LocalDateTime getLocalDateTime(Instant instant) {
-        return instant.atZone(ZoneId.systemDefault()).toLocalDateTime();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ModelMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ModelMapper.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers;
+
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdCollectionElement;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class ModelMapper<T extends CaseData> {
+
+    public abstract T fromEnvelope(Envelope envelope);
+
+    List<CcdCollectionElement<ScannedDocument>> mapDocuments(List<Document> documents) {
+        return documents
+            .stream()
+            .map(this::fromEnvelopeDocument)
+            .map(CcdCollectionElement::new)
+            .collect(Collectors.toList());
+    }
+
+    // private methods from Java9 only
+    private ScannedDocument fromEnvelopeDocument(Document document) {
+        return new ScannedDocument(
+            document.fileName,
+            document.controlNumber,
+            document.type,
+            getLocalDateTime(document.scannedAt).toLocalDate(),
+            new CcdDocument(document.url)
+        );
+    }
+
+    LocalDateTime getLocalDateTime(Instant instant) {
+        return instant.atZone(ZoneId.systemDefault()).toLocalDateTime();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ModelMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ModelMapper.java
@@ -15,18 +15,17 @@ import java.util.stream.Collectors;
 
 public abstract class ModelMapper<T extends CaseData> {
 
-    public abstract T fromEnvelope(Envelope envelope);
+    public abstract T mapEnvelope(Envelope envelope);
 
     List<CcdCollectionElement<ScannedDocument>> mapDocuments(List<Document> documents) {
         return documents
             .stream()
-            .map(this::fromEnvelopeDocument)
+            .map(this::mapDocument)
             .map(CcdCollectionElement::new)
             .collect(Collectors.toList());
     }
 
-    // private methods from Java9 only
-    private ScannedDocument fromEnvelopeDocument(Document document) {
+    private ScannedDocument mapDocument(Document document) {
         return new ScannedDocument(
             document.fileName,
             document.controlNumber,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
@@ -1,41 +1,18 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers;
 
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdCollectionElement;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdDocument;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
+import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.SupplementaryEvidence;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
-import java.time.ZoneId;
-import java.util.List;
+@Component
+public class SupplementaryEvidenceMapper extends ModelMapper<SupplementaryEvidence> {
 
-import static java.util.stream.Collectors.toList;
-
-public class SupplementaryEvidenceMapper {
-
-    private SupplementaryEvidenceMapper() {
-        // utility class
+    public SupplementaryEvidenceMapper() {
+        // empty mapper construct
     }
 
-    public static SupplementaryEvidence fromEnvelope(Envelope envelope) {
-        List<CcdCollectionElement<ScannedDocument>> scannedDocuments =
-            envelope
-                .documents
-                .stream()
-                .map(document -> new CcdCollectionElement<>(fromEnvelopeDocument(document)))
-                .collect(toList());
-
-        return new SupplementaryEvidence(scannedDocuments);
-    }
-
-    private static ScannedDocument fromEnvelopeDocument(Document document) {
-        return new ScannedDocument(
-            document.fileName,
-            document.controlNumber,
-            document.type,
-            document.scannedAt.atZone(ZoneId.systemDefault()).toLocalDate(),
-            new CcdDocument(document.url)
-        );
+    @Override
+    public SupplementaryEvidence fromEnvelope(Envelope envelope) {
+        return new SupplementaryEvidence(mapDocuments(envelope.documents));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
@@ -12,7 +12,7 @@ public class SupplementaryEvidenceMapper extends ModelMapper<SupplementaryEviden
     }
 
     @Override
-    public SupplementaryEvidence fromEnvelope(Envelope envelope) {
+    public SupplementaryEvidence mapEnvelope(Envelope envelope) {
         return new SupplementaryEvidence(mapDocuments(envelope.documents));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticatorFactory;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
@@ -122,11 +123,11 @@ abstract class AbstractEventPublisher implements EventPublisher {
     }
 
     // todo perhaps some generic interface for these data objects?
-    abstract Object mapEnvelopeToCaseDataObject(Envelope envelope);
+    abstract CaseData mapEnvelopeToCaseDataObject(Envelope envelope);
 
     private CaseDataContent buildCaseDataContent(
         String eventToken,
-        Object caseDataObject
+        CaseData caseDataObject
     ) {
         return CaseDataContent.builder()
             .eventToken(eventToken)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -2,19 +2,22 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ModelMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.SupplementaryEvidenceMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 @Component
 class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
 
-    AttachDocsToSupplementaryEvidence() {
-        // empty constructor for ccd event publisher
+    private final ModelMapper<? extends CaseData> mapper;
+
+    AttachDocsToSupplementaryEvidence(SupplementaryEvidenceMapper mapper) {
+        this.mapper = mapper;
     }
 
     @Override
     CaseData mapEnvelopeToCaseDataObject(Envelope envelope) {
-        return SupplementaryEvidenceMapper.fromEnvelope(envelope);
+        return mapper.fromEnvelope(envelope);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -17,7 +17,7 @@ class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
 
     @Override
     CaseData mapEnvelopeToCaseDataObject(Envelope envelope) {
-        return mapper.fromEnvelope(envelope);
+        return mapper.mapEnvelope(envelope);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.SupplementaryEvidenceMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
@@ -12,7 +13,7 @@ class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
     }
 
     @Override
-    Object mapEnvelopeToCaseDataObject(Envelope envelope) {
+    CaseData mapEnvelopeToCaseDataObject(Envelope envelope) {
         return SupplementaryEvidenceMapper.fromEnvelope(envelope);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ExceptionRecordMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
@@ -22,7 +23,7 @@ class CreateExceptionRecord extends AbstractEventPublisher {
     }
 
     @Override
-    Object mapEnvelopeToCaseDataObject(Envelope envelope) {
+    CaseData mapEnvelopeToCaseDataObject(Envelope envelope) {
         return ExceptionRecordMapper.fromEnvelope(envelope);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -27,7 +27,7 @@ class CreateExceptionRecord extends AbstractEventPublisher {
 
     @Override
     CaseData mapEnvelopeToCaseDataObject(Envelope envelope) {
-        return mapper.fromEnvelope(envelope);
+        return mapper.mapEnvelope(envelope);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -3,13 +3,16 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ExceptionRecordMapper;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ModelMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 @Component
 class CreateExceptionRecord extends AbstractEventPublisher {
 
-    CreateExceptionRecord() {
-        // empty constructor for ccd event publisher
+    private final ModelMapper<? extends CaseData> mapper;
+
+    CreateExceptionRecord(ExceptionRecordMapper mapper) {
+        this.mapper = mapper;
     }
 
     /**
@@ -24,7 +27,7 @@ class CreateExceptionRecord extends AbstractEventPublisher {
 
     @Override
     CaseData mapEnvelopeToCaseDataObject(Envelope envelope) {
-        return ExceptionRecordMapper.fromEnvelope(envelope);
+        return mapper.fromEnvelope(envelope);
     }
 
     @Override

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
@@ -1,10 +1,9 @@
-package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mapper;
+package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers;
 
 import org.junit.Test;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.SupplementaryEvidence;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.SupplementaryEvidenceMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
@@ -17,10 +16,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SupplementaryEvidenceMapperTest {
 
+    private static final ModelMapper<SupplementaryEvidence> mapper = new SupplementaryEvidenceMapper();
+
     @Test
     public void from_envelope_maps_all_fields_correctly() {
         Envelope envelope = SampleData.envelope(1);
-        SupplementaryEvidence supplementaryEvidence = SupplementaryEvidenceMapper.fromEnvelope(envelope);
+        SupplementaryEvidence supplementaryEvidence = mapper.fromEnvelope(envelope);
 
         assertThat(supplementaryEvidence.scannedDocuments.size()).isEqualTo(1);
 
@@ -43,7 +44,7 @@ public class SupplementaryEvidenceMapperTest {
         int numberOfDocuments = 12;
         Envelope envelope = SampleData.envelope(12);
 
-        SupplementaryEvidence supplementaryEvidence = SupplementaryEvidenceMapper.fromEnvelope(envelope);
+        SupplementaryEvidence supplementaryEvidence = mapper.fromEnvelope(envelope);
         assertThat(supplementaryEvidence.scannedDocuments.size()).isEqualTo(numberOfDocuments);
 
         List<String> expectedDocumentFileNames =
@@ -58,7 +59,7 @@ public class SupplementaryEvidenceMapperTest {
     @Test
     public void from_envelope_handles_empty_document_list() {
         Envelope envelope = SampleData.envelope(0);
-        SupplementaryEvidence supplementaryEvidence = SupplementaryEvidenceMapper.fromEnvelope(envelope);
+        SupplementaryEvidence supplementaryEvidence = mapper.fromEnvelope(envelope);
 
         assertThat(supplementaryEvidence.scannedDocuments).isEmpty();
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
@@ -21,7 +21,7 @@ public class SupplementaryEvidenceMapperTest {
     @Test
     public void from_envelope_maps_all_fields_correctly() {
         Envelope envelope = SampleData.envelope(1);
-        SupplementaryEvidence supplementaryEvidence = mapper.fromEnvelope(envelope);
+        SupplementaryEvidence supplementaryEvidence = mapper.mapEnvelope(envelope);
 
         assertThat(supplementaryEvidence.scannedDocuments.size()).isEqualTo(1);
 
@@ -44,7 +44,7 @@ public class SupplementaryEvidenceMapperTest {
         int numberOfDocuments = 12;
         Envelope envelope = SampleData.envelope(12);
 
-        SupplementaryEvidence supplementaryEvidence = mapper.fromEnvelope(envelope);
+        SupplementaryEvidence supplementaryEvidence = mapper.mapEnvelope(envelope);
         assertThat(supplementaryEvidence.scannedDocuments.size()).isEqualTo(numberOfDocuments);
 
         List<String> expectedDocumentFileNames =
@@ -59,7 +59,7 @@ public class SupplementaryEvidenceMapperTest {
     @Test
     public void from_envelope_handles_empty_document_list() {
         Envelope envelope = SampleData.envelope(0);
-        SupplementaryEvidence supplementaryEvidence = mapper.fromEnvelope(envelope);
+        SupplementaryEvidence supplementaryEvidence = mapper.mapEnvelope(envelope);
 
         assertThat(supplementaryEvidence.scannedDocuments).isEmpty();
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticatorFactory;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
@@ -36,7 +37,7 @@ public class AbstractEventPublisherTest {
     private EventPublisher eventPublisher = new AbstractEventPublisher() {
 
         @Override
-        Object mapEnvelopeToCaseDataObject(Envelope envelope) {
+        CaseData mapEnvelopeToCaseDataObject(Envelope envelope) {
             return null;
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
@@ -78,7 +78,7 @@ public class AttachDocsToSupplementaryEvidenceTest {
         assertThat(caseDataContent.getEvent().getId()).isEqualTo(EVENT_TYPE_ID);
         assertThat(caseDataContent.getEvent().getSummary()).isEqualTo("Attach scanned documents");
 
-        SupplementaryEvidence supplementaryEvidence = mapper.fromEnvelope(envelope);
+        SupplementaryEvidence supplementaryEvidence = mapper.mapEnvelope(envelope);
 
         assertThat(caseDataContent.getData()).isEqualToComparingFieldByFieldRecursively(supplementaryEvidence);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
@@ -40,8 +40,10 @@ public class AttachDocsToSupplementaryEvidenceTest {
     @Mock
     private CoreCaseDataApi coreCaseDataApi;
 
+    private static final SupplementaryEvidenceMapper mapper = new SupplementaryEvidenceMapper();
+
     @InjectMocks
-    private EventPublisher eventPublisher = new AttachDocsToSupplementaryEvidence();
+    private EventPublisher eventPublisher = new AttachDocsToSupplementaryEvidence(mapper);
 
     @Before
     public void setUp() {
@@ -76,7 +78,7 @@ public class AttachDocsToSupplementaryEvidenceTest {
         assertThat(caseDataContent.getEvent().getId()).isEqualTo(EVENT_TYPE_ID);
         assertThat(caseDataContent.getEvent().getSummary()).isEqualTo("Attach scanned documents");
 
-        SupplementaryEvidence supplementaryEvidence = SupplementaryEvidenceMapper.fromEnvelope(envelope);
+        SupplementaryEvidence supplementaryEvidence = mapper.fromEnvelope(envelope);
 
         assertThat(caseDataContent.getData()).isEqualToComparingFieldByFieldRecursively(supplementaryEvidence);
     }


### PR DESCRIPTION
### Change description ###

Reduce code duplication

- Use `interface CaseData` instead of arbitrary `java.lang.Object` for ccd event data object to be pushed
- Extract common mapper functions and only require to implement `mapEnvelope(Envelope envelope)` for event publisher mapper

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
