### PR TITLE
RPE-670#14 deal with multiple exception documents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,7 @@ dependencies {
 
   compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.8'
   compile group: 'io.vavr', name: 'vavr', version: '0.9.2'
+  compile group: 'com.google.guava', name: 'guava', version: '27.0-jre'
 
   annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordToExistingCaseTest.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordToExistingCaseTest.kt
@@ -176,7 +176,7 @@ class AttachExceptionRecordToExistingCaseTest {
             .statusCode(200)
             .body("errors.size()", equalTo(0))
 
-        val summary = "Attaching exception record($recordId) document number:$exceptionRecordDocumentNumber to case:$CASE_REF"
+        val summary = "Attaching exception record($recordId) document numbers:[$exceptionRecordDocumentNumber] to case:$CASE_REF"
 
         verify(startEventRequest())
         verify(submittedScannedRecords().numberOfScannedDocumentsIs(2))
@@ -218,7 +218,7 @@ class AttachExceptionRecordToExistingCaseTest {
             .postToCallback()
             .then()
             .statusCode(200)
-            .shouldContainError("Document with documentId $documentNumber is already attached to $CASE_REF")
+            .shouldContainError("Document with documentIds [$documentNumber] is already attached to $CASE_REF")
 
         verify(exactly(0), startEventRequest())
         verify(exactly(0), submittedScannedRecords())

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordToExistingCaseTest.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordToExistingCaseTest.kt
@@ -71,7 +71,7 @@ fun WiremockReq.numberOfScannedDocumentsIs(numberOfDocuments: Int): RequestPatte
 fun document(filename: String, documentNumber: String): Map<String, String> {
     return mapOf(
         "fileName" to filename,
-        "documentNumber" to documentNumber,
+        "id" to documentNumber,
         "someString" to "someValue"
     )
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -77,7 +77,7 @@ final class CallbackValidations {
     }
 
     @Nonnull
-    static Validation<String, List<Map<String, Object>>> hasAScannedDocument(CaseDetails theCase) {
+    static Validation<String, List<Map<String, Object>>> hasAScannedRecord(CaseDetails theCase) {
         return scannedRecordValidator.validate(theCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
@@ -52,7 +52,7 @@ final class Documents {
     }
 
     @Nonnull
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked","squid:S1135"})
     static List<Map<String, Object>> getScannedDocuments(CaseDetails theCase) {
         //TODO check that the SCANNED_DOCUMENTS exists first or return a new list ?
         return (List<Map<String, Object>>) theCase.getData().get(SCANNED_DOCUMENTS);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import org.jetbrains.annotations.NotNull;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.stream.Collectors.toSet;
+
+final class Documents {
+    private static final String SCANNED_DOCUMENTS = "scannedDocuments";
+    private static final String SCAN_RECORDS = "scanRecords";
+    private static final String DOCUMENT_NUMBER = "documentNumber";
+
+    private Documents() {
+    }
+
+    static Set<String> findDuplicates(List<Map<String, Object>> exceptionDocuments,
+                                      List<Map<String, Object>> existingDocuments) {
+        return Sets.intersection(getDocumentIdSet(existingDocuments), getDocumentIdSet(exceptionDocuments));
+    }
+
+    static void checkForDuplicatesOrElse(List<Map<String, Object>> exceptionDocuments,
+                                         List<Map<String, Object>> existingDocuments,
+                                         Consumer<Set<String>> duplicatesExist) {
+        Set<String> ids = Documents.findDuplicates(exceptionDocuments, existingDocuments);
+        if (!ids.isEmpty()) {
+            duplicatesExist.accept(ids);
+        }
+    }
+
+    @NotNull
+    static Set<String> getDocumentIdSet(List<Map<String, Object>> existingDocuments) {
+        return existingDocuments.stream()
+            .map(document -> (String) document.get("documentNumber"))
+            .collect(toSet());
+    }
+
+    static List<String> getDocumentNumbers(List<Map<String, Object>> documents) {
+        return documents
+            .stream()
+            .map(doc -> (String) doc.get(DOCUMENT_NUMBER))
+            .collect(toImmutableList());
+    }
+
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    static List<Map<String, Object>> getScannedDocuments(CaseDetails theCase) {
+        //TODO check that the SCANNED_DOCUMENTS exists first or return a new list ?
+        return (List<Map<String, Object>>) theCase.getData().get(SCANNED_DOCUMENTS);
+    }
+
+    @SuppressWarnings("unchecked")
+    static List<Map<String, Object>> getScannedRecords(Map<String, Object> exceptionData) {
+        return (List<Map<String, Object>>) exceptionData.get(SCAN_RECORDS);
+    }
+
+    static Map<String, Object> insertNewRecords(List<Map<String, Object>> exceptionDocuments,
+                                                List<Map<String, Object>> existingDocuments) {
+        ImmutableList<Object> documentList = ImmutableList.builder()
+            .addAll(existingDocuments)
+            .addAll(exceptionDocuments)
+            .build();
+        return ImmutableMap.of(SCANNED_DOCUMENTS, documentList);
+    }
+
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
@@ -18,7 +18,7 @@ import static java.util.stream.Collectors.toSet;
 final class Documents {
     private static final String SCANNED_DOCUMENTS = "scannedDocuments";
     private static final String SCAN_RECORDS = "scanRecords";
-    private static final String DOCUMENT_NUMBER = "documentNumber";
+    private static final String DOCUMENT_NUMBER = "id";
 
     private Documents() {
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
@@ -23,24 +23,24 @@ final class Documents {
     private Documents() {
     }
 
-    static Set<String> findDuplicates(List<Map<String, Object>> exceptionDocuments,
-                                      List<Map<String, Object>> existingDocuments) {
+    private static Set<String> findDuplicates(List<Map<String, Object>> exceptionDocuments,
+                                              List<Map<String, Object>> existingDocuments) {
         return Sets.intersection(getDocumentIdSet(existingDocuments), getDocumentIdSet(exceptionDocuments));
     }
 
     static void checkForDuplicatesOrElse(List<Map<String, Object>> exceptionDocuments,
                                          List<Map<String, Object>> existingDocuments,
                                          Consumer<Set<String>> duplicatesExist) {
-        Set<String> ids = Documents.findDuplicates(exceptionDocuments, existingDocuments);
+        Set<String> ids = findDuplicates(exceptionDocuments, existingDocuments);
         if (!ids.isEmpty()) {
             duplicatesExist.accept(ids);
         }
     }
 
     @NotNull
-    static Set<String> getDocumentIdSet(List<Map<String, Object>> existingDocuments) {
+    private static Set<String> getDocumentIdSet(List<Map<String, Object>> existingDocuments) {
         return existingDocuments.stream()
-            .map(document -> (String) document.get("documentNumber"))
+            .map(document -> (String) document.get(DOCUMENT_NUMBER))
             .collect(toSet());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/JurisdictionToUserMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/JurisdictionToUserMapping.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam;
 
-import com.google.common.collect.ImmutableMap;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.AbstractMap;
+import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Map.Entry;
@@ -12,7 +12,7 @@ import static java.util.stream.Collectors.toMap;
 @ConfigurationProperties(prefix = "idam")
 public class JurisdictionToUserMapping {
 
-    private Map<String, Credential> users = ImmutableMap.of();
+    private Map<String, Credential> users = new HashMap<>();
 
     public void setUsers(Map<String, Map<String, String>> users) {
         this.users = users

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
@@ -68,7 +68,7 @@ class CallbackValidationsTest {
                            boolean valid,
                            List<Map<String, Object>> realValue,
                            String errorString) {
-        checkValidation(input, valid, realValue, CallbackValidations::hasAScannedDocument, errorString);
+        checkValidation(input, valid, realValue, CallbackValidations::hasAScannedRecord, errorString);
     }
 
     private <T> void checkValidation(CaseDetails input,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
@@ -37,11 +37,11 @@ class DocumentsTest {
     }
 
     @NotNull
-    private static CaseDetails createCaseDetailsWith(Integer ... dcns) {
+    private static CaseDetails createCaseDetailsWith(Integer...dcns) {
         return CaseDetails.builder().data(ImmutableMap.of(SCANNED_DOCUMENTS, createDcnList(dcns))).build();
     }
 
-    private static List<Map<String, String>> createDcnList(Integer ... dcns) {
+    private static List<Map<String, String>> createDcnList(Integer...dcns) {
         return Stream.of(dcns)
             .map(String::valueOf)
             .map(dcn -> ImmutableMap.of(DOCUMENT_NUMBER, dcn))

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
@@ -19,7 +19,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.getScannedDocuments;
 
-public class DuplicateDocumentCheckerTest {
+class DocumentsTest {
     private static final String SCANNED_DOCUMENTS = "scannedDocuments";
     private static final String DOCUMENT_NUMBER = "documentNumber";
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
@@ -21,7 +21,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.g
 
 class DocumentsTest {
     private static final String SCANNED_DOCUMENTS = "scannedDocuments";
-    private static final String DOCUMENT_NUMBER = "documentNumber";
+    private static final String DOCUMENT_NUMBER = "id";
 
     private static Object[][] documentDuplicateTestParam() {
         return new Object[][]{

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DuplicateDocumentCheckerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DuplicateDocumentCheckerTest.java
@@ -1,0 +1,66 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.getScannedDocuments;
+
+public class DuplicateDocumentCheckerTest {
+    private static final String SCANNED_DOCUMENTS = "scannedDocuments";
+    private static final String DOCUMENT_NUMBER = "documentNumber";
+
+    private static Object[][] documentDuplicateTestParam() {
+        return new Object[][]{
+            {createCaseDetailsWith(), createDcnList(), ImmutableSet.<String>of()},
+            {createCaseDetailsWith(1, 2, 3, 4, 5), createDcnList(6, 7, 8, 9), ImmutableSet.of()},
+            {createCaseDetailsWith(1, 2, 3, 4, 5), createDcnList(6, 3, 4, 8, 9), ImmutableSet.of(3, 4)}
+        };
+    }
+
+    @NotNull
+    private Set<String> asStringSet(Set<Integer> duplicates) {
+        return duplicates.stream().map(String::valueOf).collect(toSet());
+    }
+
+    @NotNull
+    private static CaseDetails createCaseDetailsWith(Integer ... dcns) {
+        return CaseDetails.builder().data(ImmutableMap.of(SCANNED_DOCUMENTS, createDcnList(dcns))).build();
+    }
+
+    private static List<Map<String, String>> createDcnList(Integer ... dcns) {
+        return Stream.of(dcns)
+            .map(String::valueOf)
+            .map(dcn -> ImmutableMap.of(DOCUMENT_NUMBER, dcn))
+            .collect(toImmutableList());
+    }
+
+    @ParameterizedTest
+    @MethodSource("documentDuplicateTestParam")
+    @DisplayName("Check the different for duplicates between the two lists.")
+    void findDuplicatesTest(CaseDetails theCase,
+                            List<Map<String, Object>> exceptionRecords,
+                            Set<Integer> duplicates) {
+        AtomicReference<Set<String>> result = new AtomicReference<>();
+        Documents.checkForDuplicatesOrElse(exceptionRecords, getScannedDocuments(theCase), result::set);
+
+        if (duplicates.isEmpty()) {
+            assertThat(result.get()).isNull();
+        } else {
+            assertThat(result.get()).isEqualTo(asStringSet(duplicates));
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
RPE-670

### Change description ###
Enhance the attach exception record code to deal with multiple documents
- check for single or multiple document duplicates
- append multiple documents
- extract convenience functions that can be reused for the rest of the codebase in later cleanup activity