### PR TITLE
Prevent messages from being reprocessed immediately after failure

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
@@ -6,6 +6,9 @@ import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.IMessageOperations;
+
+import java.util.UUID;
 
 public class FunctionalQueueConfig {
 
@@ -18,5 +21,24 @@ public class FunctionalQueueConfig {
             new ConnectionStringBuilder(queueWriteConnectionString),
             ReceiveMode.PEEKLOCK
         );
+    }
+
+    @Bean
+    IMessageOperations testMessageOperations() {
+        return new IMessageOperations() {
+            @Override
+            public void complete(UUID lockToken) throws InterruptedException, ServiceBusException {
+                // do nothing
+            }
+
+            @Override
+            public void deadLetter(
+                UUID lockToken,
+                String reason,
+                String description
+            ) throws InterruptedException, ServiceBusException {
+                // do nothing
+            }
+        };
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
@@ -6,6 +6,7 @@ import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.IMessageOperations;
 
 import java.util.UUID;
@@ -24,7 +25,8 @@ public class FunctionalQueueConfig {
     }
 
     @Bean
-    IMessageOperations testMessageOperations() {
+    @Profile("nosb") // apply only when Service Bus should not be used
+    IMessageOperations testNoServiceBusMessageOperations() {
         return new IMessageOperations() {
             @Override
             public void complete(UUID lockToken) throws InterruptedException, ServiceBusException {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/config/IntegrationTestConfig.kt
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/config/IntegrationTestConfig.kt
@@ -14,11 +14,14 @@ import org.springframework.context.annotation.Profile
 import org.springframework.util.SocketUtils.findAvailableTcpPort
 import uk.gov.hmcts.reform.bulkscan.orchestrator.Application
 import uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.MessageSender
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.IMessageOperations
 import java.lang.System.setProperty
+import java.util.UUID
+
 
 @Import(Application::class)
 @Configuration
-@Profile("integration","nosb")  // no servicebus queue handler registration
+@Profile("integration", "nosb") // no servicebus queue handler registration
 class IntegrationTestConfig : ApplicationContextInitializer<ConfigurableApplicationContext> {
     override fun initialize(ctx: ConfigurableApplicationContext) {
         setProperty("wiremock.port", findAvailableTcpPort().toString())
@@ -31,4 +34,14 @@ class IntegrationTestConfig : ApplicationContextInitializer<ConfigurableApplicat
     @Bean
     fun messageSender(processor: IMessageHandler) = MessageSender(processor);
 
+    @Bean
+    fun messageOperations() = object : IMessageOperations {
+        override fun complete(lockToken: UUID?) {
+            // do nothing
+        }
+
+        override fun deadLetter(lockToken: UUID?, reason: String?, description: String?) {
+            // do nothing
+        }
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/QueueConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/QueueConfig.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.config;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.microsoft.azure.servicebus.IMessageHandler;
+import com.microsoft.azure.servicebus.MessageHandlerOptions;
 import com.microsoft.azure.servicebus.QueueClient;
 import com.microsoft.azure.servicebus.primitives.MessagingEntityNotFoundException;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
@@ -11,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -49,7 +51,12 @@ public class QueueConfig {
         int tries = 0;
         while (true) {
             try {
-                client.registerMessageHandler(messageHandler, executorService);
+                client.registerMessageHandler(
+                    messageHandler,
+                    new MessageHandlerOptions(1, false, Duration.ofMinutes(5)),
+                    executorService
+                );
+
                 return;
             } catch (UnsupportedOperationException e) {
                 log.info("Register handler error: {}.", e.getMessage());

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -4,18 +4,24 @@ import com.google.common.base.Strings;
 import com.microsoft.azure.servicebus.ExceptionPhase;
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IMessageHandler;
+import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisher;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EventPublisherContainer;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.IMessageOperations;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.exceptions.InvalidMessageException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.EnvelopeEventProcessor.MessageProcessingResultType.POTENTIALLY_RECOVERABLE_FAILURE;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.EnvelopeEventProcessor.MessageProcessingResultType.SUCCESS;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.EnvelopeEventProcessor.MessageProcessingResultType.UNRECOVERABLE_FAILURE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.EnvelopeParser.parse;
 
 @Service
@@ -24,12 +30,17 @@ public class EnvelopeEventProcessor implements IMessageHandler {
     private static final Logger log = LoggerFactory.getLogger(EnvelopeEventProcessor.class);
 
     private final CaseRetriever caseRetriever;
-
     private final EventPublisherContainer eventPublisherContainer;
+    private final IMessageOperations messageOperations;
 
-    public EnvelopeEventProcessor(CaseRetriever caseRetriever, EventPublisherContainer eventPublisherContainer) {
+    public EnvelopeEventProcessor(
+        CaseRetriever caseRetriever,
+        EventPublisherContainer eventPublisherContainer,
+        IMessageOperations messageOperations
+    ) {
         this.caseRetriever = caseRetriever;
         this.eventPublisherContainer = eventPublisherContainer;
+        this.messageOperations = messageOperations;
     }
 
     @Override
@@ -41,7 +52,9 @@ public class EnvelopeEventProcessor implements IMessageHandler {
          */
         CompletableFuture<Void> completableFuture = new CompletableFuture<>();
         try {
-            process(message);
+            MessageProcessingResult result = process(message);
+            tryFinaliseProcessedMessage(message, result);
+
             completableFuture.complete(null);
         } catch (Throwable t) {
             completableFuture.completeExceptionally(t);
@@ -49,7 +62,7 @@ public class EnvelopeEventProcessor implements IMessageHandler {
         return completableFuture;
     }
 
-    private void process(IMessage message) {
+    private MessageProcessingResult process(IMessage message) {
         log.info("Started processing message with ID {}", message.getMessageId());
         try {
             Envelope envelope = parse(message.getBody());
@@ -70,18 +83,82 @@ public class EnvelopeEventProcessor implements IMessageHandler {
             );
 
             eventPublisher.publish(envelope);
-
             log.info("Processed message with ID {}", message.getMessageId());
+            return new MessageProcessingResult(SUCCESS);
+        } catch (InvalidMessageException ex) {
+            log.error("Rejected message with ID {}, because it's invalid", message.getMessageId(), ex);
+            return new MessageProcessingResult(UNRECOVERABLE_FAILURE, ex);
         } catch (Exception ex) {
-            throw new MessageProcessingException(
-                "Failed to process message with ID " + message.getMessageId(),
+            log.error("Failed to process message with ID {}", message.getMessageId(), ex);
+            return new MessageProcessingResult(POTENTIALLY_RECOVERABLE_FAILURE);
+        }
+    }
+
+    private void tryFinaliseProcessedMessage(IMessage message, MessageProcessingResult processingResult) {
+        try {
+            finaliseProcessedMessage(message, processingResult);
+        } catch (Exception ex) {
+            log.error(
+                "Failed to manage processed message with ID {}. Processing result: {}",
+                message.getMessageId(),
+                processingResult,
                 ex
             );
+        }
+    }
+
+    private void finaliseProcessedMessage(
+        IMessage message,
+        MessageProcessingResult processingResult
+    ) throws InterruptedException, ServiceBusException {
+
+        switch (processingResult.resultType) {
+            case SUCCESS:
+                messageOperations.complete(message.getLockToken());
+                log.info("Message with ID {} has been completed", message.getMessageId());
+                break;
+            case UNRECOVERABLE_FAILURE:
+                messageOperations.deadLetter(
+                    message.getLockToken(),
+                    "Message processing error",
+                    processingResult.exception.getMessage()
+                );
+
+                log.info("Message with ID {} has been dead-lettered", message.getMessageId());
+                break;
+            case POTENTIALLY_RECOVERABLE_FAILURE:
+                // do nothing - let the message lock expire
+                log.info("Allowing message with ID {} to return to queue", message.getMessageId());
+                break;
+            default:
+                throw new MessageProcessingException(
+                    "Unknown message processing result type: " + processingResult.resultType
+                );
         }
     }
 
     @Override
     public void notifyException(Throwable exception, ExceptionPhase phase) {
         log.error("Error while handling message at stage: " + phase, exception);
+    }
+
+    class MessageProcessingResult {
+        public final MessageProcessingResultType resultType;
+        public final Exception exception;
+
+        public MessageProcessingResult(MessageProcessingResultType resultType) {
+            this(resultType, null);
+        }
+
+        public MessageProcessingResult(MessageProcessingResultType resultType, Exception exception) {
+            this.resultType = resultType;
+            this.exception = exception;
+        }
+    }
+
+    enum MessageProcessingResultType {
+        SUCCESS,
+        UNRECOVERABLE_FAILURE,
+        POTENTIALLY_RECOVERABLE_FAILURE
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/MessageProcessingException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/MessageProcessingException.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services;
 
 public class MessageProcessingException extends RuntimeException {
 
-    public MessageProcessingException(String message, Throwable cause) {
-        super(message, cause);
+    public MessageProcessingException(String message) {
+        super(message);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/IMessageOperations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/IMessageOperations.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus;
+
+import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+
+import java.util.UUID;
+
+/**
+ * Provides all the functions related with message lifecycle
+ * that are used when processing messages from the queue.
+ */
+public interface IMessageOperations {
+
+    void complete(UUID lockToken) throws InterruptedException, ServiceBusException;
+
+    void deadLetter(
+        UUID lockToken,
+        String reason,
+        String description
+    ) throws InterruptedException, ServiceBusException;
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/MessageOperations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/MessageOperations.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus;
+
+import com.microsoft.azure.servicebus.QueueClient;
+import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@Profile("!nosb") // do not register for the nosb (test) profile
+public class MessageOperations implements IMessageOperations {
+
+    private QueueClient queueClient;
+
+    @Autowired
+    public MessageOperations(QueueClient queueClient) {
+        this.queueClient = queueClient;
+    }
+
+    public void complete(UUID lockToken) throws InterruptedException, ServiceBusException {
+        queueClient.complete(lockToken);
+    }
+
+    public void deadLetter(
+        UUID lockToken,
+        String reason,
+        String description
+    ) throws InterruptedException, ServiceBusException {
+        queueClient.deadLetter(lockToken, reason, description);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/MessageOperationsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/MessageOperationsTest.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus;
+
+import com.microsoft.azure.servicebus.QueueClient;
+import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MessageOperationsTest {
+
+    @Mock
+    private QueueClient queueClient;
+
+    private MessageOperations messageOperations;
+
+    @Before
+    public void setUp() {
+        messageOperations = new MessageOperations(queueClient);
+    }
+
+    @Test
+    public void complete_should_call_queue_client() throws Exception {
+        UUID lockToken = UUID.randomUUID();
+
+        messageOperations.complete(lockToken);
+
+        verify(queueClient).complete(lockToken);
+        verifyNoMoreInteractions(queueClient);
+    }
+
+    @Test
+    public void complete_should_throw_exception_when_queue_client_fails() throws Exception {
+        ServiceBusException exceptionToThrow = new ServiceBusException(true);
+        willThrow(exceptionToThrow).given(queueClient).complete(any());
+
+        assertThatThrownBy(() ->
+            messageOperations.complete(UUID.randomUUID())
+        ).isSameAs(exceptionToThrow);
+    }
+
+    @Test
+    public void deadLetter_should_call_queue_client() throws Exception {
+        UUID lockToken = UUID.randomUUID();
+        String reason = "reason1";
+        String description = "description1";
+
+        messageOperations.deadLetter(lockToken, reason, description);
+
+        verify(queueClient).deadLetter(lockToken, reason, description);
+        verifyNoMoreInteractions(queueClient);
+    }
+
+    @Test
+    public void deadLetter_should_throw_exception_when_queue_client_fails() throws Exception {
+        ServiceBusException exceptionToThrow = new ServiceBusException(true);
+        willThrow(exceptionToThrow).given(queueClient).deadLetter(any(), any(), any());
+
+        assertThatThrownBy(() ->
+            messageOperations.deadLetter(UUID.randomUUID(), "reason", "description")
+        ).isSameAs(exceptionToThrow);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-446

### Change description ###

Prevent messages from being reprocessed immediately after failure. This requires message handler to manage the finalise messages itself instead of throwing/not throwing exceptions.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
