### PR TITLE
Fix `evidenceHandled` flag

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
@@ -124,9 +124,10 @@ public class SupplementaryEvidenceTest {
             caseDetails.getJurisdiction(),
             String.valueOf(caseDetails.getId())
         );
+        String evidenceHandled = (String) updatedCaseDetails.getData().getOrDefault("evidenceHandled", "NO_VALUE");
 
         updatedScannedDocuments = getScannedDocuments(updatedCaseDetails);
-        return updatedScannedDocuments.size() == excpectedScannedDocuments;
+        return updatedScannedDocuments.size() == excpectedScannedDocuments && evidenceHandled.equals("No");
     }
 
     private void verifySupplementaryEvidenceDetailsUpdated(int expectedScannedDocuments) throws JSONException {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/SupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/SupplementaryEvidence.java
@@ -4,10 +4,10 @@ import java.util.List;
 
 public class SupplementaryEvidence implements CaseData {
 
-    // This field should always be set to null, as adding supplementary evidence
-    // resets 'evidenceHandled' field in the case
+    // This field should always be set to false aka YesOrNo
+    // as adding supplementary evidence resets 'evidenceHandled' field in the case
     @SuppressWarnings("squid:S1170") // this field shouldn't be made static
-    public final String evidenceHandled = null;
+    public final String evidenceHandled = "No";
 
     public final List<CcdCollectionElement<ScannedDocument>> scannedDocuments;
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
@@ -23,7 +23,7 @@ public class SupplementaryEvidenceMapperTest {
         Envelope envelope = SampleData.envelope(1);
         SupplementaryEvidence supplementaryEvidence = mapper.mapEnvelope(envelope);
 
-        assertThat(supplementaryEvidence.evidenceHandled).isNull();
+        assertThat(supplementaryEvidence.evidenceHandled).isEqualTo("No");
 
         assertThat(supplementaryEvidence.scannedDocuments.size()).isEqualTo(1);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Evidence handle flag not updated when case is updated](https://tools.hmcts.net/jira/browse/BPS-231)

### Change description ###

`null` case is ignored. Has to be specific. Since the CCD type is `YesOrNo` this means either `Yes` OR `No` value is desired.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
