### PR TITLE
Update case retriever dependency

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/Environment.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/Environment.kt
@@ -13,7 +13,7 @@ object Environment {
     val CASE_TYPE_EXCEPTION_RECORD = CaseTypeId.EXCEPTION_RECORD
     val CASE_REF = "1539007368674134"
 
-    private val caseTypeUrl = "/caseworkers/$USER_ID/jurisdictions/$JURIDICTION/case-types/${CASE_TYPE_BULK_SCAN.id}"
+    private val caseTypeUrl = "/caseworkers/$USER_ID/jurisdictions/$JURIDICTION/case-types/$CASE_TYPE_BULK_SCAN"
     val caseUrl = "$caseTypeUrl/cases/$CASE_REF"
     val caseEventUrl = "$caseUrl/events"
     val caseSubmitUrl = "$caseTypeUrl/cases"

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/ExceptionRecordCreatorTest.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/ExceptionRecordCreatorTest.kt
@@ -36,9 +36,9 @@ class ExceptionRecordCreatorTest {
     ).readText())
 
     private val caseEventTriggerStartUrl = Environment.caseEventTriggerStartUrl
-        .replace(CASE_TYPE_BULK_SCAN.id, CASE_TYPE_EXCEPTION_RECORD.id)
+        .replace(CASE_TYPE_BULK_SCAN, CASE_TYPE_EXCEPTION_RECORD)
     private val caseSubmitUrl = Environment.caseSubmitUrl
-        .replace(CASE_TYPE_BULK_SCAN.id, CASE_TYPE_EXCEPTION_RECORD.id)
+        .replace(CASE_TYPE_BULK_SCAN, CASE_TYPE_EXCEPTION_RECORD)
 
     @Autowired
     private lateinit var server: WireMockServer

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetriever.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetriever.java
@@ -23,7 +23,7 @@ public class CaseRetriever {
         this.coreCaseDataApi = coreCaseDataApi;
     }
 
