### PR TITLE
BPS-277 Added exception record reference to the scanned documents

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -46,11 +46,13 @@ public class ScannedDocumentsHelper {
     }
 
     private static ScannedDocument mapDocument(Document document) {
-        return new ScannedDocument(document.fileName,
+        return new ScannedDocument(
+            document.fileName,
             document.controlNumber,
             document.type,
             document.scannedAt.atZone(ZoneId.systemDefault()).toLocalDateTime(),
             new CcdDocument(String.valueOf(document.url)),
-            null);
+            null
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -50,6 +50,7 @@ public class ScannedDocumentsHelper {
             document.controlNumber,
             document.type,
             document.scannedAt.atZone(ZoneId.systemDefault()).toLocalDateTime(),
-            new CcdDocument(String.valueOf(document.url)));
+            new CcdDocument(String.valueOf(document.url)),
+            null);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ScannedDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ScannedDocument.java
@@ -1,17 +1,20 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ScannedDocument {
 
     public final String fileName;
     public final String controlNumber;
     public final String type;
+    public final String exceptionReference;
     public final LocalDateTime scannedDate;
     public final CcdDocument url;
 
@@ -20,13 +23,15 @@ public class ScannedDocument {
         @JsonProperty("controlNumber") String controlNumber,
         @JsonProperty("type") String type,
         @JsonProperty("scannedDate") LocalDateTime scannedDate,
-        @JsonProperty("url") CcdDocument url
+        @JsonProperty("url") CcdDocument url,
+        @JsonProperty("exceptionRecordReference") String exceptionReference
     ) {
         this.fileName = fileName;
         this.controlNumber = controlNumber;
         this.type = type;
         this.scannedDate = scannedDate;
         this.url = url;
+        this.exceptionReference = exceptionReference;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ModelMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ModelMapper.java
@@ -31,7 +31,8 @@ public abstract class ModelMapper<T extends CaseData> {
             document.controlNumber,
             document.type,
             getLocalDateTime(document.scannedAt),
-            new CcdDocument(document.url)
+            new CcdDocument(document.url),
+            null
         );
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-277

### Change description ###
Added exception record reference to the scanned documents in the Exception record, when attaching exception record to the case.
Updated functional tests to assert exception record reference is added to all the documents in the exception record.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
