### PR TITLE
Read OCR data from the queue

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -73,7 +73,9 @@ public class ScannedDocumentsHelper {
             scannedDocument.controlNumber,
             scannedDocument.type,
             scannedDocument.scannedDate.toInstant(ZoneOffset.UTC),
-            scannedDocument.url.documentUrl
+            scannedDocument.url.documentUrl,
+            // TODO: set ocr data
+            null
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Document.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.Instant;
+import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Document {
@@ -13,6 +14,7 @@ public class Document {
     public final String type;
     public final Instant scannedAt;
     public final String url;
+    public final Map<String, String> ocrData;
 
     // region constructor
     public Document(
@@ -20,13 +22,15 @@ public class Document {
         @JsonProperty(value = "control_number", required = true) String controlNumber,
         @JsonProperty(value = "type", required = true) String type,
         @JsonProperty(value = "scanned_at", required = true) Instant scannedAt,
-        @JsonProperty(value = "url", required = true) String url
+        @JsonProperty(value = "url", required = true) String url,
+        @JsonProperty(value = "ocr_data") Map<String, String> ocrData
     ) {
         this.fileName = fileName;
         this.controlNumber = controlNumber;
         this.type = type;
         this.scannedAt = scannedAt;
         this.url = url;
+        this.ocrData = ocrData;
     }
     // endregion
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -139,7 +140,8 @@ public class SampleData {
                     String.format("control_number_%s", index),
                     String.format("type_%s", index),
                     LocalDate.parse("2018-10-01").plus(index, DAYS).atStartOfDay().toInstant(ZoneOffset.UTC),
-                    String.format("https://example.gov.uk/%s", index)
+                    String.format("https://example.gov.uk/%s", index),
+                    ImmutableMap.of("key_" + index, "value_" + index)
                 )
             ).limit(numberOfDocuments)
             .collect(Collectors.toList());

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/EnvelopeParserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/EnvelopeParserTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus;
 
+import com.google.common.collect.ImmutableMap;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -38,14 +39,16 @@ public class EnvelopeParserTest {
                     "doc1_control_number",
                     "doc1_type",
                     Instant.now(),
-                    "doc1_url"
+                    "doc1_url",
+                    ImmutableMap.of("key1", "value1")
                 ),
                 new Document(
                     "doc2_file_name",
                     "doc2_control_number",
                     "doc2_type",
                     Instant.now(),
-                    "doc2_url"
+                    "doc2_url",
+                    null
                 )
             )
         );
@@ -178,6 +181,7 @@ public class EnvelopeParserTest {
             .put("control_number", doc.controlNumber)
             .put("type", doc.type)
             .put("scanned_at", toIso8601(doc.scannedAt))
-            .put("url", doc.url);
+            .put("url", doc.url)
+            .put("ocr_data", doc.ocrData != null ? new JSONObject(doc.ocrData) : null);
     }
 }

--- a/src/test/resources/envelopes/example.json
+++ b/src/test/resources/envelopes/example.json
@@ -13,7 +13,10 @@
       "control_number": "control_number",
       "type": "doc_type",
       "scanned_at": "1970-01-01T00:00:00.000Z",
-      "url": "https://example.gov.uk/123"
+      "url": "https://example.gov.uk/123",
+      "ocr_data": {
+        "key1": "value1"
+      }
     }
   ]
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-247

### Change description ###

Include OCR data in the Document class that represents documents in queue messages. This is just a part of the solution. In future PRs this data will be sent to CCD.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
