### PR TITLE
Remove unnecessary overrides of equals and hashCode

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/CcdDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/CcdDocument.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Objects;
-
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CcdDocument {
 
@@ -13,22 +11,5 @@ public class CcdDocument {
 
     public CcdDocument(@JsonProperty("document_url") String documentUrl) {
         this.documentUrl = documentUrl;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(documentUrl);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        CcdDocument that = (CcdDocument) o;
-        return Objects.equals(documentUrl, that.documentUrl);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ScannedDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ScannedDocument.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -32,26 +31,5 @@ public class ScannedDocument {
         this.scannedDate = scannedDate;
         this.url = url;
         this.exceptionReference = exceptionReference;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ScannedDocument that = (ScannedDocument) o;
-        return Objects.equals(fileName, that.fileName)
-            && Objects.equals(controlNumber, that.controlNumber)
-            && Objects.equals(type, that.type)
-            && Objects.equals(scannedDate, that.scannedDate)
-            && Objects.equals(url, that.url);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(fileName, controlNumber, type, scannedDate, url);
     }
 }


### PR DESCRIPTION
### Change description ###

Remove unnecessary overrides of equals and hashCode. Doesn't look like they're needed for anything. No test failed after removing them.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
