### PR TITLE
Extract ScannedDocumentsExtractor from ScannedDocumentsHelper

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getScannedDocuments;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsExtractor.getScannedDocuments;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
@@ -18,7 +18,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.dm.DocumentManagementUploadService;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.helper.CcdCaseCreator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.helper.EnvelopeMessager;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.EnvelopeParser;
@@ -31,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getScannedDocuments;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsExtractor.getScannedDocuments;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -144,9 +143,9 @@ public class SupplementaryEvidenceTest {
         );
 
         Envelope updatedEnvelope = EnvelopeParser.parse(updatedCaseData.toString());
-        List<ScannedDocument> scannedDocumentList = ScannedDocumentsHelper.getScannedDocuments(newEnvelope);
+        List<ScannedDocument> scannedDocumentList = getScannedDocuments(newEnvelope);
 
-        List<ScannedDocument> scannedDocumentList2 = ScannedDocumentsHelper.getScannedDocuments(updatedEnvelope);
+        List<ScannedDocument> scannedDocumentList2 = getScannedDocuments(updatedEnvelope);
         if (!scannedDocumentList2.isEmpty()) {
             scannedDocumentList.addAll(scannedDocumentList2);
         }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsExtractor.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsExtractor.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
+
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+
+public class ScannedDocumentsExtractor {
+
+    private ScannedDocumentsExtractor() {
+        // utility class
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<ScannedDocument> getScannedDocuments(CaseDetails caseDetails) {
+        List<Map<String, Object>> data = (List<Map<String, Object>>) caseDetails.getData().get("scannedDocuments");
+
+        return data.stream().map(ScannedDocumentsHelper::createScannedDocumentWithCcdData).collect(toList());
+    }
+
+    public static List<ScannedDocument> getScannedDocuments(Envelope envelope) {
+        List<Document> documents = envelope.documents;
+        return documents.stream().map(ScannedDocumentsExtractor::mapDocument).collect(toList());
+    }
+
+    private static ScannedDocument mapDocument(Document document) {
+        return new ScannedDocument(
+            document.fileName,
+            document.controlNumber,
+            document.type,
+            document.scannedAt.atZone(ZoneId.systemDefault()).toLocalDateTime(),
+            new CcdDocument(String.valueOf(document.url)),
+            null
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -3,13 +3,10 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
@@ -31,18 +28,6 @@ public class ScannedDocumentsHelper {
     }
 
     @SuppressWarnings("unchecked")
-    public static List<ScannedDocument> getScannedDocuments(CaseDetails caseDetails) {
-        List<Map<String, Object>> data = (List<Map<String, Object>>) caseDetails.getData().get("scannedDocuments");
-
-        return data.stream().map(ScannedDocumentsHelper::createScannedDocumentWithCcdData).collect(toList());
-    }
-
-    public static List<ScannedDocument> getScannedDocuments(Envelope envelope) {
-        List<Document> documents = envelope.documents;
-        return documents.stream().map(ScannedDocumentsHelper::mapDocument).collect(toList());
-    }
-
-    @SuppressWarnings("unchecked")
     public static List<Document> getDocuments(CaseDetails caseDetails) {
         List<Map<String, Object>> data = (List<Map<String, Object>>) caseDetails.getData().get("scannedDocuments");
 
@@ -52,19 +37,8 @@ public class ScannedDocumentsHelper {
             .collect(toList());
     }
 
-    private static ScannedDocument createScannedDocumentWithCcdData(Map<String, Object> object) {
+    static ScannedDocument createScannedDocumentWithCcdData(Map<String, Object> object) {
         return objectMapper.convertValue(object.get("value"), ScannedDocument.class);
-    }
-
-    private static ScannedDocument mapDocument(Document document) {
-        return new ScannedDocument(
-            document.fileName,
-            document.controlNumber,
-            document.type,
-            document.scannedAt.atZone(ZoneId.systemDefault()).toLocalDateTime(),
-            new CcdDocument(String.valueOf(document.url)),
-            null
-        );
     }
 
     private static Document mapScannedDocument(ScannedDocument scannedDocument) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.fileContentAsBytes;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.objectMapper;
+
+public class ScannedDocumentsHelperTest {
+
+    @Test
+    public void getDocuments_should_extract_all_documents() throws Exception {
+        CaseDetails caseDetails = getCaseDetails("case-data/multiple-scanned-docs.json");
+
+        List<Document> documents = ScannedDocumentsHelper.getDocuments(caseDetails);
+
+        assertThat(documents)
+            .extracting("controlNumber")
+            .containsExactlyInAnyOrder("1000", "2000", "3000");
+    }
+
+    @Test
+    public void getDocuments_should_map_document_properties_correctly() throws Exception {
+        CaseDetails caseDetails = getCaseDetails("case-data/single-scanned-doc.json");
+
+        List<Document> documents = ScannedDocumentsHelper.getDocuments(caseDetails);
+
+        assertThat(documents.size()).isOne();
+        Document document = documents.get(0);
+
+        Document expectedDocument = new Document(
+            "filename1.pdf",
+            "1111001",
+            "Other",
+            Instant.parse("2018-12-01T12:34:56.123Z"),
+            "https://doc-url-1.example.com",
+            null
+        );
+
+        assertThat(document).isEqualToComparingFieldByField(expectedDocument);
+    }
+
+    private CaseDetails getCaseDetails(String resourceName) throws IOException {
+        return objectMapper.readValue(fileContentAsBytes(resourceName), CaseDetails.class);
+    }
+}

--- a/src/test/resources/case-data/multiple-scanned-docs.json
+++ b/src/test/resources/case-data/multiple-scanned-docs.json
@@ -1,0 +1,49 @@
+{
+  "case_data": {
+    "scannedDocuments": [
+      {
+        "value": {
+          "fileName": "filename1.pdf",
+          "controlNumber": "1000",
+          "type": "Other",
+          "scannedDate": "2018-12-01T12:34:56.123Z",
+          "url": {
+            "document_url": "https://doc-url-1.example.com"
+          },
+          "scanOCRData": [
+            {
+              "key": "field1",
+              "value": "value1"
+            },
+            {
+              "key": "field2",
+              "value": "value2"
+            }
+          ]
+        }
+      },
+      {
+        "value": {
+          "fileName": "filename2.pdf",
+          "controlNumber": "2000",
+          "type": "Cherished",
+          "scannedDate": "2018-12-02T12:34:56.123Z",
+          "url": {
+            "document_url": "https://doc-url-2.example.com"
+          }
+        }
+      },
+      {
+        "value": {
+          "fileName": "filename3.pdf",
+          "controlNumber": "3000",
+          "type": "Other",
+          "scannedDate": "2018-12-03T12:34:56.123Z",
+          "url": {
+            "document_url": "https://doc-url-3.example.com"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/test/resources/case-data/single-scanned-doc.json
+++ b/src/test/resources/case-data/single-scanned-doc.json
@@ -1,0 +1,27 @@
+{
+  "case_data": {
+    "scannedDocuments": [
+      {
+        "value": {
+          "fileName": "filename1.pdf",
+          "controlNumber": "1111001",
+          "type": "Other",
+          "scannedDate": "2018-12-01T12:34:56.123Z",
+          "url": {
+            "document_url": "https://doc-url-1.example.com"
+          },
+          "scanOCRData": [
+            {
+              "key": "field1",
+              "value": "value1"
+            },
+            {
+              "key": "field2",
+              "value": "value2"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Change description ###

Extract `ScannedDocumentsExtractor` from `ScannedDocumentsHelper`, leaving in ScannedDocumentsHelper only those methods that are used in the application and not just tests. `ScannedDocumentsExtractor` is strictly a test utility class.

Also, created some unit tests for what remained of ScannedDocumentsHelper.

This is a part of a bigger change - more methods will be added to ScannedDocumentsHelper in coming PRs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
