### PR TITLE
Include OCR data in CCD data

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsExtractor.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsExtractor.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envel
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +36,7 @@ public class ScannedDocumentsExtractor {
             document.fileName,
             document.controlNumber,
             document.type,
-            document.scannedAt.atZone(ZoneId.systemDefault()).toLocalDateTime(),
+            ZonedDateTime.ofInstant(document.scannedAt, ZoneId.systemDefault()).toLocalDateTime(),
             new CcdDocument(String.valueOf(document.url)),
             null
         );

--- a/src/integrationTest/resources/servicebus/message/exception-example.json
+++ b/src/integrationTest/resources/servicebus/message/exception-example.json
@@ -15,5 +15,9 @@
       "scanned_at": "2018-01-01T12:34:56.123Z",
       "url": "http://test-url"
     }
-  ]
+  ],
+  "ocr_data": {
+    "field1": "value1",
+    "field2": "value2"
+  }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -7,7 +7,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
@@ -46,7 +46,7 @@ public class ScannedDocumentsHelper {
             scannedDocument.fileName,
             scannedDocument.controlNumber,
             scannedDocument.type,
-            scannedDocument.scannedDate.toInstant(ZoneOffset.UTC),
+            scannedDocument.scannedDate.atZone(ZoneId.systemDefault()).toInstant(),
             scannedDocument.url.documentUrl
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -47,9 +47,7 @@ public class ScannedDocumentsHelper {
             scannedDocument.controlNumber,
             scannedDocument.type,
             scannedDocument.scannedDate.toInstant(ZoneOffset.UTC),
-            scannedDocument.url.documentUrl,
-            // TODO: set ocr data
-            null
+            scannedDocument.url.documentUrl
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/CcdKeyValue.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/CcdKeyValue.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CcdKeyValue {
+
+    public final String key;
+    public final String value;
+
+    public CcdKeyValue(@JsonProperty("key") String key, @JsonProperty("value") String value) {
+        this.key = key;
+        this.value = value;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/CcdKeyValue.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/CcdKeyValue.java
@@ -1,13 +1,11 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class CcdKeyValue {
 
     public final String key;
     public final String value;
 
-    public CcdKeyValue(@JsonProperty("key") String key, @JsonProperty("value") String value) {
+    public CcdKeyValue(String key, String value) {
         this.key = key;
         this.value = value;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
@@ -21,13 +21,17 @@ public class ExceptionRecord implements CaseData {
 
     public final List<CcdCollectionElement<ScannedDocument>> scannedDocuments;
 
+    @JsonProperty("scanOCRData")
+    public final List<CcdCollectionElement<CcdKeyValue>> ocrData;
+
     public ExceptionRecord(
         String classification,
         String poBox,
         String jurisdiction,
         LocalDateTime deliveryDate,
         LocalDateTime openingDate,
-        List<CcdCollectionElement<ScannedDocument>> scannedDocuments
+        List<CcdCollectionElement<ScannedDocument>> scannedDocuments,
+        List<CcdCollectionElement<CcdKeyValue>> ocrData
     ) {
         this.classification = classification;
         this.poBox = poBox;
@@ -35,5 +39,6 @@ public class ExceptionRecord implements CaseData {
         this.deliveryDate = deliveryDate;
         this.openingDate = openingDate;
         this.scannedDocuments = scannedDocuments;
+        this.ocrData = ocrData;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 import java.util.List;
+import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
 
@@ -26,21 +27,18 @@ public class ExceptionRecordMapper extends ModelMapper<ExceptionRecord> {
             getLocalDateTime(envelope.deliveryDate),
             getLocalDateTime(envelope.openingDate),
             mapDocuments(envelope.documents),
-            mapOcrData(envelope)
+            mapOcrData(envelope.ocrData)
         );
     }
 
-    private List<CcdCollectionElement<CcdKeyValue>> mapOcrData(Envelope envelope) {
-        if (envelope.ocrData != null) {
-            return envelope
-                .ocrData
+    private List<CcdCollectionElement<CcdKeyValue>> mapOcrData(Map<String, String> ocrData) {
+        if (ocrData != null) {
+            return ocrData
                 .entrySet()
                 .stream()
-                .map(entry ->
-                    new CcdCollectionElement<>(
-                        new CcdKeyValue(entry.getKey(), entry.getValue())
-                    )
-                ).collect(toList());
+                .map(entry -> new CcdKeyValue(entry.getKey(), entry.getValue()))
+                .map(CcdCollectionElement::new)
+                .collect(toList());
         } else {
             return null;
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -1,8 +1,14 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers;
 
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdCollectionElement;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdKeyValue;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 @Component
 public class ExceptionRecordMapper extends ModelMapper<ExceptionRecord> {
@@ -19,7 +25,24 @@ public class ExceptionRecordMapper extends ModelMapper<ExceptionRecord> {
             envelope.jurisdiction,
             getLocalDateTime(envelope.deliveryDate),
             getLocalDateTime(envelope.openingDate),
-            mapDocuments(envelope.documents)
+            mapDocuments(envelope.documents),
+            mapOcrData(envelope)
         );
+    }
+
+    private List<CcdCollectionElement<CcdKeyValue>> mapOcrData(Envelope envelope) {
+        if (envelope.ocrData != null) {
+            return envelope
+                .ocrData
+                .entrySet()
+                .stream()
+                .map(entry ->
+                    new CcdCollectionElement<>(
+                        new CcdKeyValue(entry.getKey(), entry.getValue())
+                    )
+                ).collect(toList());
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ModelMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ModelMapper.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envel
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,6 @@ public abstract class ModelMapper<T extends CaseData> {
     }
 
     LocalDateTime getLocalDateTime(Instant instant) {
-        return instant.atZone(ZoneId.systemDefault()).toLocalDateTime();
+        return ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()).toLocalDateTime();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Document.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.Instant;
-import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Document {
@@ -14,7 +13,6 @@ public class Document {
     public final String type;
     public final Instant scannedAt;
     public final String url;
-    public final Map<String, String> ocrData;
 
     // region constructor
     public Document(
@@ -22,15 +20,13 @@ public class Document {
         @JsonProperty(value = "control_number", required = true) String controlNumber,
         @JsonProperty(value = "type", required = true) String type,
         @JsonProperty(value = "scanned_at", required = true) Instant scannedAt,
-        @JsonProperty(value = "url", required = true) String url,
-        @JsonProperty(value = "ocr_data") Map<String, String> ocrData
+        @JsonProperty(value = "url", required = true) String url
     ) {
         this.fileName = fileName;
         this.controlNumber = controlNumber;
         this.type = type;
         this.scannedAt = scannedAt;
         this.url = url;
-        this.ocrData = ocrData;
     }
     // endregion
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Envelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Envelope.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Envelope {
@@ -18,6 +19,7 @@ public class Envelope {
     public final Instant openingDate;
     public final Classification classification;
     public final List<Document> documents;
+    public final Map<String, String> ocrData;
 
     public Envelope(
         @JsonProperty(value = "id", required = true) String id,
@@ -28,7 +30,8 @@ public class Envelope {
         @JsonProperty(value = "delivery_date", required = true) Instant deliveryDate,
         @JsonProperty(value = "opening_date", required = true) Instant openingDate,
         @JsonProperty(value = "classification", required = true) Classification classification,
-        @JsonProperty(value = "documents", required = true) List<Document> documents
+        @JsonProperty(value = "documents", required = true) List<Document> documents,
+        @JsonProperty(value = "ocr_data") Map<String, String> ocrData
     ) {
         this.id = id;
         this.caseRef = caseRef;
@@ -39,6 +42,7 @@ public class Envelope {
         this.openingDate = openingDate;
         this.classification = classification;
         this.documents = documents;
+        this.ocrData = ocrData;
     }
 
     public void addDocuments(List<Document> documents) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/DatetimeHelper.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/DatetimeHelper.java
@@ -10,7 +10,7 @@ public class DatetimeHelper {
 
     public static String toIso8601(Instant instant) {
         return ZonedDateTime
-            .ofInstant(instant, ZoneId.of("UTC"))
+            .ofInstant(instant, ZoneId.systemDefault())
             .format(ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -128,7 +128,8 @@ public class SampleData {
             Instant.now(),
             Instant.now(),
             Classification.NEW_APPLICATION,
-            documents(numberOfDocuments)
+            documents(numberOfDocuments),
+            ImmutableMap.of("key1", "value1")
         );
     }
 
@@ -140,8 +141,7 @@ public class SampleData {
                     String.format("control_number_%s", index),
                     String.format("type_%s", index),
                     LocalDate.parse("2018-10-01").plus(index, DAYS).atStartOfDay().toInstant(ZoneOffset.UTC),
-                    String.format("https://example.gov.uk/%s", index),
-                    ImmutableMap.of("key_" + index, "value_" + index)
+                    String.format("https://example.gov.uk/%s", index)
                 )
             ).limit(numberOfDocuments)
             .collect(Collectors.toList());

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -18,8 +18,7 @@ import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -140,7 +139,7 @@ public class SampleData {
                     String.format("file_%s.pdf", index),
                     String.format("control_number_%s", index),
                     String.format("type_%s", index),
-                    LocalDate.parse("2018-10-01").plus(index, DAYS).atStartOfDay().toInstant(ZoneOffset.UTC),
+                    ZonedDateTime.parse("2018-10-01T00:00:00Z").plus(index, DAYS).toInstant(),
                     String.format("https://example.gov.uk/%s", index)
                 )
             ).limit(numberOfDocuments)

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -118,6 +119,10 @@ public class SampleData {
     }
 
     public static Envelope envelope(int numberOfDocuments) {
+        return envelope(numberOfDocuments, ImmutableMap.of("fieldName1", "value1"));
+    }
+
+    public static Envelope envelope(int numberOfDocuments, Map<String, String> ocrData) {
         return new Envelope(
             "eb9c3598-35fc-424e-b05a-902ee9f11d56",
             CASE_REF,
@@ -128,7 +133,7 @@ public class SampleData {
             Instant.now(),
             Classification.NEW_APPLICATION,
             documents(numberOfDocuments),
-            ImmutableMap.of("key1", "value1")
+            ocrData
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
@@ -39,8 +39,7 @@ public class ScannedDocumentsHelperTest {
             "1111001",
             "Other",
             Instant.parse("2018-12-01T12:34:56.123Z"),
-            "https://doc-url-1.example.com",
-            null
+            "https://doc-url-1.example.com"
         );
 
         assertThat(document).isEqualToComparingFieldByField(expectedDocument);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdCollectionElement;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdKeyValue;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelope;
+
+public class ExceptionRecordMapperTest {
+
+    private final ExceptionRecordMapper mapper = new ExceptionRecordMapper();
+
+    @Test
+    public void mapEnvelope_maps_all_fields_correctly() {
+        // given
+        Envelope envelope = envelope(2);
+
+        // when
+        ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
+
+        // then
+        assertThat(exceptionRecord.classification).isEqualTo(envelope.classification.name());
+        assertThat(exceptionRecord.deliveryDate).isEqualTo(
+            LocalDateTime.ofInstant(envelope.deliveryDate, ZoneId.systemDefault())
+        );
+
+        assertThat(exceptionRecord.jurisdiction).isEqualTo(envelope.jurisdiction);
+
+        assertThat(exceptionRecord.openingDate).isEqualTo(
+            LocalDateTime.ofInstant(envelope.openingDate, ZoneId.systemDefault())
+        );
+
+        assertThat(exceptionRecord.poBox).isEqualTo(envelope.poBox);
+        assertThat(exceptionRecord.scannedDocuments.size()).isEqualTo(envelope.documents.size());
+
+        assertThat(toEnvelopeDocuments(exceptionRecord.scannedDocuments))
+            .usingFieldByFieldElementComparator()
+            .containsAll(envelope.documents);
+
+        assertThat(ocrDataAsMap(exceptionRecord.ocrData)).isEqualTo(envelope.ocrData);
+    }
+
+    @Test
+    public void mapEnvelope_handles_null_ocr_data() {
+        Envelope envelope = envelope(2, null);
+        ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
+        assertThat(exceptionRecord.ocrData).isNull();
+    }
+
+    private Map<String, String> ocrDataAsMap(List<CcdCollectionElement<CcdKeyValue>> ocrData) {
+        return ocrData
+            .stream()
+            .map(element -> element.value)
+            .collect(
+                toMap(kv -> kv.key, kv -> kv.value)
+            );
+    }
+
+    private List<Document> toEnvelopeDocuments(List<CcdCollectionElement<ScannedDocument>> ccdDocuments) {
+        return ccdDocuments
+            .stream()
+            .map(e -> e.value)
+            .map(scannedDocument ->
+                new Document(
+                    scannedDocument.fileName,
+                    scannedDocument.controlNumber,
+                    scannedDocument.type,
+                    scannedDocument.scannedDate.atZone(ZoneId.systemDefault()).toInstant(),
+                    scannedDocument.url.documentUrl
+                )
+            ).collect(toList());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/EnvelopeParserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/EnvelopeParserTest.java
@@ -39,18 +39,17 @@ public class EnvelopeParserTest {
                     "doc1_control_number",
                     "doc1_type",
                     Instant.now(),
-                    "doc1_url",
-                    ImmutableMap.of("key1", "value1")
+                    "doc1_url"
                 ),
                 new Document(
                     "doc2_file_name",
                     "doc2_control_number",
                     "doc2_type",
                     Instant.now(),
-                    "doc2_url",
-                    null
+                    "doc2_url"
                 )
-            )
+            ),
+            ImmutableMap.of("key1", "value1")
         );
     }
 
@@ -71,6 +70,7 @@ public class EnvelopeParserTest {
                     .put(toJson(envelope.documents.get(0)))
                     .put(toJson(envelope.documents.get(1)))
                 )
+                .put("ocr_data", new JSONObject(envelope.ocrData))
                 .toString();
 
         // when
@@ -98,6 +98,7 @@ public class EnvelopeParserTest {
                     .put(toJson(envelope.documents.get(1)))
                 )
                 .put("some_extra_ignored_field", "some_ignored_value")
+                .put("ocr_data", envelope.ocrData != null ? new JSONObject(envelope.ocrData) : null)
                 .toString();
 
         // when
@@ -181,7 +182,6 @@ public class EnvelopeParserTest {
             .put("control_number", doc.controlNumber)
             .put("type", doc.type)
             .put("scanned_at", toIso8601(doc.scannedAt))
-            .put("url", doc.url)
-            .put("ocr_data", doc.ocrData != null ? new JSONObject(doc.ocrData) : null);
+            .put("url", doc.url);
     }
 }

--- a/src/test/resources/case-data/multiple-scanned-docs.json
+++ b/src/test/resources/case-data/multiple-scanned-docs.json
@@ -9,17 +9,7 @@
           "scannedDate": "2018-12-01T12:34:56.123Z",
           "url": {
             "document_url": "https://doc-url-1.example.com"
-          },
-          "scanOCRData": [
-            {
-              "key": "field1",
-              "value": "value1"
-            },
-            {
-              "key": "field2",
-              "value": "value2"
-            }
-          ]
+          }
         }
       },
       {

--- a/src/test/resources/case-data/single-scanned-doc.json
+++ b/src/test/resources/case-data/single-scanned-doc.json
@@ -9,17 +9,7 @@
           "scannedDate": "2018-12-01T12:34:56.123Z",
           "url": {
             "document_url": "https://doc-url-1.example.com"
-          },
-          "scanOCRData": [
-            {
-              "key": "field1",
-              "value": "value1"
-            },
-            {
-              "key": "field2",
-              "value": "value2"
-            }
-          ]
+          }
         }
       }
     ]

--- a/src/test/resources/envelopes/example.json
+++ b/src/test/resources/envelopes/example.json
@@ -13,10 +13,10 @@
       "control_number": "control_number",
       "type": "doc_type",
       "scanned_at": "1970-01-01T00:00:00.000Z",
-      "url": "https://example.gov.uk/123",
-      "ocr_data": {
-        "key1": "value1"
-      }
+      "url": "https://example.gov.uk/123"
     }
-  ]
+  ],
+  "ocr_data": {
+    "key1": "value1"
+  }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-247

### Change description ###

- Include OCR data in CCD data. This involves moving OCR data from document to envelope, as that's how the processor is going to send it (https://github.com/hmcts/bulk-scan-processor/pull/323)
- Use system-default time zone when processing DateTimes. It was inconsistent and new tests failed because of it.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