-    public CaseDetails retrieve(String jurisdiction, CaseTypeId caseTypeId, String caseRef) {
+    public CaseDetails retrieve(String jurisdiction, String caseTypeId, String caseRef) {
         // not including in try catch to fast fail the method
         CcdAuthenticator authenticator = factory.createForJurisdiction(jurisdiction);
 
@@ -33,7 +33,7 @@ public class CaseRetriever {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                caseTypeId.getId(),
+                caseTypeId,
                 caseRef
             );
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseTypeId.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseTypeId.java
@@ -1,20 +1,15 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
 /**
- * Temporary enumerator for case types until CCD client is updated.
+ * Temporary collection of case types until CCD client is updated.
  */
-public enum CaseTypeId {
+public final class CaseTypeId {
 
-    BULK_SCANNED("Bulk_Scanned"),
-    EXCEPTION_RECORD("ExceptionRecord");
+    public static final String BULK_SCANNED = "Bulk_Scanned";
 
-    private final String id;
+    public static final String EXCEPTION_RECORD = "ExceptionRecord";
 
-    CaseTypeId(String id) {
-        this.id = id;
-    }
-
-    public String getId() {
-        return id;
+    private CaseTypeId() {
+        // utility class constructor
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
@@ -58,7 +58,7 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
  */
 abstract class AbstractEventPublisher implements EventPublisher {
 
-    private final String caseTypeId;
+    private final CaseTypeId caseTypeId;
 
     private static final Logger log = LoggerFactory.getLogger(AbstractEventPublisher.class);
 
@@ -69,7 +69,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
     private CcdAuthenticatorFactory authenticatorFactory;
 
     AbstractEventPublisher(CaseTypeId caseTypeId) {
-        this.caseTypeId = caseTypeId.getId();
+        this.caseTypeId = caseTypeId;
     }
 
     @Override
@@ -114,7 +114,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                caseTypeId,
+                caseTypeId.getId(),
                 getEventTypeId()
             );
         } else {
@@ -123,7 +123,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                caseTypeId,
+                caseTypeId.getId(),
                 caseRef,
                 getEventTypeId()
             );
@@ -160,7 +160,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                caseTypeId,
+                caseTypeId.getId(),
                 true,
                 caseDataContent
             );
@@ -170,7 +170,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                caseTypeId,
+                caseTypeId.getId(),
                 caseRef,
                 true,
                 caseDataContent
@@ -179,6 +179,12 @@ abstract class AbstractEventPublisher implements EventPublisher {
     }
 
     // end region - execution steps
+
+
+    @Override
+    public CaseTypeId getCaseTypeIdForEvent() {
+        return caseTypeId;
+    }
 
     /**
      * EventPublisher is coupled with event type id. Used in building case data.

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticatorFactory;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
@@ -53,12 +52,10 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
  * private final EventPublisher somePublisher;}</pre>
  * <p/>
  * Then include each publisher in {@link EventPublisherContainer}
- * <p/>
- * {@code CASE_TYPE_ID}s are publicly available in {@code EventPublisher} interface
  */
 abstract class AbstractEventPublisher implements EventPublisher {
 
-    private final CaseTypeId caseTypeId;
+    private final String caseTypeId;
 
     private static final Logger log = LoggerFactory.getLogger(AbstractEventPublisher.class);
 
@@ -68,7 +65,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
     @Autowired
     private CcdAuthenticatorFactory authenticatorFactory;
 
-    AbstractEventPublisher(CaseTypeId caseTypeId) {
+    AbstractEventPublisher(String caseTypeId) {
         this.caseTypeId = caseTypeId;
     }
 
@@ -114,7 +111,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                caseTypeId.getId(),
+                caseTypeId,
                 getEventTypeId()
             );
         } else {
@@ -123,7 +120,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                caseTypeId.getId(),
+                caseTypeId,
                 caseRef,
                 getEventTypeId()
             );
@@ -160,7 +157,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                caseTypeId.getId(),
+                caseTypeId,
                 true,
                 caseDataContent
             );
@@ -170,7 +167,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
                 authenticator.getServiceToken(),
                 authenticator.getUserDetails().getId(),
                 jurisdiction,
-                caseTypeId.getId(),
+                caseTypeId,
                 caseRef,
                 true,
                 caseDataContent
@@ -182,7 +179,7 @@ abstract class AbstractEventPublisher implements EventPublisher {
 
 
     @Override
-    public CaseTypeId getCaseTypeIdForEvent() {
+    public String getCaseTypeIdForEvent() {
         return caseTypeId;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisher.java
@@ -1,11 +1,10 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 public interface EventPublisher {
 
-    CaseTypeId getCaseTypeIdForEvent();
+    String getCaseTypeIdForEvent();
 
     void publish(Envelope envelope);
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisher.java
@@ -1,8 +1,11 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 public interface EventPublisher {
+
+    CaseTypeId getCaseTypeIdForEvent();
 
     void publish(Envelope envelope);
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisherContainer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisherContainer.java
@@ -40,7 +40,11 @@ public class EventPublisherContainer {
 
         switch (envelope.classification) {
             case SUPPLEMENTARY_EVIDENCE:
-                boolean caseExists = doesCaseExist(envelope.jurisdiction, CaseTypeId.BULK_SCANNED, envelope.caseRef);
+                boolean caseExists = doesCaseExist(
+                    envelope.jurisdiction,
+                    attachDocsPublisher.getCaseTypeIdForEvent(),
+                    envelope.caseRef
+                );
                 eventPublisher = caseExists ? attachDocsPublisher : exceptionRecordCreator;
 
                 break;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisherContainer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisherContainer.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 import com.google.common.base.Strings;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
@@ -60,7 +59,7 @@ public class EventPublisherContainer {
         return eventPublisher;
     }
 
-    private boolean doesCaseExist(String jurisdiction, CaseTypeId caseTypeId, String caseRef) {
+    private boolean doesCaseExist(String jurisdiction, String caseTypeId, String caseRef) {
         CaseDetails caseDetails = Strings.isNullOrEmpty(caseRef)
             ? null
             : caseRetriever.retrieve(jurisdiction, caseTypeId, caseRef);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -52,7 +52,7 @@ public class SampleData {
     public static final CaseDetails THE_CASE = CaseDetails.builder()
         .id(CASE_ID)
         .jurisdiction(JURSIDICTION)
-        .caseTypeId(BULK_SCANNED.getId())
+        .caseTypeId(BULK_SCANNED)
         .build();
 
     public static final ObjectMapper objectMapper;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisherContainer;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
@@ -82,7 +81,7 @@ public class EnvelopeEventProcessorTest {
     private EventPublisher getDummyPublisher() {
         return new EventPublisher() {
             @Override
-            public CaseTypeId getCaseTypeIdForEvent() {
+            public String getCaseTypeIdForEvent() {
                 return null;
             }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -6,48 +6,32 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisherContainer;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.CASE_REF;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.JURSIDICTION;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.THE_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelopeJson;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId.BULK_SCANNED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EnvelopeEventProcessorTest {
     @Mock
     private IMessage someMessage;
     @Mock
-    private CaseRetriever caseRetriever;
-    @Mock
     private EventPublisherContainer eventPublisherContainer;
-    @Mock
-    private CcdAuthenticator authInfo;
 
     private EnvelopeEventProcessor processor;
 
     @Before
     public void before() {
-        processor = new EnvelopeEventProcessor(caseRetriever, eventPublisherContainer);
-        when(caseRetriever.retrieve(eq(JURSIDICTION), eq(BULK_SCANNED), eq(CASE_REF))).thenReturn(THE_CASE);
-        when(eventPublisherContainer.getPublisher(any(Envelope.class), any(CaseDetails.class)))
-            .thenReturn(getDummyPublisher());
-        when(eventPublisherContainer.getPublisher(any(Envelope.class), eq(null)))
-            .thenReturn(getDummyPublisher());
+        processor = new EnvelopeEventProcessor(eventPublisherContainer);
+        when(eventPublisherContainer.getPublisher(any(Envelope.class))).thenReturn(getDummyPublisher());
         given(someMessage.getBody()).willReturn(envelopeJson());
     }
 
@@ -92,19 +76,6 @@ public class EnvelopeEventProcessorTest {
     public void should_not_do_anything_in_notify() {
         // when
         processor.notifyException(null, null);
-    }
-
-    @Test
-    public void should_return_exceptionally_completed_future_if_exception_is_thrown() throws Exception {
-        // given
-        given(someMessage.getBody()).willReturn(envelopeJson());
-        given(caseRetriever.retrieve(any(), any(), any())).willThrow(new RuntimeException());
-
-        // when
-        CompletableFuture<Void> result = processor.onMessageAsync(someMessage);
-
-        // then
-        assertThat(result.isCompletedExceptionally()).isTrue();
     }
 
     private EventPublisher getDummyPublisher() {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseTypeId;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisherContainer;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
@@ -79,8 +80,15 @@ public class EnvelopeEventProcessorTest {
     }
 
     private EventPublisher getDummyPublisher() {
-        return (Envelope envelope) -> {
-            //
+        return new EventPublisher() {
+            @Override
+            public CaseTypeId getCaseTypeIdForEvent() {
+                return null;
+            }
+
+            @Override
+            public void publish(Envelope envelope) {
+            }
         };
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrieverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrieverTest.java
@@ -34,7 +34,7 @@ public class CaseRetrieverTest {
 
     private CaseRetriever retriever;
 
-    private static final String caseTypeId = BULK_SCANNED.getId();
+    private static final String caseTypeId = BULK_SCANNED;
 
     @Test
     public void should_retrieve_case_successfully() {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
@@ -85,7 +85,7 @@ public class AbstractEventPublisherTest {
             authenticator.getServiceToken(),
             authenticator.getUserDetails().getId(),
             ENVELOPE.jurisdiction,
-            BULK_SCANNED.getId(),
+            BULK_SCANNED,
             ENVELOPE.caseRef,
             EVENT_TYPE_ID
         );
@@ -96,7 +96,7 @@ public class AbstractEventPublisherTest {
             authenticator.getServiceToken(),
             authenticator.getUserDetails().getId(),
             ENVELOPE.jurisdiction,
-            BULK_SCANNED.getId(),
+            BULK_SCANNED,
             ENVELOPE.caseRef,
             true,
             CaseDataContent

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisherContainerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EventPublisherContainerTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -12,12 +13,20 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelopeJson;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.objectMapper;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EventPublisherContainerTest {
+
+    @Mock
+    private CaseRetriever caseRetriever;
 
     @Mock
     private AttachDocsToSupplementaryEvidence attachDocsToSupplementaryEvidence;
@@ -30,6 +39,7 @@ public class EventPublisherContainerTest {
     @Before
     public void setUp() {
         eventPublisherContainer = new EventPublisherContainer(
+            caseRetriever,
             attachDocsToSupplementaryEvidence,
             createExceptionRecord
         );
@@ -37,13 +47,15 @@ public class EventPublisherContainerTest {
 
     @Test
     public void should_get_AttachDocsToSupplementaryEvidence_event_publisher() throws IOException {
+        // given
+        given(caseRetriever.retrieve(anyString(), any(), anyString())).willReturn(mock(CaseDetails.class));
+
         // when
         EventPublisher eventPublisher = eventPublisherContainer.getPublisher(
             objectMapper.readValue(
                 envelopeJson(Classification.SUPPLEMENTARY_EVIDENCE),
                 Envelope.class
-            ),
-            mock(CaseDetails.class)
+            )
         );
 
         // then
@@ -57,8 +69,7 @@ public class EventPublisherContainerTest {
             objectMapper.readValue(
                 envelopeJson(Classification.SUPPLEMENTARY_EVIDENCE),
                 Envelope.class
-            ),
-            null
+            )
         );
 
         // then
@@ -72,11 +83,13 @@ public class EventPublisherContainerTest {
             objectMapper.readValue(
                 envelopeJson(Classification.EXCEPTION),
                 Envelope.class
-            ),
-            null
+            )
         );
 
         // then
         assertThat(eventPublisher).isInstanceOf(createExceptionRecord.getClass());
+
+        // and
+        verify(caseRetriever, never()).retrieve(anyString(), any(), anyString());
     }
 }


### PR DESCRIPTION
### Change description ###

Move `CaseRetriever` to another component of dependency chain instead of `EnvelopeProcessor` leaving the processing steps dead simple:

- parse
- choose publisher
- publish

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
