### PR TITLE
Improve ccd event logging

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
@@ -57,10 +57,6 @@ abstract class AbstractEventPublisher {
     }
 
     protected void publish(Envelope envelope, String caseTypeId, String eventTypeId, String eventSummary) {
-        String caseRef = envelope.caseRef;
-
-        logCaseCreationEntry(caseRef);
-
         CcdAuthenticator authenticator = authenticateJurisdiction(envelope.jurisdiction);
         StartEventResponse eventResponse = startEvent(authenticator, envelope, caseTypeId, eventTypeId);
         CaseDataContent caseDataContent = buildCaseDataContent(eventResponse, envelope, eventTypeId, eventSummary);
@@ -68,10 +64,6 @@ abstract class AbstractEventPublisher {
     }
 
     // region - execution steps
-
-    private void logCaseCreationEntry(String caseRef) {
-        log.info("Creating {} for case {}", getClass().getSimpleName(), caseRef);
-    }
 
     private CcdAuthenticator authenticateJurisdiction(String jurisdiction) {
         return authenticatorFactory.createForJurisdiction(jurisdiction);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.SupplementaryEvidenceMapper;
@@ -11,6 +13,8 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsH
 @Component
 class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
 
+    private static final Logger log = LoggerFactory.getLogger(AttachDocsToSupplementaryEvidence.class);
+
     public static final String EVENT_TYPE_ID = "attachScannedDocs";
     public static final String EVENT_SUMMARY = "Attach scanned documents";
 
@@ -21,6 +25,7 @@ class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
     }
 
     public void publish(Envelope envelope, String caseTypeId) {
+        log.info("Attaching supplementary evidence from envelope {} to case {}", envelope.id, existingCase.getId());
         publish(envelope, caseTypeId, EVENT_TYPE_ID, EVENT_SUMMARY);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ExceptionRecordMapper;
@@ -8,6 +10,8 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 
 @Component
 public class CreateExceptionRecord extends AbstractEventPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(CreateExceptionRecord.class);
 
     public static final String CASE_TYPE = "ExceptionRecord";
     public static final String EVENT_TYPE_ID = "createException";
@@ -20,11 +24,13 @@ public class CreateExceptionRecord extends AbstractEventPublisher {
     }
 
     public void publish(Envelope envelope) {
+        log.info("Creating exception record for envelope {}", envelope.id);
         publish(envelope, envelope.jurisdiction + "_" + CASE_TYPE, EVENT_TYPE_ID, EVENT_SUMMARY);
     }
 
     /**
      * Exception record does not present any existing case hence the creation of it.
+     *
      * @param envelope Original envelope
      * @return {@code null} as a case reference
      */


### PR DESCRIPTION
Moving logging from the base abstract class that tries to be generic and handle all child classes (more changes to come in next PRs) to the classes that know about what their job is.

### Before
Exception record: `'Creating CreateExceptionRecord for case '` (no ID)
Supplementary evidence: `'Creating AttachDocsToSupplementaryEvidence for case 123456'`

### After
Exception record: `'Creating exception record for envelope XYZ'`
Supplementary evidence: `'Attaching supplementary evidence from envelope XYZ to case 123456'`
