### PR TITLE
BPS-403 Prefix jurisdiction to the Exception Record case type id

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
@@ -151,7 +151,7 @@ public class AttachExceptionRecordToExistingCaseTest {
     private Optional<CaseDetails> lookUpExceptionRecord(UUID randomPoBox) {
         List<CaseDetails> caseDetailsList = caseSearcher.search(
             SampleData.JURSIDICTION,
-            DelegatePublisher.EXCEPTION_RECORD_CASE_TYPE,
+            SampleData.JURSIDICTION + "_" + DelegatePublisher.EXCEPTION_RECORD_CASE_TYPE,
             ImmutableMap.of(
                 "case.poBox", randomPoBox.toString()
             )

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
@@ -74,7 +74,7 @@ public class ExceptionRecordCreationTest {
     private boolean hasExceptionRecordBeenCreated(UUID randomPoBox) {
         List<CaseDetails> caseDetails = caseSearcher.search(
             SampleData.JURSIDICTION,
-            DelegatePublisher.EXCEPTION_RECORD_CASE_TYPE,
+            SampleData.JURSIDICTION + "_" + DelegatePublisher.EXCEPTION_RECORD_CASE_TYPE,
             ImmutableMap.of(
                 "case.poBox", randomPoBox.toString()
             )

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/config/Environment.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/config/Environment.kt
@@ -8,7 +8,7 @@ object Environment {
     val USER_ID = "640"
     val JURIDICTION = "BULKSCAN"
     const val CASE_TYPE_BULK_SCAN = "Bulk_Scanned"
-    const val CASE_TYPE_EXCEPTION_RECORD = "ExceptionRecord"
+    const val CASE_TYPE_EXCEPTION_RECORD = "BULKSCAN_ExceptionRecord"
     val CASE_REF = "1539007368674134"
 
     private val caseTypeUrl = "/caseworkers/$USER_ID/jurisdictions/$JURIDICTION/case-types/$CASE_TYPE_BULK_SCAN"

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -19,7 +19,7 @@ class CreateExceptionRecord extends AbstractEventPublisher {
 
     @Override
     public void publish(Envelope envelope) {
-        publish(envelope, CASE_TYPE);
+        publish(envelope, envelope.jurisdiction + "_" + CASE_TYPE);
     }
 
     /**

--- a/src/test/resources/mappings/caseworkers_640_jurisdictions_bulkscan_case-types_bulk_scanned_cases_1539007368674134_exception_record-5e24bd28-34a3-4a7c-a78e-359b9dcc7254.json
+++ b/src/test/resources/mappings/caseworkers_640_jurisdictions_bulkscan_case-types_bulk_scanned_cases_1539007368674134_exception_record-5e24bd28-34a3-4a7c-a78e-359b9dcc7254.json
@@ -2,7 +2,7 @@
   "id" : "5e24bd28-34a3-4a7c-a78e-359b9dcc7254",
   "name" : "caseworkers_640_jurisdictions_bulkscan_case-types_bulk_scanned_cases_1539007368674134_events",
   "request" : {
-    "url" : "/caseworkers/640/jurisdictions/BULKSCAN/case-types/ExceptionRecord/cases?ignore-warning=true",
+    "url" : "/caseworkers/640/jurisdictions/BULKSCAN/case-types/BULKSCAN_ExceptionRecord/cases?ignore-warning=true",
     "method" : "POST",
     "bodyPatterns": [
       {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-403


### Change description ###
When creating an exception record, prefix jurisdiction to the case type id.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
