### PR TITLE
Remove not needed mapper interface

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapper.java
@@ -1,11 +1,9 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers;
 
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -14,19 +12,21 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public interface ModelMapper<T extends CaseData> {
+public class DocumentMapper {
 
-    T mapEnvelope(Envelope envelope);
+    private DocumentMapper() {
+        // util class
+    }
 
-    default List<CcdCollectionElement<ScannedDocument>> mapDocuments(List<Document> documents) {
+    public static List<CcdCollectionElement<ScannedDocument>> mapDocuments(List<Document> documents) {
         return documents
             .stream()
-            .map(this::mapDocument)
+            .map(DocumentMapper::mapDocument)
             .map(CcdCollectionElement::new)
             .collect(Collectors.toList());
     }
 
-    default ScannedDocument mapDocument(Document document) {
+    public static ScannedDocument mapDocument(Document document) {
         return new ScannedDocument(
             document.fileName,
             document.controlNumber,
@@ -38,7 +38,7 @@ public interface ModelMapper<T extends CaseData> {
         );
     }
 
-    default LocalDateTime getLocalDateTime(Instant instant) {
+    public static LocalDateTime getLocalDateTime(Instant instant) {
         return ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()).toLocalDateTime();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -10,15 +10,16 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.OcrDa
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.DocumentMapper.getLocalDateTime;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.DocumentMapper.mapDocuments;
 
 @Component
-public class ExceptionRecordMapper implements ModelMapper<ExceptionRecord> {
+public class ExceptionRecordMapper {
 
     public ExceptionRecordMapper() {
         // empty mapper construct
     }
 
-    @Override
     public ExceptionRecord mapEnvelope(Envelope envelope) {
         return new ExceptionRecord(
             envelope.classification.name(),

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
@@ -4,14 +4,15 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.SupplementaryEvidence;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.DocumentMapper.mapDocuments;
+
 @Component
-public class SupplementaryEvidenceMapper implements ModelMapper<SupplementaryEvidence> {
+public class SupplementaryEvidenceMapper {
 
     public SupplementaryEvidenceMapper() {
         // empty mapper construct
     }
 
-    @Override
     public SupplementaryEvidence mapEnvelope(Envelope envelope) {
         return new SupplementaryEvidence(mapDocuments(envelope.documents));
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ModelMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.SupplementaryEvidenceMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
@@ -16,7 +15,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsH
 @Component
 class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
 
-    private final ModelMapper<? extends CaseData> mapper;
+    private final SupplementaryEvidenceMapper mapper;
 
     AttachDocsToSupplementaryEvidence(SupplementaryEvidenceMapper mapper) {
         this.mapper = mapper;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ExceptionRecordMapper;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ModelMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 
 @Component
@@ -11,7 +10,7 @@ class CreateExceptionRecord extends AbstractEventPublisher {
 
     static final String CASE_TYPE = "ExceptionRecord";
 
-    private final ModelMapper<? extends CaseData> mapper;
+    private final ExceptionRecordMapper mapper;
 
     CreateExceptionRecord(ExceptionRecordMapper mapper) {
         this.mapper = mapper;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SupplementaryEvidenceMapperTest {
 
-    private static final ModelMapper<SupplementaryEvidence> mapper = new SupplementaryEvidenceMapper();
+    private static final SupplementaryEvidenceMapper mapper = new SupplementaryEvidenceMapper();
 
     @Test
     public void from_envelope_maps_all_fields_correctly() {


### PR DESCRIPTION
Interface was never really used.
Event publishers (`CreateExceptionRecord` and `AttachDocsToSupplementaryEvidence`) take concrete implementations.

More importantly, this will allow customisation of `SupplementaryEvidenceMapper` which will soon take existing documents as parameter, not just envelope from the queue.

