### PR TITLE
Don't add supplementary evidence with the same control number

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
@@ -23,7 +23,7 @@ public class SupplementaryEvidenceMapper {
         Stream<Document> docsToAdd =
             envelopeDocs
                 .stream()
-                .filter(d -> existingDocs.stream().noneMatch(e -> Objects.equals(e.url, d.url)));
+                .filter(d -> existingDocs.stream().noneMatch(e -> areDuplicates(d, e)));
 
         return new SupplementaryEvidence(
             mapDocuments(
@@ -33,5 +33,10 @@ public class SupplementaryEvidenceMapper {
                 ).collect(toList())
             )
         );
+    }
+
+    private boolean areDuplicates(Document d1, Document d2) {
+        return Objects.equals(d1.url, d2.url)
+            || Objects.equals(d1.controlNumber, d2.controlNumber);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
@@ -15,6 +15,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+@SuppressWarnings("checkstyle:LineLength")
 public class SupplementaryEvidenceMapperTest {
 
     private static final SupplementaryEvidenceMapper mapper = new SupplementaryEvidenceMapper();

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
@@ -70,7 +70,7 @@ public class SupplementaryEvidenceMapperTest {
         List<Document> envelopeDocs =
             asList(
                 new Document("a1.pdf", "aaa1", "type_a1", "subtype_a1", now().plusSeconds(3), "http://localhost/a.pdf"), // same url!
-                new Document("b.pdf", "bbb", "type_b", "subtype_b", now().plusSeconds(4), "http://localhost/xxxxx.pdf")  // same name etc, but different url
+                new Document("b.pdf", "bbb1", "type_b", "subtype_b", now().plusSeconds(4), "http://localhost/xxxxx.pdf")
             );
 
         // when
@@ -84,9 +84,38 @@ public class SupplementaryEvidenceMapperTest {
                 tuple(ccdDoc.value.fileName, ccdDoc.value.url.documentUrl)
             )
             .containsExactly(
-                tuple("a.pdf","http://localhost/a.pdf"),
-                tuple("b.pdf","http://localhost/b.pdf"),
-                tuple("b.pdf","http://localhost/xxxxx.pdf")
+                tuple("a.pdf", "http://localhost/a.pdf"),
+                tuple("b.pdf", "http://localhost/b.pdf"),
+                tuple("b.pdf", "http://localhost/xxxxx.pdf")
+            );
+    }
+
+    @Test
+    public void should_not_add_document_from_envelope_if_document_with_the_same_control_number_is_already_present_in_case() {
+        // given
+        List<Document> existingDocs =
+            asList(
+                new Document("a.pdf", "AAA", "type_a", "subtype_a", now().plusSeconds(1), "http://localhost/a.pdf"),
+                new Document("b.pdf", "BBB", "type_b", "subtype_b", now().plusSeconds(2), "http://localhost/b.pdf")
+            );
+
+        List<Document> envelopeDocs =
+            asList(
+                new Document("c.pdf", "AAA", "type_c", "subtype_c", now().plusSeconds(3), "http://localhost/c.pdf"), // same control number!
+                new Document("d.pdf", "DDD", "type_d", "subtype_d", now().plusSeconds(4), "http://localhost/d.pdf")
+            );
+
+        // when
+        SupplementaryEvidence result = mapper.map(existingDocs, envelopeDocs);
+
+        // then
+        assertThat(result.scannedDocuments).hasSize(3); // only one doc should be added
+        assertThat(result.scannedDocuments)
+            .extracting(ccdDoc -> tuple(ccdDoc.value.fileName, ccdDoc.value.controlNumber))
+            .containsExactly(
+                tuple("a.pdf", "AAA"),
+                tuple("b.pdf", "BBB"),
+                tuple("d.pdf", "DDD")
             );
     }
 


### PR DESCRIPTION
Previously just url, now also same control number will result in not adding a document to case.