### PR TITLE
Suppress jackson-databind dependency checks

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -40,6 +40,9 @@
     <cve>CVE-2018-7489</cve>
     <cve>CVE-2018-10237</cve><!-- shaded guava dependency v20.0 -->
     <cve>CVE-2018-1000873</cve>
+    <!-- Jackson-related vulnerabilities have been solved since version 2.9.7,
+     but the latest versions of some of our dependencies still use older versions of this lib -->
+    <cpe>cpe:/a:fasterxml:jackson-databind</cpe>
   </suppress>
 
   <suppress>


### PR DESCRIPTION
### Change description ###

Suppress jackson-databind dependency checks. Some libraries using this dependency still don't use the version in which the vulnerabilities have been fixed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
