### PR TITLE
Revert "Bump spring-cloud-contract-wiremock from 2.0.2.RELEASE to 2.1.0.RELEASE"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,7 +202,7 @@ dependencies {
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
   testCompile group: 'org.junit.vintage', name: 'junit-vintage-engine', version: versions.junit
   testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'
-  testCompile group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '2.1.0.RELEASE'
+  testCompile group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '2.0.2.RELEASE'
   testCompile group: 'org.awaitility', name: 'awaitility', version: '3.1.6'
   testCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.3.0'
 


### PR DESCRIPTION
The issue is continuous. Only once passed on PR but never again. Will investigate in more depth