### PR TITLE
BPS-244 Renamed ccd event types and combined scanRecords and scannedDocuments

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
@@ -37,8 +37,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getScannedDocumentsForExceptionRecord;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getScannedDocumentsForSupplementaryEvidence;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getScannedDocuments;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -166,7 +165,7 @@ public class AttachExceptionRecordToExistingCaseTest {
             String.valueOf(caseDetails.getId())
         );
 
-        List<ScannedDocument> updatedScannedDocuments = getScannedDocumentsForSupplementaryEvidence(updatedCase);
+        List<ScannedDocument> updatedScannedDocuments = getScannedDocuments(updatedCase);
 
         return updatedScannedDocuments.size() == expectedScannedDocsSize;
     }
@@ -180,9 +179,9 @@ public class AttachExceptionRecordToExistingCaseTest {
             String.valueOf(caseDetails.getId())
         );
 
-        List<ScannedDocument> updatedScannedDocuments = getScannedDocumentsForSupplementaryEvidence(updatedCase);
+        List<ScannedDocument> updatedScannedDocuments = getScannedDocuments(updatedCase);
 
-        List<ScannedDocument> exceptionRecordDocuments = getScannedDocumentsForExceptionRecord(exceptionRecord);
+        List<ScannedDocument> exceptionRecordDocuments = getScannedDocuments(exceptionRecord);
 
         assertThat(updatedScannedDocuments).isNotEmpty();
         assertThat(exceptionRecordDocuments).isNotEmpty();

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getScannedDocumentsForSupplementaryEvidence;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getScannedDocuments;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -125,7 +125,7 @@ public class SupplementaryEvidenceTest {
             String.valueOf(caseDetails.getId())
         );
 
