### PR TITLE
Enable Divorce and Probate jurisdictions in AAT

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,3 +1,4 @@
 capacity = "2"
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"
 idam_client_redirect_uri = "https://rpe-bulk-scan-processor-sandbox.service.core-compute-sandbox.internal/oauth2/callback"
+supported_jurisdictions = ["SSCS", "BULKSCAN", "DIVORCE"]

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,4 +1,4 @@
 capacity = "2"
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"
 idam_client_redirect_uri = "https://rpe-bulk-scan-processor-sandbox.service.core-compute-sandbox.internal/oauth2/callback"
-supported_jurisdictions = ["SSCS", "BULKSCAN", "DIVORCE"]
+supported_jurisdictions = ["SSCS", "BULKSCAN", "DIVORCE", "PROBATE"]

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -25,7 +25,6 @@ locals {
     // add secrets to all bulk-scan vaults in the form idam-users-<jurisdiction>-username idam-users-<jurisdiction>-password
     SSCS = "idam-users-sscs"
     BULKSCAN = "idam-users-bulkscan"
-    DIVORCE = "idam-users-div"
   }
 
   all_jurisdictions     = "${keys(local.users)}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -25,6 +25,7 @@ locals {
     // add secrets to all bulk-scan vaults in the form idam-users-<jurisdiction>-username idam-users-<jurisdiction>-password
     SSCS = "idam-users-sscs"
     BULKSCAN = "idam-users-bulkscan"
+    DIVORCE = "idam-users-div"
   }
 
   all_jurisdictions     = "${keys(local.users)}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -26,6 +26,7 @@ locals {
     SSCS = "idam-users-sscs"
     BULKSCAN = "idam-users-bulkscan"
     DIVORCE = "idam-users-div"
+    PROBATE = "idam-users-probate"
   }
 
   all_jurisdictions     = "${keys(local.users)}"


### PR DESCRIPTION
### Change description ###

Enable Divorce jurisdiction in AAT. After this change, the orchestrator will be able to map Divorce jurisdiction to the right Idam credentials when talking to CCD.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
