### PR TITLE
BPS-413 Added logs to debug supplementary evidence functional tests failures

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
@@ -8,7 +8,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,7 +67,6 @@ public class SupplementaryEvidenceTest {
         randomPoBox = UUID.randomUUID();
     }
 
-    @Disabled
     @Test
     public void should_attach_supplementary_evidence_to_the_case_with_no_evidence_docs() throws Exception {
         //given
@@ -94,7 +92,6 @@ public class SupplementaryEvidenceTest {
         verifySupplementaryEvidenceDetailsUpdated(1);
     }
 
-    @Disabled
     @Test
     public void should_attach_supplementary_evidence_to_the_case_with_existing_evidence_docs() throws Exception {
         //given

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ModelMapper;
@@ -16,6 +18,8 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsH
 @Component
 class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
 
+    private static final Logger log = LoggerFactory.getLogger(AttachDocsToSupplementaryEvidence.class);
+
     private final ModelMapper<? extends CaseData> mapper;
 
     AttachDocsToSupplementaryEvidence(SupplementaryEvidenceMapper mapper) {
@@ -30,7 +34,10 @@ class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
     @Override
     public CaseDataContent buildCaseDataContent(StartEventResponse eventResponse, Envelope envelope) {
         List<Document> documents = getDocuments(eventResponse.getCaseDetails());
+        log.info("Case Id: {} Existing Documents Size: {}", eventResponse.getCaseDetails().getId(), documents.size());
+
         envelope.addDocuments(documents);
+        log.info("Documents Size after adding to envelope documents: {}", envelope.documents.size());
 
         return super.buildCaseDataContent(eventResponse, envelope);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ModelMapper;
@@ -18,8 +16,6 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsH
 @Component
 class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
 
-    private static final Logger log = LoggerFactory.getLogger(AttachDocsToSupplementaryEvidence.class);
-
     private final ModelMapper<? extends CaseData> mapper;
 
     AttachDocsToSupplementaryEvidence(SupplementaryEvidenceMapper mapper) {
@@ -34,10 +30,7 @@ class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
     @Override
     public CaseDataContent buildCaseDataContent(StartEventResponse eventResponse, Envelope envelope) {
         List<Document> documents = getDocuments(eventResponse.getCaseDetails());
-        log.info("Case Id: {} Existing Documents Size: {}", eventResponse.getCaseDetails().getId(), documents.size());
-
         envelope.addDocuments(documents);
-        log.info("Documents Size after adding to envelope documents: {}", envelope.documents.size());
 
         return super.buildCaseDataContent(eventResponse, envelope);
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-413


### Change description ###
Supplementary Evidence functional tests were disabled as they started failing.
Enabled the failing tests and added logs to debug them.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
