### PR TITLE
Refactor 02: breakdown envelope processor

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/handler/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/handler/EnvelopeEventProcessor.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscan.orchestrator.services;
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.handler;
 
 import com.google.common.base.Strings;
 import com.microsoft.azure.servicebus.ExceptionPhase;
@@ -16,8 +16,6 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.IProcessedE
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.NotificationSendingException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.exceptions.InvalidMessageException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.exceptions.MessageProcessingException;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.handler.MessageProcessingResult;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.handler.MessageProcessingResultType;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/handler/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/handler/EnvelopeEventProcessor.java
@@ -62,7 +62,7 @@ public class EnvelopeEventProcessor implements IMessageHandler {
             tryFinaliseProcessedMessage(message, result);
 
             completableFuture.complete(null);
-        } catch (Throwable t) {
+        } catch (Exception t) {
             completableFuture.completeExceptionally(t);
         }
         return completableFuture;
@@ -162,7 +162,7 @@ public class EnvelopeEventProcessor implements IMessageHandler {
 
     @Override
     public void notifyException(Throwable exception, ExceptionPhase phase) {
-        log.error("Error while handling message at stage: " + phase, exception);
+        log.error("Error while handling message at stage: {}", phase, exception);
     }
 
     private Supplier<CaseDetails> getCaseRetriever(final Envelope envelope) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/handler/MessageProcessingResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/handler/MessageProcessingResult.java
@@ -1,17 +1,43 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.handler;
 
+import java.util.function.Supplier;
+
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.handler.MessageProcessingResultType.POTENTIALLY_RECOVERABLE_FAILURE;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.handler.MessageProcessingResultType.SUCCESS;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.handler.MessageProcessingResultType.UNRECOVERABLE_FAILURE;
+
 public class MessageProcessingResult {
 
-    public final MessageProcessingResultType resultType;
+    final MessageProcessingResultType resultType;
 
     public final Exception exception;
 
-    public MessageProcessingResult(MessageProcessingResultType resultType) {
+    MessageProcessingResult(MessageProcessingResultType resultType) {
         this(resultType, null);
     }
 
-    public MessageProcessingResult(MessageProcessingResultType resultType, Exception exception) {
+    MessageProcessingResult(MessageProcessingResultType resultType, Exception exception) {
         this.resultType = resultType;
         this.exception = exception;
+    }
+
+    static MessageProcessingResult success() {
+        return new MessageProcessingResult(SUCCESS);
+    }
+
+    static MessageProcessingResult recoverable(Exception exception) {
+        return new MessageProcessingResult(POTENTIALLY_RECOVERABLE_FAILURE, exception);
+    }
+
+    static MessageProcessingResult unrecoverable(Exception exception) {
+        return new MessageProcessingResult(UNRECOVERABLE_FAILURE, exception);
+    }
+
+    private boolean isSuccess() {
+        return MessageProcessingResultType.SUCCESS.equals(resultType);
+    }
+
+    MessageProcessingResult andThen(Supplier<MessageProcessingResult> function) {
+        return isSuccess() ? function.get() : this;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/handler/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/handler/EnvelopeEventProcessorTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.bulkscan.orchestrator.services;
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.handler;
 
 import com.microsoft.azure.servicebus.IMessage;
 import org.junit.Before;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/handler/MessageProcessingResultTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/handler/MessageProcessingResultTest.java
@@ -1,0 +1,48 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.handler;
+
+import org.junit.Test;
+
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+
+public class MessageProcessingResultTest {
+
+    @Test
+    public void should_return_second_object_when_first_was_successful() {
+        // given
+        MessageProcessingResult successResult = MessageProcessingResult.success();
+        MessageProcessingResult recoverableResult = MessageProcessingResult.recoverable(new RuntimeException("oh no"));
+
+        // when
+        MessageProcessingResult flatResult = successResult.andThen(() -> recoverableResult);
+
+        // then
+        assertThat(flatResult).isEqualTo(recoverableResult);
+    }
+
+    @Test
+    public void should_not_exec_further_steps_when_given_result_is_not_successful() {
+        // given
+        MessageProcessingResult result = MessageProcessingResult.unrecoverable(new RuntimeException("oh no"));
+        Supplier<MessageProcessingResult> mockFunction = mock(TestSupplier.class);
+
+        // when
+        MessageProcessingResult flatResult = result.andThen(mockFunction);
+
+        // then
+        assertThat(result).isEqualTo(flatResult);
+        verify(mockFunction, never()).get();
+    }
+
+    private static class TestSupplier implements Supplier<MessageProcessingResult> {
+
+        @Override
+        public MessageProcessingResult get() {
+            return MessageProcessingResult.success();
+        }
+    }
+}


### PR DESCRIPTION
### Change description ###

1st PR: #291 

This PR moves handler itself to new package. This way inner package classes can "communicate" package-privately as there's no need to disclose this information anyway.

In order to smoothly breakdown the single `process` method I'm adding some basic composition of `MessageProcessingResult`. It's kind of flatmap with fail fast. Fast-forwarding to the last (6th) branch the `process` holds 3 distinct steps to complete the processing. 4th one is message finaliser - keeping it separate as is now. Steps:

1. parse envelope
2. publish envelope
3. notify processor
4. finalise the message

or if you prefer more bullet points 😆:

1. process message:
1.1. parse envelope
1.2. publish envelope
1.3. notify processor
2. finalise the message

last one kind of explains the separation mentioned above

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
