### PR TITLE
Simplify case creation in functional test: step 1

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
@@ -94,8 +94,9 @@ public class AttachExceptionRecordToExistingCaseTest {
     @Test
     public void should_attach_exception_record_to_the_existing_case_with_evidence_documents() throws Exception {
         //given
+        // TODO: simply create list of docs in code
         Envelope newEnvelope = updateEnvelope("envelopes/new-envelope-with-evidence.json");
-        CaseDetails caseDetails = ccdCaseCreator.createCase(newEnvelope);
+        CaseDetails caseDetails = ccdCaseCreator.createCase(newEnvelope.documents);
         CaseDetails exceptionRecord = createExceptionRecord("envelopes/supplementary-evidence-envelope.json");
 
         // when
@@ -207,9 +208,10 @@ public class AttachExceptionRecordToExistingCaseTest {
     }
 
     private CaseDetails createCase(String jsonFileName) {
+        // TODO: simply create a list of documents in code instead
         String caseData = SampleData.fileContentAsString(jsonFileName);
         Envelope newEnvelope = EnvelopeParser.parse(caseData);
-        return ccdCaseCreator.createCase(newEnvelope);
+        return ccdCaseCreator.createCase(newEnvelope.documents);
     }
 
     private Envelope updateEnvelope(String envelope) throws JSONException {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Collections.emptyList;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -51,9 +52,7 @@ public class SupplementaryEvidenceTest {
     public void should_attach_supplementary_evidence_to_the_case_with_no_evidence_docs() throws Exception {
         //given
         String dmUrl = dmUploadService.uploadToDmStore("Evidence2.pdf", "documents/supplementary-evidence.pdf");
-        String caseData = SampleData.fileContentAsString("envelopes/new-envelope.json");
-        Envelope newEnvelope = EnvelopeParser.parse(caseData);
-        CaseDetails caseDetails = ccdCaseCreator.createCase(newEnvelope);
+        CaseDetails caseDetails = ccdCaseCreator.createCase(emptyList());
 
         // when
         envelopeMessager.sendMessageFromFile(
@@ -77,9 +76,10 @@ public class SupplementaryEvidenceTest {
         String dmUrlOriginal = dmUploadService.uploadToDmStore("original.pdf", "documents/supplementary-evidence.pdf");
         String dmUrlNew = dmUploadService.uploadToDmStore("new.pdf", "documents/supplementary-evidence.pdf");
 
+        // TODO: simply create a list of docs instead
         JSONObject newCaseData = updateEnvelope("envelopes/new-envelope-with-evidence.json", null, dmUrlOriginal);
         Envelope newEnvelope = EnvelopeParser.parse(newCaseData.toString());
-        CaseDetails caseDetails = ccdCaseCreator.createCase(newEnvelope);
+        CaseDetails caseDetails = ccdCaseCreator.createCase(newEnvelope.documents);
 
         // when
         envelopeMessager.sendMessageFromFile(

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCaseCreator.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCaseCreator.java
@@ -6,12 +6,14 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.SupplementaryEvidenceMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticatorFactory;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
+
+import java.util.List;
 
 import static java.util.Collections.emptyList;
 
@@ -38,14 +40,14 @@ public class CcdCaseCreator {
         this.coreCaseDataApi = coreCaseDataApi;
     }
 
-    public CaseDetails createCase(Envelope envelope) {
+    public CaseDetails createCase(List<Document> documents) {
         log.info("Creating new case");
         CcdAuthenticator authenticator = ccdAuthenticatorFactory.createForJurisdiction(JURISDICTION);
 
         StartEventResponse startEventResponse = startEventForCreateCase(authenticator);
         log.info("Started {} event for creating a new case", startEventResponse.getEventId());
 
-        CaseDataContent caseDataContent = prepareCaseData(startEventResponse, envelope);
+        CaseDataContent caseDataContent = prepareCaseData(startEventResponse, documents);
 
         CaseDetails caseDetails = submitNewCase(authenticator, caseDataContent);
         log.info("Submitted {} event for creating a new case", startEventResponse.getEventId());
@@ -53,7 +55,7 @@ public class CcdCaseCreator {
         return caseDetails;
     }
 
-    private CaseDataContent prepareCaseData(StartEventResponse startEventResponse, Envelope envelope) {
+    private CaseDataContent prepareCaseData(StartEventResponse startEventResponse, List<Document> documents) {
         return CaseDataContent.builder()
             .eventToken(startEventResponse.getToken())
             .event(Event.builder()
@@ -61,7 +63,7 @@ public class CcdCaseCreator {
                 .summary("create new case")
                 .description("create new case for tests")
                 .build())
-            .data(supplementaryEvidenceMapper.map(emptyList(), envelope.documents))
+            .data(supplementaryEvidenceMapper.map(emptyList(), documents))
             .build();
     }
 


### PR DESCRIPTION
Before:
`CaseCreator.createCase` helper method took an instance of `Envelope` as a parameter.
The following steps were taken to create a case:
1. envelope json is loaded and some parts of it are overwritten in code using urls to files in dm store
2. the resulting json is parsed into an instance of `Envelope`
3. only the list of documents from envelope object are used in case creation

After:
`CaseCreator.createCase` helper method takes a list of documents as parameter.
The following steps can now be taken to create a case (todo in next pr)
1. create a list of documents in code with urls to files in dm store.
