### PR TITLE
Continue processing the queue after failing message

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/MessageProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/MessageProcessor.java
@@ -28,22 +28,47 @@ public class MessageProcessor {
     public void run() {
         logger.info("Started processing queue messages.");
 
-        IMessage msg = null;
         int processedMessagesCount = 0;
+        int failedMessageCount = 0;
 
         try {
+            IMessage msg = null;
             while ((msg = msgReceiver.receive()) != null) {
-                envelopeProcessor.onMessageAsync(msg).get();
-                msgReceiver.complete(msg.getLockToken());
+                if (tryProcessMessage(msg)) {
+                    msgReceiver.complete(msg.getLockToken());
+                } else {
+                    failedMessageCount++;
+                }
+
                 processedMessagesCount++;
             }
-            logger.info("Message processing complete. Processed {} messages", processedMessagesCount);
+
+            logProcessingCompletion(processedMessagesCount, failedMessageCount);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             logger.error("interrupted", e);
         } catch (Throwable throwable) {
-            logger.error("Message processing exception msgId:{}", getMessageId(msg), throwable);
+            logger.error("Message processing job failed", throwable);
         }
+    }
+
+    private boolean tryProcessMessage(IMessage message) {
+        try {
+            envelopeProcessor.onMessageAsync(message).get();
+            return true;
+        } catch (Exception ex) {
+            logger.error("Failed to process message with Id: {}", getMessageId(message), ex);
+            return false;
+        }
+    }
+
+    private void logProcessingCompletion(int processedMessagesCount, int failedMessageCount) {
+        logger.info(
+            "Message processing complete. Successful: {}, Failed: {}, Total: {})",
+            processedMessagesCount - failedMessageCount,
+            failedMessageCount,
+            processedMessagesCount
+        );
     }
 
     private String getMessageId(IMessage msg) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/MessageProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/MessageProcessorTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ExecutionException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -77,6 +78,28 @@ public class MessageProcessorTest {
         // then
         verify(envelopeEventProcessor, times(2)).onMessageAsync(someMessage);
         verify(receiver, times(3)).receive();
+    }
+
+    @Test
+    public void should_continue_processing_after_message_specific_failure() throws Exception {
+        // given
+        // there are 2 messages on the queue
+        given(receiver.receive())
+            .willReturn(someMessage)
+            .willReturn(someMessage)
+            .willReturn(null);
+
+        // and every attempt to process a message fails
+        willThrow(new RuntimeException("test")).given(envelopeEventProcessor).onMessageAsync(any());
+
+        // when
+        messageProcessor.run();
+
+        // then
+        // all messages are read with an attempt to process them
+        verify(envelopeEventProcessor, times(2)).onMessageAsync(someMessage);
+        verify(receiver, times(3)).receive();
+        verify(receiver, never()).complete(any());
     }
 
 


### PR DESCRIPTION
### Change description ###

Continue processing the queue even when processing of a message fails, so that a problematic messages (invalid, referencing a non-existing case, etc.) don't prevent other messages from being processed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
