### PR TITLE
Updated idam url to point to idam test envionment

### DIFF
--- a/infrastructure/sprod.tfvars
+++ b/infrastructure/sprod.tfvars
@@ -1,4 +1,4 @@
 capacity = "2"
-idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"
+idam_api_url = "http://betadevbccidamapplb.reform.hmcts.net"
 idam_client_redirect_uri = "https://rpe-bulk-scan-processor-sandbox.service.core-compute-sandbox.internal/oauth2/callback"
 supported_jurisdictions = ["SSCS", "BULKSCAN", "DIVORCE", "PROBATE"]


### PR DESCRIPTION

### Change description ###

- Sprod cannot connect to Idam preproduction environment. Hence updated idam url to use the test environment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```