### PR TITLE
BPS-411 Create Exception Record for invalid case reference

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
@@ -103,6 +103,28 @@ public class ExceptionRecordCreationTest {
         assertThat(getOcrData(caseDetails)).isEqualTo(expectedOcrData);
     }
 
+    @DisplayName("Should create ExceptionRecord when provided/requested case reference is invalid")
+    @Test
+    public void create_exception_record_for_invalid_case_reference()
+        throws JSONException, InterruptedException, ServiceBusException {
+        // given
+        UUID randomPoBox = UUID.randomUUID();
+
+        // when
+        envelopeMessager.sendMessageFromFile(
+            "envelopes/supplementary-evidence-envelope.json",
+            "1234",
+            randomPoBox,
+            dmUrl
+        );
+
+        // then
+        await("Exception record being created")
+            .atMost(60, TimeUnit.SECONDS)
+            .pollInterval(Duration.FIVE_SECONDS)
+            .until(() -> hasExceptionRecordBeenCreated(randomPoBox));
+    }
+
     private boolean hasExceptionRecordBeenCreated(UUID poBox) {
         return findCasesByPoBox(poBox).size() == 1;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetriever.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetriever.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Service
@@ -40,7 +41,9 @@ public class CaseRetriever {
         } catch (FeignException exception) {
             if (exception.status() == NOT_FOUND.value()) {
                 log.info("Case not found. Ref:{}, jurisdiction:{}", caseRef, jurisdiction);
-
+                return null;
+            } else if (exception.status() == BAD_REQUEST.value()) {
+                log.info("Invalid Case Ref:{}, jurisdiction:{}", caseRef, jurisdiction);
                 return null;
             } else {
                 throw exception;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrieverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrieverTest.java
@@ -66,6 +66,29 @@ public class CaseRetrieverTest {
         assertThat(theCase).isNull();
     }
 
+
+    @Test
+    public void should_return_null_for_when_the_case_ref_is_not_valid() {
+        retriever = new CaseRetriever(authenticator, dataApi);
+        FeignException exception = FeignException.errorStatus(
+            "methodKey",
+            Response
+                .builder()
+                .headers(Collections.emptyMap())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .reason("Invalid Case Ref")
+                .build()
+        );
+
+        given(dataApi.getCase(USER_TOKEN, SERVICE_TOKEN, CASE_REF))
+            .willThrow(exception);
+        given(authenticator.createForJurisdiction(JURSIDICTION)).willReturn(AUTH_DETAILS);
+
+        CaseDetails theCase = retriever.retrieve(JURSIDICTION, CASE_REF);
+
+        assertThat(theCase).isNull();
+    }
+
     @Test
     public void should_throw_exception_when_api_response_is_other_than_not_found_feign_exception() {
         retriever = new CaseRetriever(authenticator, dataApi);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-411


### Change description ###
Updated Case Retriever to return null when invalid case ref is provided. 
Added functional test to verify if exception record is created for invalid case ref.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
