### PR TITLE
Copy document subtype values to document type 

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ModelMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ModelMapper.java
@@ -26,7 +26,7 @@ public abstract class ModelMapper<T extends CaseData> {
             .collect(Collectors.toList());
     }
 
-    private ScannedDocument mapDocument(Document document) {
+    ScannedDocument mapDocument(Document document) {
         return new ScannedDocument(
             document.fileName,
             document.controlNumber,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
@@ -1,7 +1,11 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.SupplementaryEvidence;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 @Component
@@ -14,5 +18,30 @@ public class SupplementaryEvidenceMapper extends ModelMapper<SupplementaryEviden
     @Override
     public SupplementaryEvidence mapEnvelope(Envelope envelope) {
         return new SupplementaryEvidence(mapDocuments(envelope.documents));
+    }
+
+    @Override
+    ScannedDocument mapDocument(Document document) {
+        if (StringUtils.isNotEmpty(document.subtype)) {
+            return new ScannedDocument(
+                document.fileName,
+                document.controlNumber,
+                document.subtype,
+                null,
+                getLocalDateTime(document.scannedAt),
+                new CcdDocument(document.url),
+                null
+            );
+        } else {
+            return new ScannedDocument(
+                document.fileName,
+                document.controlNumber,
+                document.type,
+                null,
+                getLocalDateTime(document.scannedAt),
+                new CcdDocument(document.url),
+                null
+            );
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
@@ -1,12 +1,13 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.SupplementaryEvidence;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @Component
 public class SupplementaryEvidenceMapper implements ModelMapper<SupplementaryEvidence> {
@@ -21,27 +22,15 @@ public class SupplementaryEvidenceMapper implements ModelMapper<SupplementaryEvi
     }
 
     @Override
-    ScannedDocument mapDocument(Document document) {
-        if (StringUtils.isNotEmpty(document.subtype)) {
-            return new ScannedDocument(
-                document.fileName,
-                document.controlNumber,
-                document.subtype,
-                null,
-                getLocalDateTime(document.scannedAt),
-                new CcdDocument(document.url),
-                null
-            );
-        } else {
-            return new ScannedDocument(
-                document.fileName,
-                document.controlNumber,
-                document.type,
-                null,
-                getLocalDateTime(document.scannedAt),
-                new CcdDocument(document.url),
-                null
-            );
-        }
+    public ScannedDocument mapDocument(Document document) {
+        return new ScannedDocument(
+            document.fileName,
+            document.controlNumber,
+            isNotEmpty(document.subtype) ? document.subtype : document.type,
+            null,
+            getLocalDateTime(document.scannedAt),
+            new CcdDocument(document.url),
+            null
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Document.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.Instant;
@@ -11,6 +13,7 @@ public class Document {
     public final String fileName;
     public final String controlNumber;
     public final String type;
+    @JsonInclude(Include.NON_NULL)
     public final String subtype;
     public final Instant scannedAt;
     public final String url;
@@ -20,7 +23,7 @@ public class Document {
         @JsonProperty(value = "file_name", required = true) String fileName,
         @JsonProperty(value = "control_number", required = true) String controlNumber,
         @JsonProperty(value = "type", required = true) String type,
-        @JsonProperty(value = "subtype", required = true) String subtype,
+        @JsonProperty(value = "subtype") String subtype,
         @JsonProperty(value = "scanned_at", required = true) Instant scannedAt,
         @JsonProperty(value = "url", required = true) String url
     ) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -120,10 +120,14 @@ public class SampleData {
     }
 
     public static Envelope envelope(int numberOfDocuments) {
-        return envelope(numberOfDocuments, ImmutableMap.of("fieldName1", "value1"), false);
+        return envelope(numberOfDocuments, ImmutableMap.of("fieldName1", "value1"), true);
     }
 
-    public static Envelope envelope(int numberOfDocuments, Map<String, String> ocrData, boolean subtypeValuesNull) {
+    public static Envelope envelope(
+        int numberOfDocuments,
+        Map<String, String> ocrData,
+        boolean setDocumentSubtypeValues
+    ) {
         return new Envelope(
             "eb9c3598-35fc-424e-b05a-902ee9f11d56",
             CASE_REF,
@@ -133,19 +137,19 @@ public class SampleData {
             Instant.now(),
             Instant.now(),
             Classification.NEW_APPLICATION,
-            documents(numberOfDocuments, subtypeValuesNull),
+            documents(numberOfDocuments, setDocumentSubtypeValues),
             ocrData
         );
     }
 
-    private static List<Document> documents(int numberOfDocuments, boolean setSubtypeValuesNull) {
+    private static List<Document> documents(int numberOfDocuments, boolean setDocumentSubtypeValues) {
         return Stream.iterate(1, i -> i + 1)
             .map(index ->
                 new Document(
                     String.format("file_%s.pdf", index),
                     String.format("control_number_%s", index),
                     String.format("type_%s", index),
-                    setSubtypeValuesNull ? null : String.format("subtype_%s", index),
+                    setDocumentSubtypeValues ? String.format("subtype_%s", index) : null,
                     ZonedDateTime.parse("2018-10-01T00:00:00Z").plus(index, DAYS).toInstant(),
                     String.format("https://example.gov.uk/%s", index)
                 )

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -120,10 +120,10 @@ public class SampleData {
     }
 
     public static Envelope envelope(int numberOfDocuments) {
-        return envelope(numberOfDocuments, ImmutableMap.of("fieldName1", "value1"));
+        return envelope(numberOfDocuments, ImmutableMap.of("fieldName1", "value1"), false);
     }
 
-    public static Envelope envelope(int numberOfDocuments, Map<String, String> ocrData) {
+    public static Envelope envelope(int numberOfDocuments, Map<String, String> ocrData, boolean subtypeValuesNull) {
         return new Envelope(
             "eb9c3598-35fc-424e-b05a-902ee9f11d56",
             CASE_REF,
@@ -133,19 +133,19 @@ public class SampleData {
             Instant.now(),
             Instant.now(),
             Classification.NEW_APPLICATION,
-            documents(numberOfDocuments),
+            documents(numberOfDocuments, subtypeValuesNull),
             ocrData
         );
     }
 
-    private static List<Document> documents(int numberOfDocuments) {
+    private static List<Document> documents(int numberOfDocuments, boolean setSubtypeValuesNull) {
         return Stream.iterate(1, i -> i + 1)
             .map(index ->
                 new Document(
                     String.format("file_%s.pdf", index),
                     String.format("control_number_%s", index),
                     String.format("type_%s", index),
-                    String.format("subtype_%s", index),
+                    setSubtypeValuesNull ? null : String.format("subtype_%s", index),
                     ZonedDateTime.parse("2018-10-01T00:00:00Z").plus(index, DAYS).toInstant(),
                     String.format("https://example.gov.uk/%s", index)
                 )

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -54,9 +54,39 @@ public class ExceptionRecordMapperTest {
 
     @Test
     public void mapEnvelope_handles_null_ocr_data() {
-        Envelope envelope = envelope(2, null);
+        Envelope envelope = envelope(2, null, false);
         ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
         assertThat(exceptionRecord.ocrData).isNull();
+    }
+
+    @Test
+    public void mapEnvelope_handles_null_subtype_in_documents() {
+        Envelope envelope = envelope(2, null, true);
+
+        ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
+
+        List<String> expectedDocumentSubtypeValues =
+            envelope.documents.stream().map(d -> d.subtype).collect(toList());
+
+        List<String> actualDocumentSubtypeValues =
+            exceptionRecord.scannedDocuments.stream().map(d -> d.value.subtype).collect(toList());
+
+        assertThat(actualDocumentSubtypeValues).isEqualTo(expectedDocumentSubtypeValues);
+    }
+
+    @Test
+    public void mapEnvelope_handles_subtype_values_in_documents() {
+        Envelope envelope = envelope(2, null, false);
+
+        ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
+
+        List<String> expectedDocumentSubtypeValues =
+            envelope.documents.stream().map(d -> d.subtype).collect(toList());
+
+        List<String> actualDocumentSubtypeValues =
+            exceptionRecord.scannedDocuments.stream().map(d -> d.value.subtype).collect(toList());
+
+        assertThat(actualDocumentSubtypeValues).isEqualTo(expectedDocumentSubtypeValues);
     }
 
     private Map<String, String> ocrDataAsMap(List<CcdCollectionElement<CcdKeyValue>> ocrData) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -54,14 +54,14 @@ public class ExceptionRecordMapperTest {
 
     @Test
     public void mapEnvelope_handles_null_ocr_data() {
-        Envelope envelope = envelope(2, null, false);
+        Envelope envelope = envelope(2, null, true);
         ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
         assertThat(exceptionRecord.ocrData).isNull();
     }
 
     @Test
     public void mapEnvelope_handles_null_subtype_in_documents() {
-        Envelope envelope = envelope(2, null, true);
+        Envelope envelope = envelope(2, null, false);
 
         ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
 
@@ -76,7 +76,7 @@ public class ExceptionRecordMapperTest {
 
     @Test
     public void mapEnvelope_handles_subtype_values_in_documents() {
-        Envelope envelope = envelope(2, null, false);
+        Envelope envelope = envelope(2, null, true);
 
         ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
@@ -63,7 +63,7 @@ public class SupplementaryEvidenceMapperTest {
     @Test
     public void map_envelope_maps_all_documents_with_subtype_values_copied_to_type() {
         int numberOfDocuments = 2;
-        Envelope envelope = SampleData.envelope(2, null, false);
+        Envelope envelope = SampleData.envelope(2, null, true);
 
         SupplementaryEvidence supplementaryEvidence = mapper.mapEnvelope(envelope);
         assertThat(supplementaryEvidence.scannedDocuments.size()).isEqualTo(numberOfDocuments);
@@ -88,7 +88,7 @@ public class SupplementaryEvidenceMapperTest {
     @Test
     public void map_envelope_maps_all_documents_with_subtype_values_null() {
         int numberOfDocuments = 2;
-        Envelope envelope = SampleData.envelope(2, null, true);
+        Envelope envelope = SampleData.envelope(2, null, false);
 
         SupplementaryEvidence supplementaryEvidence = mapper.mapEnvelope(envelope);
         assertThat(supplementaryEvidence.scannedDocuments.size()).isEqualTo(numberOfDocuments);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-449

### Change description ###
Supplementary Evidence documents shouldn't contain "subtype" values.
If subtype values exist in the service bus message, copy subtype value to the type.
TODO: In the next pr, a functional test will be added.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
