### PR TITLE
BPS-400 Handle NullPointerException when scanned documents are null in ccd case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -3,12 +3,12 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.springframework.util.Assert;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -30,12 +30,12 @@ public class ScannedDocumentsHelper {
 
     @SuppressWarnings("unchecked")
     public static List<Document> getDocuments(CaseDetails caseDetails) {
-        Map<String, Object> caseData = caseDetails.getData();
-        Assert.notNull(caseData, "Case Data must not be null");
+        List<Map<String, Object>> scannedDocuments =
+            (List<Map<String, Object>>) caseDetails.getData().get("scannedDocuments");
 
-        List<Map<String, Object>> scannedDocuments = (List<Map<String, Object>>) caseData.get("scannedDocuments");
-        // ccd returns an empty list when scanned documents are not present.
-        Assert.notNull(scannedDocuments, "Scanned Documents must not be null");
+        if (scannedDocuments == null) {
+            return Collections.emptyList();
+        }
 
         return scannedDocuments.stream()
             .map(ScannedDocumentsHelper::createScannedDocumentWithCcdData)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.util.Assert;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -29,9 +30,14 @@ public class ScannedDocumentsHelper {
 
     @SuppressWarnings("unchecked")
     public static List<Document> getDocuments(CaseDetails caseDetails) {
-        List<Map<String, Object>> data = (List<Map<String, Object>>) caseDetails.getData().get("scannedDocuments");
+        Map<String, Object> caseData = caseDetails.getData();
+        Assert.notNull(caseData, "Case Data must not be null");
 
-        return data.stream()
+        List<Map<String, Object>> scannedDocuments = (List<Map<String, Object>>) caseData.get("scannedDocuments");
+        // ccd returns an empty list when scanned documents are not present.
+        Assert.notNull(scannedDocuments, "Scanned Documents must not be null");
+
+        return scannedDocuments.stream()
             .map(ScannedDocumentsHelper::createScannedDocumentWithCcdData)
             .map(ScannedDocumentsHelper::mapScannedDocument)
             .collect(toList());

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
 
-import org.json.JSONObject;
 import org.junit.Test;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -10,7 +9,6 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.fileContentAsBytes;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.objectMapper;
 
@@ -28,28 +26,13 @@ public class ScannedDocumentsHelperTest {
     }
 
     @Test
-    public void getDocuments_should_throw_exception_when_scannedDocuments_are_missing()
+    public void getDocuments_should_return_empty_collection_when_scannedDocuments_are_missing()
         throws Exception {
         CaseDetails caseDetails = getCaseDetails("case-data/missing-scanned-documents.json");
 
-        Throwable throwable = catchThrowable(() -> ScannedDocumentsHelper.getDocuments(caseDetails));
+        List<Document> documents = ScannedDocumentsHelper.getDocuments(caseDetails);
 
-        assertThat(throwable)
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Scanned Documents must not be null");
-    }
-
-    @Test
-    public void getDocuments_should_throws_exception_when_caseData_is_missing()
-        throws IOException {
-        JSONObject emptyCase = new JSONObject();
-        CaseDetails caseDetails = objectMapper.readValue(emptyCase.toString().getBytes(), CaseDetails.class);
-
-        Throwable throwable = catchThrowable(() -> ScannedDocumentsHelper.getDocuments(caseDetails));
-
-        assertThat(throwable)
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Case Data must not be null");
+        assertThat(documents).isEmpty();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
 
+import org.json.JSONObject;
 import org.junit.Test;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -9,6 +10,7 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.fileContentAsBytes;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.objectMapper;
 
@@ -23,6 +25,31 @@ public class ScannedDocumentsHelperTest {
         assertThat(documents)
             .extracting("controlNumber")
             .containsExactlyInAnyOrder("1000", "2000", "3000");
+    }
+
+    @Test
+    public void getDocuments_should_throw_exception_when_scannedDocuments_are_missing()
+        throws Exception {
+        CaseDetails caseDetails = getCaseDetails("case-data/missing-scanned-documents.json");
+
+        Throwable throwable = catchThrowable(() -> ScannedDocumentsHelper.getDocuments(caseDetails));
+
+        assertThat(throwable)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Scanned Documents must not be null");
+    }
+
+    @Test
+    public void getDocuments_should_throws_exception_when_caseData_is_missing()
+        throws IOException {
+        JSONObject emptyCase = new JSONObject();
+        CaseDetails caseDetails = objectMapper.readValue(emptyCase.toString().getBytes(), CaseDetails.class);
+
+        Throwable throwable = catchThrowable(() -> ScannedDocumentsHelper.getDocuments(caseDetails));
+
+        assertThat(throwable)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Case Data must not be null");
     }
 
     @Test

--- a/src/test/resources/case-data/missing-scanned-documents.json
+++ b/src/test/resources/case-data/missing-scanned-documents.json
@@ -1,0 +1,8 @@
+{
+  "case_data": {
+    "id": "0192",
+    "case_ref": "",
+    "po_box": "BULKSCAN PO BOX",
+    "jurisdiction": "BULKSCAN"
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-400

### Change description ###
Added assertions to check ccd data and scanned documents are not null


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
