### PR TITLE
Simplify functional test

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
@@ -2,11 +2,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator;
 
 import com.google.common.base.Strings;
 import org.awaitility.Duration;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,14 +13,15 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.helper.CcdCaseCreator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.helper.EnvelopeMessager;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseRetriever;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.EnvelopeParser;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -76,10 +72,11 @@ public class SupplementaryEvidenceTest {
         String dmUrlOriginal = dmUploadService.uploadToDmStore("original.pdf", "documents/supplementary-evidence.pdf");
         String dmUrlNew = dmUploadService.uploadToDmStore("new.pdf", "documents/supplementary-evidence.pdf");
 
-        // TODO: simply create a list of docs instead
-        JSONObject newCaseData = updateEnvelope("envelopes/new-envelope-with-evidence.json", null, dmUrlOriginal);
-        Envelope newEnvelope = EnvelopeParser.parse(newCaseData.toString());
-        CaseDetails caseDetails = ccdCaseCreator.createCase(newEnvelope.documents);
+        CaseDetails caseDetails =
+            ccdCaseCreator.createCase(
+                singletonList(
+                    new Document("evidence.pdf", "123", "other", null, Instant.now(), dmUrlOriginal)
+                ));
 
         // when
         envelopeMessager.sendMessageFromFile(
@@ -109,20 +106,5 @@ public class SupplementaryEvidenceTest {
 
         List<ScannedDocument> updatedScannedDocuments = getScannedDocuments(updatedCaseDetails);
         return updatedScannedDocuments.size() == excpectedScannedDocuments && evidenceHandled.equals("No");
-    }
-
-    @NotNull
-    private JSONObject updateEnvelope(String fileName, @Nullable Long caseRef, String docUrl) throws JSONException {
-        String updatedCase = SampleData.fileContentAsString(fileName);
-        JSONObject updatedCaseData = new JSONObject(updatedCase);
-
-        if (caseRef != null) {
-            updatedCaseData.put("case_ref", caseRef);
-        }
-
-        JSONArray documents = updatedCaseData.getJSONArray("documents");
-        JSONObject document = (JSONObject) documents.get(0);
-        document.put("url", docUrl);
-        return updatedCaseData;
     }
 }


### PR DESCRIPTION
Instead of loading envelope json from file, modifying the json, then deserializing it to envelope object and retrieving documents from it, just create a list of documents in code.