### PR TITLE
Revert "Bump junit5"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,6 @@ compileTestKotlin {
 
 test {
   useJUnitPlatform()
-  failFast = true
 }
 
 task functional(type: Test, description: 'Runs the functional tests.', group: 'Verification') {
@@ -77,7 +76,6 @@ task integration(type: Test, description: 'Runs the integration tests.', group: 
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
   useJUnitPlatform()
-  failFast = true
 
   testLogging {
     exceptionFormat = 'full'
@@ -88,7 +86,6 @@ task smoke(type: Test) {
   description = "Runs Smoke Tests"
   testClassesDirs = sourceSets.smokeTest.output.classesDirs
   classpath = sourceSets.smokeTest.runtimeClasspath
-  useJUnitPlatform()
 }
 
 checkstyle {
@@ -163,7 +160,7 @@ def versions = [
   reformLogging   : '4.0.1',
   springBoot      : springBoot.class.package.implementationVersion,
   springfoxSwagger: '2.9.2',
-  junit           : '5.4.0'
+  junit           : '5.3.2'
 ]
 
 dependencyManagement {
@@ -214,7 +211,9 @@ dependencies {
 
   testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot)
   testCompile group: 'com.typesafe', name: 'config', version: '1.3.3'
-  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter', version: versions.junit
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
   testCompile group: 'org.junit.vintage', name: 'junit-vintage-engine', version: versions.junit
   testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '2.24.0'
   testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'


### PR DESCRIPTION
### Change description ###

Looks like this version jump incorrectly populates coverage report even though locally result is the same with both versions

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
