### PR TITLE
Update case type

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.helper.EnvelopeMessager;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.EnvelopeParser;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
@@ -63,6 +64,7 @@ public class SupplementaryEvidenceTest {
 
         CaseDetails updatedCaseDetails = caseRetriever.retrieve(
             caseDetails.getJurisdiction(),
+            CaseTypeId.BULK_SCANNED,
             String.valueOf(caseDetails.getId())
         );
 
@@ -80,7 +82,10 @@ public class SupplementaryEvidenceTest {
     private Boolean hasCaseBeenUpdatedWithSupplementaryEvidence(CaseDetails caseDetails) {
 
         CaseDetails updatedCaseDetails = caseRetriever.retrieve(
-            caseDetails.getJurisdiction(), String.valueOf(caseDetails.getId()));
+            caseDetails.getJurisdiction(),
+            CaseTypeId.BULK_SCANNED,
+            String.valueOf(caseDetails.getId())
+        );
 
         List<ScannedDocument> updatedScannedDocuments = ScannedDocumentsHelper.getScannedDocuments(updatedCaseDetails);
         return updatedScannedDocuments.size() > 0;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CaseRetrievalTest.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CaseRetrievalTest.kt
@@ -11,7 +11,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.CASE_REF
 import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.CASE_TYPE_BULK_SCAN
 import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.JURIDICTION
-import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.retrieveCase
+import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.caseUrl
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticatorFactory
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi
@@ -40,6 +40,6 @@ class CaseRetrievalTest {
     fun `Should call to retrieve the case from ccd`() {
         caseRetriever.retrieve(JURIDICTION, CASE_TYPE_BULK_SCAN, CASE_REF)
 
-        server.verify(getRequestedFor(urlEqualTo(retrieveCase())))
+        server.verify(getRequestedFor(urlEqualTo(caseUrl)))
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CaseRetrievalTest.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CaseRetrievalTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.CASE_REF
+import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.CASE_TYPE_BULK_SCAN
 import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.JURIDICTION
 import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.retrieveCase
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever
@@ -37,7 +38,7 @@ class CaseRetrievalTest {
 
     @Test
     fun `Should call to retrieve the case from ccd`() {
-        caseRetriever.retrieve(JURIDICTION, CASE_REF)
+        caseRetriever.retrieve(JURIDICTION, CASE_TYPE_BULK_SCAN, CASE_REF)
 
         server.verify(getRequestedFor(urlEqualTo(retrieveCase())))
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/Environment.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/Environment.kt
@@ -9,8 +9,8 @@ object Environment {
 
     val USER_ID = "640"
     val JURIDICTION = "BULKSCAN"
-    val CASE_TYPE_BULK_SCAN = EventPublisher.BULK_SCANNED
-    val CASE_TYPE_EXCEPTION_RECORD = EventPublisher.EXCEPTION_RECORD
+    val CASE_TYPE_BULK_SCAN = EventPublisher.CASE_TYPE_BULK_SCANNED
+    val CASE_TYPE_EXCEPTION_RECORD = EventPublisher.CASE_TYPE_EXCEPTION_RECORD
     val CASE_REF = "1539007368674134"
 
     val caseUrl = "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN}/cases/${CASE_REF}"

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/Environment.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/Environment.kt
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.controllers
 
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher
 
 /**
  * This Singleton contains all the environmental items needed in the integration test profile.
@@ -9,16 +9,17 @@ object Environment {
 
     val USER_ID = "640"
     val JURIDICTION = "BULKSCAN"
-    val CASE_TYPE = CaseRetriever.CASE_TYPE_ID
+    val CASE_TYPE_BULK_SCAN = EventPublisher.BULK_SCANNED
+    val CASE_TYPE_EXCEPTION_RECORD = EventPublisher.EXCEPTION_RECORD
     val CASE_REF = "1539007368674134"
 
-    val caseUrl = "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE}/cases/${CASE_REF}"
+    val caseUrl = "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN}/cases/${CASE_REF}"
     val caseEventUrl = "${caseUrl}/events"
-    val caseTypeUrl = "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE}"
+    val caseTypeUrl = "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN}"
     val caseSubmitUrl = "$caseTypeUrl/cases"
     val caseEventTriggerStartUrl = "$caseTypeUrl/event-triggers/createException/token"
 
     /** url for retrieve Case */
     fun retrieveCase() =
-        "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE}/cases/${CASE_REF}"
+        "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN}/cases/${CASE_REF}"
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/Environment.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/Environment.kt
@@ -13,13 +13,9 @@ object Environment {
     val CASE_TYPE_EXCEPTION_RECORD = CaseTypeId.EXCEPTION_RECORD
     val CASE_REF = "1539007368674134"
 
-    val caseUrl = "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN.getId()}/cases/${CASE_REF}"
-    val caseEventUrl = "${caseUrl}/events"
-    val caseTypeUrl = "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN.getId()}"
+    private val caseTypeUrl = "/caseworkers/$USER_ID/jurisdictions/$JURIDICTION/case-types/${CASE_TYPE_BULK_SCAN.id}"
+    val caseUrl = "$caseTypeUrl/cases/$CASE_REF"
+    val caseEventUrl = "$caseUrl/events"
     val caseSubmitUrl = "$caseTypeUrl/cases"
     val caseEventTriggerStartUrl = "$caseTypeUrl/event-triggers/createException/token"
-
-    /** url for retrieve Case */
-    fun retrieveCase() =
-        "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN.getId()}/cases/${CASE_REF}"
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/Environment.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/Environment.kt
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.controllers
 
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId
 
 /**
  * This Singleton contains all the environmental items needed in the integration test profile.
@@ -9,8 +9,8 @@ object Environment {
 
     val USER_ID = "640"
     val JURIDICTION = "BULKSCAN"
-    val CASE_TYPE_BULK_SCAN = EventPublisher.CASE_TYPE_BULK_SCANNED
-    val CASE_TYPE_EXCEPTION_RECORD = EventPublisher.CASE_TYPE_EXCEPTION_RECORD
+    val CASE_TYPE_BULK_SCAN = CaseTypeId.CASE_TYPE_BULK_SCANNED
+    val CASE_TYPE_EXCEPTION_RECORD = CaseTypeId.CASE_TYPE_EXCEPTION_RECORD
     val CASE_REF = "1539007368674134"
 
     val caseUrl = "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN}/cases/${CASE_REF}"

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/Environment.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/Environment.kt
@@ -9,17 +9,17 @@ object Environment {
 
     val USER_ID = "640"
     val JURIDICTION = "BULKSCAN"
-    val CASE_TYPE_BULK_SCAN = CaseTypeId.CASE_TYPE_BULK_SCANNED
-    val CASE_TYPE_EXCEPTION_RECORD = CaseTypeId.CASE_TYPE_EXCEPTION_RECORD
+    val CASE_TYPE_BULK_SCAN = CaseTypeId.BULK_SCANNED
+    val CASE_TYPE_EXCEPTION_RECORD = CaseTypeId.EXCEPTION_RECORD
     val CASE_REF = "1539007368674134"
 
-    val caseUrl = "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN}/cases/${CASE_REF}"
+    val caseUrl = "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN.getId()}/cases/${CASE_REF}"
     val caseEventUrl = "${caseUrl}/events"
-    val caseTypeUrl = "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN}"
+    val caseTypeUrl = "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN.getId()}"
     val caseSubmitUrl = "$caseTypeUrl/cases"
     val caseEventTriggerStartUrl = "$caseTypeUrl/event-triggers/createException/token"
 
     /** url for retrieve Case */
     fun retrieveCase() =
-        "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN}/cases/${CASE_REF}"
+        "/caseworkers/${USER_ID}/jurisdictions/${JURIDICTION}/case-types/${CASE_TYPE_BULK_SCAN.getId()}/cases/${CASE_REF}"
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/ExceptionRecordCreatorTest.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/ExceptionRecordCreatorTest.kt
@@ -35,10 +35,11 @@ class ExceptionRecordCreatorTest {
     ).readText())
 
     private val caseEventTriggerStartUrl = Environment.caseEventTriggerStartUrl
-        .replace(CASE_TYPE_BULK_SCAN, CASE_TYPE_EXCEPTION_RECORD)
+        .replace(CASE_TYPE_BULK_SCAN.getId(), CASE_TYPE_EXCEPTION_RECORD.getId())
     private val caseSubmitUrl = Environment.caseSubmitUrl
-        .replace(CASE_TYPE_BULK_SCAN, CASE_TYPE_EXCEPTION_RECORD)
-    private val caseUrl = Environment.caseUrl.replace(CASE_TYPE_BULK_SCAN, CASE_TYPE_EXCEPTION_RECORD)
+        .replace(CASE_TYPE_BULK_SCAN.getId(), CASE_TYPE_EXCEPTION_RECORD.getId())
+    private val caseUrl = Environment.caseUrl
+        .replace(CASE_TYPE_BULK_SCAN.getId(), CASE_TYPE_EXCEPTION_RECORD.getId())
 
     @Autowired
     private lateinit var server: WireMockServer

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/ExceptionRecordCreatorTest.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/ExceptionRecordCreatorTest.kt
@@ -18,9 +18,8 @@ import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.caseEventTriggerStartUrl
-import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.caseSubmitUrl
-import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.caseUrl
+import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.CASE_TYPE_BULK_SCAN
+import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.CASE_TYPE_EXCEPTION_RECORD
 import java.io.File
 import java.util.concurrent.TimeUnit
 
@@ -34,6 +33,12 @@ class ExceptionRecordCreatorTest {
     private val mockExceptionMessage = Message(File(
         "src/integrationTest/resources/servicebus/message/exception-example.json"
     ).readText())
+
+    private val caseEventTriggerStartUrl = Environment.caseEventTriggerStartUrl
+        .replace(CASE_TYPE_BULK_SCAN, CASE_TYPE_EXCEPTION_RECORD)
+    private val caseSubmitUrl = Environment.caseSubmitUrl
+        .replace(CASE_TYPE_BULK_SCAN, CASE_TYPE_EXCEPTION_RECORD)
+    private val caseUrl = Environment.caseUrl.replace(CASE_TYPE_BULK_SCAN, CASE_TYPE_EXCEPTION_RECORD)
 
     @Autowired
     private lateinit var server: WireMockServer

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/ExceptionRecordCreatorTest.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/ExceptionRecordCreatorTest.kt
@@ -20,6 +20,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.CASE_TYPE_BULK_SCAN
 import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.CASE_TYPE_EXCEPTION_RECORD
+import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.Environment.caseUrl
 import java.io.File
 import java.util.concurrent.TimeUnit
 
@@ -35,11 +36,9 @@ class ExceptionRecordCreatorTest {
     ).readText())
 
     private val caseEventTriggerStartUrl = Environment.caseEventTriggerStartUrl
-        .replace(CASE_TYPE_BULK_SCAN.getId(), CASE_TYPE_EXCEPTION_RECORD.getId())
+        .replace(CASE_TYPE_BULK_SCAN.id, CASE_TYPE_EXCEPTION_RECORD.id)
     private val caseSubmitUrl = Environment.caseSubmitUrl
-        .replace(CASE_TYPE_BULK_SCAN.getId(), CASE_TYPE_EXCEPTION_RECORD.getId())
-    private val caseUrl = Environment.caseUrl
-        .replace(CASE_TYPE_BULK_SCAN.getId(), CASE_TYPE_EXCEPTION_RECORD.getId())
+        .replace(CASE_TYPE_BULK_SCAN.id, CASE_TYPE_EXCEPTION_RECORD.id)
 
     @Autowired
     private lateinit var server: WireMockServer

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -52,7 +52,7 @@ public class EnvelopeEventProcessor implements IMessageHandler {
         Envelope envelope = parse(message.getBody());
         CaseDetails theCase = Strings.isNullOrEmpty(envelope.caseRef)
             ? null
-            : caseRetriever.retrieve(envelope.jurisdiction, envelope.caseRef);
+            : caseRetriever.retrieve(envelope.jurisdiction, EventPublisher.BULK_SCANNED, envelope.caseRef);
 
         EventPublisher eventPublisher = eventPublisherContainer.getPublisher(envelope, theCase);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisherContainer;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
@@ -52,7 +53,7 @@ public class EnvelopeEventProcessor implements IMessageHandler {
         Envelope envelope = parse(message.getBody());
         CaseDetails theCase = Strings.isNullOrEmpty(envelope.caseRef)
             ? null
-            : caseRetriever.retrieve(envelope.jurisdiction, EventPublisher.CASE_TYPE_BULK_SCANNED, envelope.caseRef);
+            : caseRetriever.retrieve(envelope.jurisdiction, CaseTypeId.CASE_TYPE_BULK_SCANNED, envelope.caseRef);
 
         EventPublisher eventPublisher = eventPublisherContainer.getPublisher(envelope, theCase);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -52,7 +52,7 @@ public class EnvelopeEventProcessor implements IMessageHandler {
         Envelope envelope = parse(message.getBody());
         CaseDetails theCase = Strings.isNullOrEmpty(envelope.caseRef)
             ? null
-            : caseRetriever.retrieve(envelope.jurisdiction, EventPublisher.BULK_SCANNED, envelope.caseRef);
+            : caseRetriever.retrieve(envelope.jurisdiction, EventPublisher.CASE_TYPE_BULK_SCANNED, envelope.caseRef);
 
         EventPublisher eventPublisher = eventPublisherContainer.getPublisher(envelope, theCase);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -53,7 +53,7 @@ public class EnvelopeEventProcessor implements IMessageHandler {
         Envelope envelope = parse(message.getBody());
         CaseDetails theCase = Strings.isNullOrEmpty(envelope.caseRef)
             ? null
-            : caseRetriever.retrieve(envelope.jurisdiction, CaseTypeId.CASE_TYPE_BULK_SCANNED, envelope.caseRef);
+            : caseRetriever.retrieve(envelope.jurisdiction, CaseTypeId.BULK_SCANNED, envelope.caseRef);
 
         EventPublisher eventPublisher = eventPublisherContainer.getPublisher(envelope, theCase);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetriever.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetriever.java
@@ -23,7 +23,7 @@ public class CaseRetriever {
         this.coreCaseDataApi = coreCaseDataApi;
     }
 
-    public CaseDetails retrieve(String jurisdiction, String caseTypeId, String caseRef) {
+    public CaseDetails retrieve(String jurisdiction, CaseTypeId caseTypeId, String caseRef) {
         // not including in try catch to fast fail the method
         CcdAuthenticator authenticator = factory.createForJurisdiction(jurisdiction);
 
@@ -33,7 +33,7 @@ public class CaseRetriever {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                caseTypeId,
+                caseTypeId.getId(),
                 caseRef
             );
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetriever.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetriever.java
@@ -12,8 +12,6 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @Service
 public class CaseRetriever {
 
-    public static final String CASE_TYPE_ID = "Bulk_Scanned";
-
     private static final Logger log = LoggerFactory.getLogger(CaseRetriever.class);
 
     private final CcdAuthenticatorFactory factory;
@@ -25,7 +23,7 @@ public class CaseRetriever {
         this.coreCaseDataApi = coreCaseDataApi;
     }
 
-    public CaseDetails retrieve(String jurisdiction, String caseRef) {
+    public CaseDetails retrieve(String jurisdiction, String caseTypeId, String caseRef) {
         // not including in try catch to fast fail the method
         CcdAuthenticator authenticator = factory.createForJurisdiction(jurisdiction);
 
@@ -35,7 +33,7 @@ public class CaseRetriever {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                CASE_TYPE_ID,
+                caseTypeId,
                 caseRef
             );
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseTypeId.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseTypeId.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+/**
+ * Temporary enumerator for case types until CCD client is updated.
+ */
+public enum CaseTypeId {
+
+    BULK_SCANNED("Bulk_Scanned"),
+    EXCEPTION_RECORD("ExceptionRecord");
+
+    private final String id;
+
+    CaseTypeId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
@@ -129,7 +129,6 @@ abstract class AbstractEventPublisher implements EventPublisher {
         }
     }
 
-    // todo perhaps some generic interface for these data objects?
     abstract CaseData mapEnvelopeToCaseDataObject(Envelope envelope);
 
     private CaseDataContent buildCaseDataContent(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
  * class PublisherName extends AbstractEventPublisher {
  *
  *     PublisherName() {
+ *         super(CASE_TYPE_ID);
  *         // any extra autowiring needed
  *     }
  *
@@ -51,10 +52,12 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
  * private final EventPublisher somePublisher;}</pre>
  * <p/>
  * Then include each publisher in {@link EventPublisherContainer}
+ * <p/>
+ * {@code CASE_TYPE_ID}s are publicly available in {@code EventPublisher} interface
  */
 abstract class AbstractEventPublisher implements EventPublisher {
 
-    static final String CASE_TYPE_ID = "Bulk_Scanned";
+    private final String caseTypeId;
 
     private static final Logger log = LoggerFactory.getLogger(AbstractEventPublisher.class);
 
@@ -63,6 +66,10 @@ abstract class AbstractEventPublisher implements EventPublisher {
 
     @Autowired
     private CcdAuthenticatorFactory authenticatorFactory;
+
+    AbstractEventPublisher(String caseTypeId) {
+        this.caseTypeId = caseTypeId;
+    }
 
     @Override
     public void publish(Envelope envelope) {
@@ -106,7 +113,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                CASE_TYPE_ID,
+                caseTypeId,
                 getEventTypeId()
             );
         } else {
@@ -115,7 +122,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                CASE_TYPE_ID,
+                caseTypeId,
                 caseRef,
                 getEventTypeId()
             );
@@ -153,7 +160,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                CASE_TYPE_ID,
+                caseTypeId,
                 true,
                 caseDataContent
             );
@@ -163,7 +170,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                CASE_TYPE_ID,
+                caseTypeId,
                 caseRef,
                 true,
                 caseDataContent

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticatorFactory;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
@@ -67,8 +68,8 @@ abstract class AbstractEventPublisher implements EventPublisher {
     @Autowired
     private CcdAuthenticatorFactory authenticatorFactory;
 
-    AbstractEventPublisher(String caseTypeId) {
-        this.caseTypeId = caseTypeId;
+    AbstractEventPublisher(CaseTypeId caseTypeId) {
+        this.caseTypeId = caseTypeId.getId();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -12,7 +12,7 @@ class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
     private final ModelMapper<? extends CaseData> mapper;
 
     AttachDocsToSupplementaryEvidence(SupplementaryEvidenceMapper mapper) {
-        super(EventPublisher.BULK_SCANNED);
+        super(EventPublisher.CASE_TYPE_BULK_SCANNED);
         this.mapper = mapper;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -12,6 +12,7 @@ class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
     private final ModelMapper<? extends CaseData> mapper;
 
     AttachDocsToSupplementaryEvidence(SupplementaryEvidenceMapper mapper) {
+        super(EventPublisher.BULK_SCANNED);
         this.mapper = mapper;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ModelMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.SupplementaryEvidenceMapper;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 @Component
@@ -12,7 +13,7 @@ class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
     private final ModelMapper<? extends CaseData> mapper;
 
     AttachDocsToSupplementaryEvidence(SupplementaryEvidenceMapper mapper) {
-        super(EventPublisher.CASE_TYPE_BULK_SCANNED);
+        super(CaseTypeId.CASE_TYPE_BULK_SCANNED);
         this.mapper = mapper;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -13,7 +13,7 @@ class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
     private final ModelMapper<? extends CaseData> mapper;
 
     AttachDocsToSupplementaryEvidence(SupplementaryEvidenceMapper mapper) {
-        super(CaseTypeId.CASE_TYPE_BULK_SCANNED);
+        super(CaseTypeId.BULK_SCANNED);
         this.mapper = mapper;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -13,7 +13,7 @@ class CreateExceptionRecord extends AbstractEventPublisher {
     private final ModelMapper<? extends CaseData> mapper;
 
     CreateExceptionRecord(ExceptionRecordMapper mapper) {
-        super(CaseTypeId.CASE_TYPE_EXCEPTION_RECORD);
+        super(CaseTypeId.EXCEPTION_RECORD);
         this.mapper = mapper;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ExceptionRecordMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ModelMapper;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 @Component
@@ -12,7 +13,7 @@ class CreateExceptionRecord extends AbstractEventPublisher {
     private final ModelMapper<? extends CaseData> mapper;
 
     CreateExceptionRecord(ExceptionRecordMapper mapper) {
-        super(EventPublisher.CASE_TYPE_EXCEPTION_RECORD);
+        super(CaseTypeId.CASE_TYPE_EXCEPTION_RECORD);
         this.mapper = mapper;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -12,6 +12,7 @@ class CreateExceptionRecord extends AbstractEventPublisher {
     private final ModelMapper<? extends CaseData> mapper;
 
     CreateExceptionRecord(ExceptionRecordMapper mapper) {
+        super(EventPublisher.EXCEPTION_RECORD);
         this.mapper = mapper;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -12,7 +12,7 @@ class CreateExceptionRecord extends AbstractEventPublisher {
     private final ModelMapper<? extends CaseData> mapper;
 
     CreateExceptionRecord(ExceptionRecordMapper mapper) {
-        super(EventPublisher.EXCEPTION_RECORD);
+        super(EventPublisher.CASE_TYPE_EXCEPTION_RECORD);
         this.mapper = mapper;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisher.java
@@ -4,10 +4,5 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envel
 
 public interface EventPublisher {
 
-    // temporary adding custom case types until ccd api is updated
-    // at the moment BULKSCAN jurisdiction is able to use following types anyway
-    String CASE_TYPE_BULK_SCANNED = "Bulk_Scanned";
-    String CASE_TYPE_EXCEPTION_RECORD = "ExceptionRecord";
-
     void publish(Envelope envelope);
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisher.java
@@ -4,5 +4,8 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envel
 
 public interface EventPublisher {
 
+    String BULK_SCANNED = "Bulk_Scanned";
+    String EXCEPTION_RECORD = "ExceptionRecord";
+
     void publish(Envelope envelope);
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisher.java
@@ -4,8 +4,10 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envel
 
 public interface EventPublisher {
 
-    String BULK_SCANNED = "Bulk_Scanned";
-    String EXCEPTION_RECORD = "ExceptionRecord";
+    // temporary adding custom case types until ccd api is updated
+    // at the moment BULKSCAN jurisdiction is able to use following types anyway
+    String CASE_TYPE_BULK_SCANNED = "Bulk_Scanned";
+    String CASE_TYPE_EXCEPTION_RECORD = "ExceptionRecord";
 
     void publish(Envelope envelope);
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -28,7 +28,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.Collections.emptyList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.DatetimeHelper.toIso8601;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.BULK_SCANNED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.CASE_TYPE_BULK_SCANNED;
 
 public class SampleData {
     public static final String SERVICE_TOKEN = "SERVICE_TOKEN";
@@ -52,7 +52,7 @@ public class SampleData {
     public static final CaseDetails THE_CASE = CaseDetails.builder()
         .id(CASE_ID)
         .jurisdiction(JURSIDICTION)
-        .caseTypeId(BULK_SCANNED)
+        .caseTypeId(CASE_TYPE_BULK_SCANNED)
         .build();
 
     public static final ObjectMapper objectMapper;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -28,7 +28,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.Collections.emptyList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.DatetimeHelper.toIso8601;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.CASE_TYPE_BULK_SCANNED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.BULK_SCANNED;
 
 public class SampleData {
     public static final String SERVICE_TOKEN = "SERVICE_TOKEN";
@@ -52,7 +52,7 @@ public class SampleData {
     public static final CaseDetails THE_CASE = CaseDetails.builder()
         .id(CASE_ID)
         .jurisdiction(JURSIDICTION)
-        .caseTypeId(CASE_TYPE_BULK_SCANNED.getId())
+        .caseTypeId(BULK_SCANNED.getId())
         .build();
 
     public static final ObjectMapper objectMapper;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -28,7 +28,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.Collections.emptyList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.DatetimeHelper.toIso8601;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.CASE_TYPE_BULK_SCANNED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.CASE_TYPE_BULK_SCANNED;
 
 public class SampleData {
     public static final String SERVICE_TOKEN = "SERVICE_TOKEN";
@@ -52,7 +52,7 @@ public class SampleData {
     public static final CaseDetails THE_CASE = CaseDetails.builder()
         .id(CASE_ID)
         .jurisdiction(JURSIDICTION)
-        .caseTypeId(CASE_TYPE_BULK_SCANNED)
+        .caseTypeId(CASE_TYPE_BULK_SCANNED.getId())
         .build();
 
     public static final ObjectMapper objectMapper;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -28,7 +28,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.Collections.emptyList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.DatetimeHelper.toIso8601;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever.CASE_TYPE_ID;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.BULK_SCANNED;
 
 public class SampleData {
     public static final String SERVICE_TOKEN = "SERVICE_TOKEN";
@@ -52,7 +52,7 @@ public class SampleData {
     public static final CaseDetails THE_CASE = CaseDetails.builder()
         .id(CASE_ID)
         .jurisdiction(JURSIDICTION)
-        .caseTypeId(CASE_TYPE_ID)
+        .caseTypeId(BULK_SCANNED)
         .build();
 
     public static final ObjectMapper objectMapper;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -25,7 +25,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.CASE_REF;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.JURSIDICTION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.THE_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelopeJson;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.BULK_SCANNED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.CASE_TYPE_BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EnvelopeEventProcessorTest {
@@ -43,7 +43,7 @@ public class EnvelopeEventProcessorTest {
     @Before
     public void before() {
         processor = new EnvelopeEventProcessor(caseRetriever, eventPublisherContainer);
-        when(caseRetriever.retrieve(eq(JURSIDICTION), eq(BULK_SCANNED), eq(CASE_REF))).thenReturn(THE_CASE);
+        when(caseRetriever.retrieve(eq(JURSIDICTION), eq(CASE_TYPE_BULK_SCANNED), eq(CASE_REF))).thenReturn(THE_CASE);
         when(eventPublisherContainer.getPublisher(any(Envelope.class), any(CaseDetails.class)))
             .thenReturn(getDummyPublisher());
         when(eventPublisherContainer.getPublisher(any(Envelope.class), eq(null)))

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -25,6 +25,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.CASE_REF;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.JURSIDICTION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.THE_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelopeJson;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EnvelopeEventProcessorTest {
@@ -42,7 +43,7 @@ public class EnvelopeEventProcessorTest {
     @Before
     public void before() {
         processor = new EnvelopeEventProcessor(caseRetriever, eventPublisherContainer);
-        when(caseRetriever.retrieve(eq(JURSIDICTION), eq(CASE_REF))).thenReturn(THE_CASE);
+        when(caseRetriever.retrieve(eq(JURSIDICTION), eq(BULK_SCANNED), eq(CASE_REF))).thenReturn(THE_CASE);
         when(eventPublisherContainer.getPublisher(any(Envelope.class), any(CaseDetails.class)))
             .thenReturn(getDummyPublisher());
         when(eventPublisherContainer.getPublisher(any(Envelope.class), eq(null)))
@@ -97,7 +98,7 @@ public class EnvelopeEventProcessorTest {
     public void should_return_exceptionally_completed_future_if_exception_is_thrown() throws Exception {
         // given
         given(someMessage.getBody()).willReturn(envelopeJson());
-        given(caseRetriever.retrieve(any(), any())).willThrow(new RuntimeException());
+        given(caseRetriever.retrieve(any(), any(), any())).willThrow(new RuntimeException());
 
         // when
         CompletableFuture<Void> result = processor.onMessageAsync(someMessage);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -25,7 +25,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.CASE_REF;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.JURSIDICTION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.THE_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelopeJson;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.CASE_TYPE_BULK_SCANNED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EnvelopeEventProcessorTest {
@@ -43,7 +43,7 @@ public class EnvelopeEventProcessorTest {
     @Before
     public void before() {
         processor = new EnvelopeEventProcessor(caseRetriever, eventPublisherContainer);
-        when(caseRetriever.retrieve(eq(JURSIDICTION), eq(CASE_TYPE_BULK_SCANNED), eq(CASE_REF))).thenReturn(THE_CASE);
+        when(caseRetriever.retrieve(eq(JURSIDICTION), eq(BULK_SCANNED), eq(CASE_REF))).thenReturn(THE_CASE);
         when(eventPublisherContainer.getPublisher(any(Envelope.class), any(CaseDetails.class)))
             .thenReturn(getDummyPublisher());
         when(eventPublisherContainer.getPublisher(any(Envelope.class), eq(null)))

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -25,7 +25,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.CASE_REF;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.JURSIDICTION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.THE_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelopeJson;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.CASE_TYPE_BULK_SCANNED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.CASE_TYPE_BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EnvelopeEventProcessorTest {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrieverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrieverTest.java
@@ -23,7 +23,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.SERVICE_TOKEN
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.THE_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_ID;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_TOKEN;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.CASE_TYPE_BULK_SCANNED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CaseRetrieverTest {
@@ -34,7 +34,7 @@ public class CaseRetrieverTest {
 
     private CaseRetriever retriever;
 
-    private static final String caseTypeId = CASE_TYPE_BULK_SCANNED.getId();
+    private static final String caseTypeId = BULK_SCANNED.getId();
 
     @Test
     public void should_retrieve_case_successfully() {
@@ -44,7 +44,7 @@ public class CaseRetrieverTest {
             .willReturn(THE_CASE);
         given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
 
-        CaseDetails theCase = retriever.retrieve(JURSIDICTION, CASE_TYPE_BULK_SCANNED, CASE_REF);
+        CaseDetails theCase = retriever.retrieve(JURSIDICTION, BULK_SCANNED, CASE_REF);
         assertThat(theCase.getId()).isEqualTo(CASE_ID);
     }
 
@@ -65,7 +65,7 @@ public class CaseRetrieverTest {
             .willThrow(exception);
         given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
 
-        CaseDetails theCase = retriever.retrieve(JURSIDICTION, CASE_TYPE_BULK_SCANNED, CASE_REF);
+        CaseDetails theCase = retriever.retrieve(JURSIDICTION, BULK_SCANNED, CASE_REF);
 
         assertThat(theCase).isNull();
     }
@@ -87,6 +87,6 @@ public class CaseRetrieverTest {
             .willThrow(exception);
         given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
 
-        assertThatCode(() -> retriever.retrieve(JURSIDICTION, CASE_TYPE_BULK_SCANNED, CASE_REF)).isEqualTo(exception);
+        assertThatCode(() -> retriever.retrieve(JURSIDICTION, BULK_SCANNED, CASE_REF)).isEqualTo(exception);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrieverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrieverTest.java
@@ -23,7 +23,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.SERVICE_TOKEN
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.THE_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_ID;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_TOKEN;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.CASE_TYPE_BULK_SCANNED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.CASE_TYPE_BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CaseRetrieverTest {
@@ -34,11 +34,13 @@ public class CaseRetrieverTest {
 
     private CaseRetriever retriever;
 
+    private static final String caseTypeId = CASE_TYPE_BULK_SCANNED.getId();
+
     @Test
     public void should_retrieve_case_successfully() {
         retriever = new CaseRetriever(authenticator, dataApi);
 
-        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, CASE_TYPE_BULK_SCANNED, CASE_REF))
+        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, caseTypeId, CASE_REF))
             .willReturn(THE_CASE);
         given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
 
@@ -59,7 +61,7 @@ public class CaseRetrieverTest {
                 .build()
         );
 
-        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, CASE_TYPE_BULK_SCANNED, CASE_REF))
+        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, caseTypeId, CASE_REF))
             .willThrow(exception);
         given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
 
@@ -81,7 +83,7 @@ public class CaseRetrieverTest {
                 .build()
         );
 
-        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, CASE_TYPE_BULK_SCANNED, CASE_REF))
+        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, caseTypeId, CASE_REF))
             .willThrow(exception);
         given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrieverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrieverTest.java
@@ -23,7 +23,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.SERVICE_TOKEN
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.THE_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_ID;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_TOKEN;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.BULK_SCANNED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.CASE_TYPE_BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CaseRetrieverTest {
@@ -38,11 +38,11 @@ public class CaseRetrieverTest {
     public void should_retrieve_case_successfully() {
         retriever = new CaseRetriever(authenticator, dataApi);
 
-        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, BULK_SCANNED, CASE_REF))
+        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, CASE_TYPE_BULK_SCANNED, CASE_REF))
             .willReturn(THE_CASE);
         given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
 
-        CaseDetails theCase = retriever.retrieve(JURSIDICTION, BULK_SCANNED, CASE_REF);
+        CaseDetails theCase = retriever.retrieve(JURSIDICTION, CASE_TYPE_BULK_SCANNED, CASE_REF);
         assertThat(theCase.getId()).isEqualTo(CASE_ID);
     }
 
@@ -59,11 +59,11 @@ public class CaseRetrieverTest {
                 .build()
         );
 
-        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, BULK_SCANNED, CASE_REF))
+        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, CASE_TYPE_BULK_SCANNED, CASE_REF))
             .willThrow(exception);
         given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
 
-        CaseDetails theCase = retriever.retrieve(JURSIDICTION, BULK_SCANNED, CASE_REF);
+        CaseDetails theCase = retriever.retrieve(JURSIDICTION, CASE_TYPE_BULK_SCANNED, CASE_REF);
 
         assertThat(theCase).isNull();
     }
@@ -81,10 +81,10 @@ public class CaseRetrieverTest {
                 .build()
         );
 
-        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, BULK_SCANNED, CASE_REF))
+        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, CASE_TYPE_BULK_SCANNED, CASE_REF))
             .willThrow(exception);
         given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
 
-        assertThatCode(() -> retriever.retrieve(JURSIDICTION, BULK_SCANNED, CASE_REF)).isEqualTo(exception);
+        assertThatCode(() -> retriever.retrieve(JURSIDICTION, CASE_TYPE_BULK_SCANNED, CASE_REF)).isEqualTo(exception);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrieverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrieverTest.java
@@ -23,7 +23,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.SERVICE_TOKEN
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.THE_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_ID;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_TOKEN;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever.CASE_TYPE_ID;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CaseRetrieverTest {
@@ -38,11 +38,11 @@ public class CaseRetrieverTest {
     public void should_retrieve_case_successfully() {
         retriever = new CaseRetriever(authenticator, dataApi);
 
-        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, CASE_TYPE_ID, CASE_REF))
+        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, BULK_SCANNED, CASE_REF))
             .willReturn(THE_CASE);
         given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
 
-        CaseDetails theCase = retriever.retrieve(JURSIDICTION, CASE_REF);
+        CaseDetails theCase = retriever.retrieve(JURSIDICTION, BULK_SCANNED, CASE_REF);
         assertThat(theCase.getId()).isEqualTo(CASE_ID);
     }
 
@@ -59,11 +59,11 @@ public class CaseRetrieverTest {
                 .build()
         );
 
-        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, CASE_TYPE_ID, CASE_REF))
+        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, BULK_SCANNED, CASE_REF))
             .willThrow(exception);
         given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
 
-        CaseDetails theCase = retriever.retrieve(JURSIDICTION, CASE_REF);
+        CaseDetails theCase = retriever.retrieve(JURSIDICTION, BULK_SCANNED, CASE_REF);
 
         assertThat(theCase).isNull();
     }
@@ -81,10 +81,10 @@ public class CaseRetrieverTest {
                 .build()
         );
 
-        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, CASE_TYPE_ID, CASE_REF))
+        given(dataApi.readForCaseWorker(USER_TOKEN, SERVICE_TOKEN, USER_ID, JURSIDICTION, BULK_SCANNED, CASE_REF))
             .willThrow(exception);
         given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
 
-        assertThatCode(() -> retriever.retrieve(JURSIDICTION, CASE_REF)).isEqualTo(exception);
+        assertThatCode(() -> retriever.retrieve(JURSIDICTION, BULK_SCANNED, CASE_REF)).isEqualTo(exception);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.CASE_TYPE_BULK_SCANNED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.CASE_TYPE_BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractEventPublisherTest {
@@ -85,7 +85,7 @@ public class AbstractEventPublisherTest {
             authenticator.getServiceToken(),
             authenticator.getUserDetails().getId(),
             ENVELOPE.jurisdiction,
-            CASE_TYPE_BULK_SCANNED,
+            CASE_TYPE_BULK_SCANNED.getId(),
             ENVELOPE.caseRef,
             EVENT_TYPE_ID
         );
@@ -96,7 +96,7 @@ public class AbstractEventPublisherTest {
             authenticator.getServiceToken(),
             authenticator.getUserDetails().getId(),
             ENVELOPE.jurisdiction,
-            CASE_TYPE_BULK_SCANNED,
+            CASE_TYPE_BULK_SCANNED.getId(),
             ENVELOPE.caseRef,
             true,
             CaseDataContent

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractEventPublisherTest {
@@ -34,7 +35,7 @@ public class AbstractEventPublisherTest {
     private static final Envelope ENVELOPE = SampleData.envelope(1);
 
     @InjectMocks
-    private EventPublisher eventPublisher = new AbstractEventPublisher() {
+    private EventPublisher eventPublisher = new AbstractEventPublisher(BULK_SCANNED) {
 
         @Override
         CaseData mapEnvelopeToCaseDataObject(Envelope envelope) {
@@ -84,7 +85,7 @@ public class AbstractEventPublisherTest {
             authenticator.getServiceToken(),
             authenticator.getUserDetails().getId(),
             ENVELOPE.jurisdiction,
-            AbstractEventPublisher.CASE_TYPE_ID,
+            BULK_SCANNED,
             ENVELOPE.caseRef,
             EVENT_TYPE_ID
         );
@@ -95,7 +96,7 @@ public class AbstractEventPublisherTest {
             authenticator.getServiceToken(),
             authenticator.getUserDetails().getId(),
             ENVELOPE.jurisdiction,
-            AbstractEventPublisher.CASE_TYPE_ID,
+            BULK_SCANNED,
             ENVELOPE.caseRef,
             true,
             CaseDataContent

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.CASE_TYPE_BULK_SCANNED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractEventPublisherTest {
@@ -35,7 +35,7 @@ public class AbstractEventPublisherTest {
     private static final Envelope ENVELOPE = SampleData.envelope(1);
 
     @InjectMocks
-    private EventPublisher eventPublisher = new AbstractEventPublisher(CASE_TYPE_BULK_SCANNED) {
+    private EventPublisher eventPublisher = new AbstractEventPublisher(BULK_SCANNED) {
 
         @Override
         CaseData mapEnvelopeToCaseDataObject(Envelope envelope) {
@@ -85,7 +85,7 @@ public class AbstractEventPublisherTest {
             authenticator.getServiceToken(),
             authenticator.getUserDetails().getId(),
             ENVELOPE.jurisdiction,
-            CASE_TYPE_BULK_SCANNED.getId(),
+            BULK_SCANNED.getId(),
             ENVELOPE.caseRef,
             EVENT_TYPE_ID
         );
@@ -96,7 +96,7 @@ public class AbstractEventPublisherTest {
             authenticator.getServiceToken(),
             authenticator.getUserDetails().getId(),
             ENVELOPE.jurisdiction,
-            CASE_TYPE_BULK_SCANNED.getId(),
+            BULK_SCANNED.getId(),
             ENVELOPE.caseRef,
             true,
             CaseDataContent

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.BULK_SCANNED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher.CASE_TYPE_BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractEventPublisherTest {
@@ -35,7 +35,7 @@ public class AbstractEventPublisherTest {
     private static final Envelope ENVELOPE = SampleData.envelope(1);
 
     @InjectMocks
-    private EventPublisher eventPublisher = new AbstractEventPublisher(BULK_SCANNED) {
+    private EventPublisher eventPublisher = new AbstractEventPublisher(CASE_TYPE_BULK_SCANNED) {
 
         @Override
         CaseData mapEnvelopeToCaseDataObject(Envelope envelope) {
@@ -85,7 +85,7 @@ public class AbstractEventPublisherTest {
             authenticator.getServiceToken(),
             authenticator.getUserDetails().getId(),
             ENVELOPE.jurisdiction,
-            BULK_SCANNED,
+            CASE_TYPE_BULK_SCANNED,
             ENVELOPE.caseRef,
             EVENT_TYPE_ID
         );
@@ -96,7 +96,7 @@ public class AbstractEventPublisherTest {
             authenticator.getServiceToken(),
             authenticator.getUserDetails().getId(),
             ENVELOPE.jurisdiction,
-            BULK_SCANNED,
+            CASE_TYPE_BULK_SCANNED,
             ENVELOPE.caseRef,
             true,
             CaseDataContent


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create exception record for supplementary evidence type](https://tools.hmcts.net/jira/browse/RPE-656)

### Change description ###

`ExceptionRecord` is a different case type for ccd resource. Modifying all `EventPublisher` related classes to manually state which type is it during the autowire construct time

Work to be done: move case retriever to the publisher container so relevant calls can be made at the time of need

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
