### PR TITLE
[PREVIEW] Fix IDAM redirect URI configuration setting

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -51,10 +51,10 @@ locals {
 
     QUEUE_CONNECTION_STRING = "${data.terraform_remote_state.shared_infra.queue_primary_listen_connection_string}"
 
-    IDAM_API_URL           = "${var.idam_api_url}"
-    IDAM_CLIENT_SECRET     = "${data.azurerm_key_vault_secret.idam_client_secret.value}"
-    IDAM_REDIRECT_URI      = "${var.idam_redirect_uri}"
-    CORE_CASE_DATA_API_URL = "${local.ccdApiUrl}"
+    IDAM_API_URL              = "${var.idam_api_url}"
+    IDAM_CLIENT_SECRET        = "${data.azurerm_key_vault_secret.idam_client_secret.value}"
+    IDAM_CLIENT_REDIRECT_URI  = "${var.idam_redirect_uri}"
+    CORE_CASE_DATA_API_URL    = "${local.ccdApiUrl}"
   }
 }
 


### PR DESCRIPTION
### Change description ###

Fix IDAM redirect URI configuration setting. The name of the app setting in Terraform didn't match the path in application.yaml.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
