### PR TITLE
Pass event type and summary as parameters

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -11,10 +11,17 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsH
 @Component
 class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
 
+    public static final String EVENT_TYPE_ID = "attachScannedDocs";
+    public static final String EVENT_SUMMARY = "Attach scanned documents";
+
     private final SupplementaryEvidenceMapper mapper;
 
     AttachDocsToSupplementaryEvidence(SupplementaryEvidenceMapper mapper) {
         this.mapper = mapper;
+    }
+
+    public void publish(Envelope envelope, String caseTypeId) {
+        publish(envelope, caseTypeId, EVENT_TYPE_ID, EVENT_SUMMARY);
     }
 
     @Override
@@ -23,15 +30,5 @@ class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
             getDocuments(eventResponse.getCaseDetails()),
             envelope.documents
         );
-    }
-
-    @Override
-    String getEventTypeId() {
-        return "attachScannedDocs";
-    }
-
-    @Override
-    String getEventSummary() {
-        return "Attach scanned documents";
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -10,6 +10,8 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 public class CreateExceptionRecord extends AbstractEventPublisher {
 
     public static final String CASE_TYPE = "ExceptionRecord";
+    public static final String EVENT_TYPE_ID = "createException";
+    public static final String EVENT_SUMMARY = "Create an exception record";
 
     private final ExceptionRecordMapper mapper;
 
@@ -18,7 +20,7 @@ public class CreateExceptionRecord extends AbstractEventPublisher {
     }
 
     public void publish(Envelope envelope) {
-        publish(envelope, envelope.jurisdiction + "_" + CASE_TYPE);
+        publish(envelope, envelope.jurisdiction + "_" + CASE_TYPE, EVENT_TYPE_ID, EVENT_SUMMARY);
     }
 
     /**
@@ -34,15 +36,5 @@ public class CreateExceptionRecord extends AbstractEventPublisher {
     @Override
     CaseData buildCaseData(StartEventResponse eventResponse, Envelope envelope) {
         return mapper.mapEnvelope(envelope);
-    }
-
-    @Override
-    String getEventTypeId() {
-        return "createException";
-    }
-
-    @Override
-    String getEventSummary() {
-        return "Create an exception record";
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
@@ -93,9 +93,9 @@ public class AbstractEventPublisherTest {
         );
     }
 
-    class TestEventPublisher extends AbstractEventPublisher {
-        static final String EVENT_TYPE_ID = "test";
-        static final String EVENT_SUMMARY = "test summary";
+    protected class TestEventPublisher extends AbstractEventPublisher {
+        protected static final String EVENT_TYPE_ID = "test";
+        protected static final String EVENT_SUMMARY = "test summary";
 
         @Override
         CaseData buildCaseData(StartEventResponse eventResponse, Envelope envelope) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
@@ -27,30 +27,10 @@ import static org.mockito.Mockito.verify;
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractEventPublisherTest {
 
-    private static final String EVENT_TYPE_ID = "test";
-
-    private static final String EVENT_SUMMARY = "test summary";
-
     private static final Envelope ENVELOPE = SampleData.envelope(1);
 
     @InjectMocks
-    private AbstractEventPublisher eventPublisher = new AbstractEventPublisher() {
-
-        @Override
-        CaseData buildCaseData(StartEventResponse eventResponse, Envelope envelope) {
-            return null;
-        }
-
-        @Override
-        String getEventTypeId() {
-            return EVENT_TYPE_ID;
-        }
-
-        @Override
-        String getEventSummary() {
-            return EVENT_SUMMARY;
-        }
-    };
+    private TestEventPublisher eventPublisher = new TestEventPublisher();
 
     @Mock
     private CoreCaseDataApi ccdApi;
@@ -86,7 +66,7 @@ public class AbstractEventPublisherTest {
             ENVELOPE.jurisdiction,
             SampleData.BULK_SCANNED_CASE_TYPE,
             ENVELOPE.caseRef,
-            EVENT_TYPE_ID
+            TestEventPublisher.EVENT_TYPE_ID
         );
 
         // and
@@ -102,8 +82,8 @@ public class AbstractEventPublisherTest {
                 .builder()
                 .event(Event
                     .builder()
-                    .id(EVENT_TYPE_ID)
-                    .summary(EVENT_SUMMARY)
+                    .id(TestEventPublisher.EVENT_TYPE_ID)
+                    .summary(TestEventPublisher.EVENT_SUMMARY)
                     .build()
                 )
                 .data(null)
@@ -111,5 +91,19 @@ public class AbstractEventPublisherTest {
                 .ignoreWarning(false)
                 .build()
         );
+    }
+
+    class TestEventPublisher extends AbstractEventPublisher {
+        static final String EVENT_TYPE_ID = "test";
+        static final String EVENT_SUMMARY = "test summary";
+
+        @Override
+        CaseData buildCaseData(StartEventResponse eventResponse, Envelope envelope) {
+            return null;
+        }
+
+        public void publish(Envelope env, String caseType) {
+            publish(env, caseType, EVENT_TYPE_ID, EVENT_SUMMARY);
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
@@ -30,7 +30,7 @@ public class AbstractEventPublisherTest {
     private static final Envelope ENVELOPE = SampleData.envelope(1);
 
     @InjectMocks
-    private TestEventPublisher eventPublisher = new TestEventPublisher();
+    private final TestEventPublisher eventPublisher = new TestEventPublisher();
 
     @Mock
     private CoreCaseDataApi ccdApi;
@@ -98,7 +98,7 @@ public class AbstractEventPublisherTest {
         protected static final String EVENT_SUMMARY = "test summary";
 
         @Override
-        CaseData buildCaseData(StartEventResponse eventResponse, Envelope envelope) {
+        protected CaseData buildCaseData(StartEventResponse eventResponse, Envelope envelope) {
             return null;
         }
 


### PR DESCRIPTION
A small step in the 'composition over inheritance' direction.
This follows the recent removal of the `DelegatePublisher`.

`AttachSupplementaryEvidence` and `CreateExceptionRecords` classes now pass their event types and summaries to the base class method as parameters when creating events in CCD, making it easier to see what's going on and simplifying changes in the future.

As a bonus, this change also happens to solve 14 Codacy issues.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
