### PR TITLE
Remove default connection string from application settings

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,10 +18,10 @@ spring:
 azure:
   servicebus:
     envelopes:
-      connection-string: ${ENVELOPES_QUEUE_CONNECTION_STRING:"NO_VALUE_SUPPLIED"}
+      connection-string: ${ENVELOPES_QUEUE_CONNECTION_STRING}
       queue-name: envelopes
     processed-envelopes:
-      connection-string: ${PROCESSED_ENVELOPES_QUEUE_CONNECTION_STRING:"NO_VALUE_SUPPLIED"}
+      connection-string: ${PROCESSED_ENVELOPES_QUEUE_CONNECTION_STRING}
       queue-name: processed-envelopes
 
 core_case_data:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-445

### Change description ###

Remove default Service Bus connection strings from application settings. Those defaults prevented the application from crashing quickly, failing preview builds.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
