### PR TITLE
Make sure OCR data is parsed and mapped to CCD object as received

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Envelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Envelope.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.util.OcrDataDeserialiser;
 
 import java.time.Instant;
 import java.util.List;
@@ -31,6 +33,7 @@ public class Envelope {
         @JsonProperty(value = "opening_date", required = true) Instant openingDate,
         @JsonProperty(value = "classification", required = true) Classification classification,
         @JsonProperty(value = "documents", required = true) List<Document> documents,
+        @JsonDeserialize(using = OcrDataDeserialiser.class)
         @JsonProperty(value = "ocr_data") Map<String, String> ocrData
     ) {
         this.id = id;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/util/OcrDataDeserialiser.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/util/OcrDataDeserialiser.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class OcrDataDeserialiser extends StdDeserializer<Map<String, String>> {
+
+    protected OcrDataDeserialiser() {
+        super(LinkedHashMap.class);
+    }
+
+    @Override
+    public Map<String, String> deserialize(
+        JsonParser p,
+        DeserializationContext ctxt
+    ) throws IOException, JsonProcessingException {
+        JsonNode node = p.readValueAsTree();
+
+        Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+        Map<String, String> ocrData = new LinkedHashMap<>();
+
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> entry = fields.next();
+            ocrData.put(entry.getKey(), entry.getValue().asText());
+        }
+
+        return ocrData;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/feature/OcrDataOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/feature/OcrDataOrderTest.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.feature;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.helper.CcdCollectionElementComparator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdCollectionElement;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdKeyValue;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ExceptionRecordMapper;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.EnvelopeParser;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OcrDataOrderTest {
+
+    @DisplayName("Should parse incoming envelope with OCR data and map to same order in CCD record")
+    @Test
+    public void sameOrder() {
+        // given
+        byte[] envelopeMessage = SampleData.exampleJsonAsBytes();
+
+        // when
+        Envelope envelope = EnvelopeParser.parse(envelopeMessage);
+        assertThat(envelope.ocrData).isInstanceOf(LinkedHashMap.class);
+
+        // and
+        ExceptionRecordMapper mapper = new ExceptionRecordMapper();
+        ExceptionRecord record = mapper.mapEnvelope(envelope);
+        assertThat(record.ocrData).isInstanceOf(ArrayList.class);
+        assertThat(record.ocrData.size()).isEqualTo(envelope.ocrData.size());
+
+        // then
+        int i = 0;
+        Iterator<Map.Entry<String, String>> entries = envelope.ocrData.entrySet().iterator();
+
+        while (entries.hasNext()) {
+            Map.Entry<String, String> expectedEntry = entries.next();
+            assertThat(record.ocrData.get(i).value.key).isEqualTo(expectedEntry.getKey());
+            assertThat(record.ocrData.get(i).value.value).isEqualTo(expectedEntry.getValue());
+            i++;
+        }
+
+        // and (just for sanity/clearance)
+        assertThat(record.ocrData)
+            .usingElementComparator(new CcdCollectionElementComparator())
+            .containsExactly(
+                new CcdCollectionElement<>(new CcdKeyValue("text_field", "some text")),
+                new CcdCollectionElement<>(new CcdKeyValue("number_field", "123")),
+                new CcdCollectionElement<>(new CcdKeyValue("boolean_field", "true")),
+                new CcdCollectionElement<>(new CcdKeyValue("null_field", ""))
+            );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCollectionElementComparator.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCollectionElementComparator.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
+
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdCollectionElement;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdKeyValue;
+
+import java.util.Comparator;
+
+public class CcdCollectionElementComparator implements Comparator<CcdCollectionElement<CcdKeyValue>> {
+
+    @Override
+    public int compare(CcdCollectionElement<CcdKeyValue> o1, CcdCollectionElement<CcdKeyValue> o2) {
+        return o1.value.key.compareTo(o2.value.key) & o1.value.value.compareTo(o2.value.value);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/EnvelopeParserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/EnvelopeParserTest.java
@@ -49,7 +49,11 @@ public class EnvelopeParserTest {
                     "doc2_url"
                 )
             ),
-            ImmutableMap.of("key1", "value1")
+            ImmutableMap.of(
+                "key1", "value1",
+                "key2", "value2",
+                "key0", "value0"
+            )
         );
     }
 

--- a/src/test/resources/envelopes/example.json
+++ b/src/test/resources/envelopes/example.json
@@ -17,6 +17,9 @@
     }
   ],
   "ocr_data": {
-    "key1": "value1"
+    "text_field": "some text",
+    "number_field": 123,
+    "boolean_field": true,
+    "null_field": null
   }
 }


### PR DESCRIPTION
### Change description ###

No other interactions with ocr data found - just parsing from service bus and mapping to ccd collection items. Suggesting similar approach for deserialisation and additional check of java api: `Collector.toList` uses `ArrayList` so should be fine with element collection/addition

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
