### PR TITLE
Remove kotlin 05: integration tests remove kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,8 +185,6 @@ dependencyManagement {
 }
 
 dependencies {
-  integrationTestCompile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8'
-  integrationTestCompile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect'
   functionalTestCompile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8'
   functionalTestCompile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect'
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ task integration(type: Test, description: 'Runs the integration tests.', group: 
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
   useJUnitPlatform()
+  failFast = true
 
   testLogging {
     exceptionFormat = 'full'

--- a/build.gradle
+++ b/build.gradle
@@ -51,12 +51,7 @@ tasks.withType(JavaCompile) {
   options.compilerArgs << "-Xlint:unchecked" << "-Werror"
 }
 
-compileKotlin {
-  kotlinOptions {
-    jvmTarget = "1.8"
-  }
-}
-compileTestKotlin {
+compileFunctionalTestKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
   }


### PR DESCRIPTION
### Change description ###

A simple one after all the pain

Branches to go:

- [ ] refactor/functional-tests
- [x] refactor/integration-tests-ccd #254 
- [x] refactor/integration-tests-ccd-events #253 
- [x] refactor/integration-tests-config #251
- [x] refactor/integration-tests-remove-kotlin
- [x] refactor/integration-tests-util #252 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
