### PR TITLE
Make the set of supported jurisdictions configurable

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -25,17 +25,25 @@ locals {
     // add secrets to all bulk-scan vaults in the form idam-users-<jurisdiction>-username idam-users-<jurisdiction>-password
     SSCS = "idam-users-sscs"
     BULKSCAN = "idam-users-bulkscan"
+    DIVORCE = "idam-users-div"
   }
 
-  users_secret_names = "${values(local.users)}"
+  all_jurisdictions     = "${keys(local.users)}"
+  supported_user_keys   = "${matchkeys(local.all_jurisdictions, local.all_jurisdictions, var.supported_jurisdictions)}"
+  supported_user_values = "${matchkeys(values(local.users), local.all_jurisdictions, var.supported_jurisdictions)}"
+
+  # a subset of local.users, limited to the supported jurisdictions
+  supported_users       = "${zipmap(local.supported_user_keys, local.supported_user_values)}"
+
+  users_secret_names = "${values(local.supported_users)}"
 
   users_usernames_settings = "${zipmap(
-                                    formatlist("IDAM_USERS_%s_USERNAME", keys(local.users)),
+                                    formatlist("IDAM_USERS_%s_USERNAME", keys(local.supported_users)),
                                     data.azurerm_key_vault_secret.idam_users_usernames.*.value
                                 )}"
 
   users_passwords_settings = "${zipmap(
-                                    formatlist("IDAM_USERS_%s_PASSWORD", keys(local.users)),
+                                    formatlist("IDAM_USERS_%s_PASSWORD", keys(local.supported_users)),
                                     data.azurerm_key_vault_secret.idam_users_passwords.*.value
                                 )}"
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -52,3 +52,9 @@ variable "idam_client_redirect_uri" {
 variable "s2s_name" {
   default = "bulk_scan_orchestrator"
 }
+
+variable "supported_jurisdictions" {
+  type = "list"
+  description = "Jurisdictions to be supported by Bulk Scan in the given environment. Bulk Scan will only be able to map these ones to IDAM user credentials"
+  default = ["SSCS", "BULKSCAN"]
+}


### PR DESCRIPTION
### Change description ###

Make it configurable which jurisdictions should be supported by the orchestrator, so that we can support integration testing on aat before given service goes live, while keeping prod unaffected.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
