### PR TITLE
Make `AbstractEventPublisher` abstract from `Envelope`

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisher.java
@@ -53,11 +53,17 @@ abstract class AbstractEventPublisher<T> {
     }
 
     protected void publish(T eventSource, String caseTypeId, String eventTypeId, String eventSummary) {
+        // prepare event
         LoggableEvent event = LoggableEvent.getInstance(eventSource);
+
+        // prepare publisher
         String caseRef = getCaseReference(eventSource);
         String jurisdiction = event.getJurisdiction();
 
+        // authenticate
         CcdAuthenticator authenticator = ccdApi.authenticateJurisdiction(jurisdiction);
+
+        // start event
         StartEventResponse startEventResponse = ccdApi.startEvent(
             authenticator,
             jurisdiction,
@@ -66,12 +72,16 @@ abstract class AbstractEventPublisher<T> {
             eventTypeId
         );
         event.logEventStart(eventTypeId, caseRef == null ? "NO_CASE" : caseRef, caseTypeId);
+
+        // build data to send
         CaseDataContent caseDataContent = buildCaseDataContent(
             startEventResponse,
             eventSource,
             eventTypeId,
             eventSummary
         );
+
+        // submit event
         CaseDetails submitEventResponse = ccdApi.submitEvent(
             authenticator,
             jurisdiction,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -12,7 +12,7 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getDocuments;
 
 @Component
-class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
+class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher<Envelope> {
 
     private static final Logger log = LoggerFactory.getLogger(AttachDocsToSupplementaryEvidence.class);
 
@@ -35,10 +35,15 @@ class AttachDocsToSupplementaryEvidence extends AbstractEventPublisher {
     }
 
     @Override
-    CaseData buildCaseData(StartEventResponse eventResponse, Envelope envelope) {
+    String getCaseReference(Envelope eventSource) {
+        return eventSource.caseRef;
+    }
+
+    @Override
+    CaseData buildCaseData(StartEventResponse eventResponse, Envelope eventSource) {
         return mapper.map(
             getDocuments(eventResponse.getCaseDetails()),
-            envelope.documents
+            eventSource.documents
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -9,7 +9,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envel
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 
 @Component
-public class CreateExceptionRecord extends AbstractEventPublisher {
+public class CreateExceptionRecord extends AbstractEventPublisher<Envelope> {
 
     private static final Logger log = LoggerFactory.getLogger(CreateExceptionRecord.class);
 
@@ -30,17 +30,16 @@ public class CreateExceptionRecord extends AbstractEventPublisher {
 
     /**
      * Exception record does not present any existing case hence the creation of it.
-     *
-     * @param envelope Original envelope
+     * @param eventSource Original envelope
      * @return {@code null} as a case reference
      */
     @Override
-    String getCaseRef(Envelope envelope) {
+    String getCaseReference(Envelope eventSource) {
         return null;
     }
 
     @Override
-    CaseData buildCaseData(StartEventResponse eventResponse, Envelope envelope) {
-        return mapper.mapEnvelope(envelope);
+    CaseData buildCaseData(StartEventResponse eventResponse, Envelope eventSource) {
+        return mapper.mapEnvelope(eventSource);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeEvent.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
+
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+
+class EnvelopeEvent implements LoggableEvent<Envelope> {
+
+    private final Envelope envelope;
+
+    EnvelopeEvent(Envelope envelope) {
+        this.envelope = envelope;
+    }
+
+    @Override
+    public Envelope getEventSource() {
+        return envelope;
+    }
+
+    @Override
+    public String getJurisdiction() {
+        return envelope.jurisdiction;
+    }
+
+    @Override
+    public void logPublishStart(String eventClass) {
+        log.info("Starting CCD Event of {} for case {}", eventClass, envelope.caseRef);
+    }
+
+    @Override
+    public void logEventStart(String eventTypeId, String caseRef, String caseTypeId) {
+        log.info(
+            "Started CCD event of type {} for envelope with ID {}, file name {}, case ref {}, case type {}",
+            eventTypeId,
+            envelope.id,
+            envelope.zipFileName,
+            caseRef,
+            caseTypeId
+        );
+    }
+
+    @Override
+    public void logSubmitEvent(String caseTypeId, String eventTypeId, Long submitEventResponseId) {
+        log.info(
+            "Created CCD case of type {} and event of type {}. Envelope ID: {}, file name: {}, case ID: {}",
+            caseTypeId,
+            eventTypeId,
+            envelope.id,
+            envelope.zipFileName,
+            submitEventResponseId
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/LoggableEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/LoggableEvent.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+
+interface LoggableEvent<T> {
+
+    Logger log = LoggerFactory.getLogger(LoggableEvent.class);
+
+    static <V> LoggableEvent getInstance(V eventSource) {
+        if (eventSource instanceof Envelope) {
+            return new EnvelopeEvent((Envelope) eventSource);
+        }
+
+        throw new UnknownEventException(
+            "Could not understand event source of " + eventSource.getClass().getCanonicalName()
+        );
+    }
+
+    T getEventSource();
+
+    String getJurisdiction();
+
+    void logPublishStart(String eventClass);
+
+    void logEventStart(String eventTypeId, String caseRef, String caseTypeId);
+
+    void logSubmitEvent(String caseTypeId, String eventTypeId, Long submitEventResponseId);
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/UnknownEventException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/UnknownEventException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
+
+public class UnknownEventException extends RuntimeException {
+
+    UnknownEventException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AbstractEventPublisherTest.java
@@ -90,9 +90,14 @@ public class AbstractEventPublisherTest {
         );
     }
 
-    protected class TestEventPublisher extends AbstractEventPublisher {
+    protected class TestEventPublisher extends AbstractEventPublisher<Envelope> {
         protected static final String EVENT_TYPE_ID = "test";
         protected static final String EVENT_SUMMARY = "test summary";
+
+        @Override
+        String getCaseReference(Envelope eventSource) {
+            return eventSource.caseRef;
+        }
 
         @Override
         protected CaseData buildCaseData(StartEventResponse eventResponse, Envelope envelope) {


### PR DESCRIPTION
### Change description ###

Second major revamp of `AbstractEventPublisher` following #314. This PR includes complete abstraction of event it is trying to publish. Introducing `Event` kind of object which is wrapper-alike and contains logs. Previously event publisher was tightly coupled with `Envelope` which mostly was useful(was used?) for logging reasons. The rest properties could originate from anywhere.

There is another different object which also "uses" event publisher technique and is entirely unaware of any envelopes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