-        updatedScannedDocuments = getScannedDocumentsForSupplementaryEvidence(updatedCaseDetails);
+        updatedScannedDocuments = getScannedDocuments(updatedCaseDetails);
         return updatedScannedDocuments.size() == excpectedScannedDocuments;
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCaseCreator.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCaseCreator.java
@@ -20,7 +20,7 @@ public class CcdCaseCreator {
 
     private static final String JURISDICTION = "BULKSCAN";
     private static final String CASE_TYPE_ID = "Bulk_Scanned";
-    private static final String CREATE_CASE_EVENT_TYPE_ID = "receiveRecords";
+    private static final String CREATE_CASE_EVENT_TYPE_ID = "createCase";
 
     private final CcdAuthenticatorFactory ccdAuthenticatorFactory;
     private final CoreCaseDataApi coreCaseDataApi;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordToExistingCaseTest.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordToExistingCaseTest.kt
@@ -141,7 +141,7 @@ class AttachExceptionRecordToExistingCaseTest {
         .data(exceptionData)
 
     private fun exceptionDataWithDoc(map: Map<String, Any>) =
-        mapOf("attachToCaseReference" to CASE_REF, "scanRecords" to listOf(map))
+        mapOf("attachToCaseReference" to CASE_REF, "scannedDocuments" to listOf(map))
 
     private val startEventResponse = StartEventResponse
         .builder()

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -30,14 +30,7 @@ public class ScannedDocumentsHelper {
     }
 
     @SuppressWarnings("unchecked")
-    public static List<ScannedDocument> getScannedDocumentsForExceptionRecord(CaseDetails caseDetails) {
-        List<Map<String, Object>> data = (List<Map<String, Object>>) caseDetails.getData().get("scanRecords");
-
-        return data.stream().map(ScannedDocumentsHelper::createScannedDocumentWithCcdData).collect(toList());
-    }
-
-    @SuppressWarnings("unchecked")
-    public static List<ScannedDocument> getScannedDocumentsForSupplementaryEvidence(CaseDetails caseDetails) {
+    public static List<ScannedDocument> getScannedDocuments(CaseDetails caseDetails) {
         List<Map<String, Object>> data = (List<Map<String, Object>>) caseDetails.getData().get("scannedDocuments");
 
         return data.stream().map(ScannedDocumentsHelper::createScannedDocumentWithCcdData).collect(toList());

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
@@ -19,7 +19,7 @@ public class ExceptionRecord implements CaseData {
 
     public final LocalDateTime openingDate;
 
-    public final List<CcdCollectionElement<ScannedDocument>> scanRecords;
+    public final List<CcdCollectionElement<ScannedDocument>> scannedDocuments;
 
     public ExceptionRecord(
         String classification,
@@ -27,13 +27,13 @@ public class ExceptionRecord implements CaseData {
         String jurisdiction,
         LocalDateTime deliveryDate,
         LocalDateTime openingDate,
-        List<CcdCollectionElement<ScannedDocument>> scannedRecords
+        List<CcdCollectionElement<ScannedDocument>> scannedDocuments
     ) {
         this.classification = classification;
         this.poBox = poBox;
         this.jurisdiction = jurisdiction;
         this.deliveryDate = deliveryDate;
         this.openingDate = openingDate;
-        this.scanRecords = scannedRecords;
+        this.scannedDocuments = scannedDocuments;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -17,7 +17,7 @@ final class CallbackValidations {
     private static final Logger log = LoggerFactory.getLogger(CallbackValidations.class);
 
     private static final CaseReferenceValidator caseRefValidator = new CaseReferenceValidator();
-    private static final ScannedRecordValidator scannedRecordValidator = new ScannedRecordValidator();
+    private static final ScannedDocumentValidator scannedDocumentValidator = new ScannedDocumentValidator();
 
     private CallbackValidations() {
     }
@@ -59,6 +59,6 @@ final class CallbackValidations {
 
     @Nonnull
     static Validation<String, List<Map<String, Object>>> hasAScannedRecord(CaseDetails theCase) {
-        return scannedRecordValidator.validate(theCase);
+        return scannedDocumentValidator.validate(theCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/ScannedDocumentValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/ScannedDocumentValidator.java
@@ -9,15 +9,15 @@ import java.util.Optional;
 
 import static io.vavr.control.Validation.invalid;
 
-class ScannedRecordValidator {
-    private static final String SCAN_RECORDS = "scanRecords";
+class ScannedDocumentValidator {
+    private static final String SCANNED_DOCUMENTS = "scannedDocuments";
 
     @SuppressWarnings("unchecked")
     Validation<String, List<Map<String, Object>>> validate(CaseDetails theCase) {
         return getScannedRecord(theCase)
             .filter(list -> list instanceof List)
-            .map(scanRecords -> (List<Map<String, Object>>) scanRecords)
-            .filter(scanRecords -> !scanRecords.isEmpty())
+            .map(scannedDocuments -> (List<Map<String, Object>>) scannedDocuments)
+            .filter(scannedDocuments -> !scannedDocuments.isEmpty())
             .map(Validation::<String, List<Map<String, Object>>>valid)
             .orElseGet(() -> invalid("There were no documents in exception record"));
     }
@@ -25,6 +25,6 @@ class ScannedRecordValidator {
     private static Optional<Object> getScannedRecord(CaseDetails theCase) {
         return Optional.ofNullable(theCase)
             .map(CaseDetails::getData)
-            .map(data -> data.get(SCAN_RECORDS));
+            .map(data -> data.get(SCANNED_DOCUMENTS));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getScannedDocuments;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getScannedDocumentsForSupplementaryEvidence;
 
 @Component
 class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
@@ -35,7 +34,7 @@ class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
     @Override
     public CaseDataContent buildCaseDataContent(StartEventResponse eventResponse, Envelope envelope) {
 
-        List<ScannedDocument> ccdScannedDocuments = getScannedDocumentsForSupplementaryEvidence(
+        List<ScannedDocument> ccdScannedDocuments = getScannedDocuments(
             eventResponse.getCaseDetails()
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
@@ -26,7 +26,7 @@ class TestCaseBuilder {
 
     static CaseDetails caseWithDocument(List<Map<String, Object>> caseReference) {
         Map<String, Object> data = new HashMap<>();
-        data.put("scanRecords", caseReference);
+        data.put("scannedDocuments", caseReference);
         return createCaseWith(b -> b.data(data));
     }
 

--- a/src/test/resources/mappings/caseworkers_640_jurisdictions_bulkscan_case-types_bulk_scanned_cases_1539007368674134_exception_record-5e24bd28-34a3-4a7c-a78e-359b9dcc7254.json
+++ b/src/test/resources/mappings/caseworkers_640_jurisdictions_bulkscan_case-types_bulk_scanned_cases_1539007368674134_exception_record-5e24bd28-34a3-4a7c-a78e-359b9dcc7254.json
@@ -7,7 +7,7 @@
     "bodyPatterns": [
       {
         "matchesJsonPath": {
-          "expression": "$.data.scanRecords[0].value.fileName",
+          "expression": "$.data.scannedDocuments[0].value.fileName",
           "contains": "testfilename"
         }
       }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-244


### Change description ###
Combined scanRecords in Exception Record and scannedDocuments  in supplementary evidence.
Renamed case event type for creating a new case in ccd.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
