### PR TITLE
Convert ModelMapper abstract class to interface

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import static java.util.stream.Collectors.toList;
 
 @Component
-public class ExceptionRecordMapper extends ModelMapper<ExceptionRecord> {
+public class ExceptionRecordMapper implements ModelMapper<ExceptionRecord> {
 
     public ExceptionRecordMapper() {
         // empty mapper construct

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ModelMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ModelMapper.java
@@ -14,11 +14,11 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class ModelMapper<T extends CaseData> {
+public interface ModelMapper<T extends CaseData> {
 
-    public abstract T mapEnvelope(Envelope envelope);
+    T mapEnvelope(Envelope envelope);
 
-    List<CcdCollectionElement<ScannedDocument>> mapDocuments(List<Document> documents) {
+    default List<CcdCollectionElement<ScannedDocument>> mapDocuments(List<Document> documents) {
         return documents
             .stream()
             .map(this::mapDocument)
@@ -26,7 +26,7 @@ public abstract class ModelMapper<T extends CaseData> {
             .collect(Collectors.toList());
     }
 
-    private ScannedDocument mapDocument(Document document) {
+    default ScannedDocument mapDocument(Document document) {
         return new ScannedDocument(
             document.fileName,
             document.controlNumber,
@@ -38,7 +38,7 @@ public abstract class ModelMapper<T extends CaseData> {
         );
     }
 
-    LocalDateTime getLocalDateTime(Instant instant) {
+    default LocalDateTime getLocalDateTime(Instant instant) {
         return ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()).toLocalDateTime();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
@@ -5,7 +5,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.SupplementaryEvidence
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 @Component
-public class SupplementaryEvidenceMapper extends ModelMapper<SupplementaryEvidence> {
+public class SupplementaryEvidenceMapper implements ModelMapper<SupplementaryEvidence> {
 
     public SupplementaryEvidenceMapper() {
         // empty mapper construct


### PR DESCRIPTION
This is required for the previous pr https://github.com/hmcts/bulk-scan-orchestrator/pull/210/
Qualitygate reported that ModelMapper should be converted to interface as I had to override mapDocument method in SupplementaryEvidenceMapper.