### PR TITLE
Feature: manually dead letter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ task integration(type: Test, description: 'Runs the integration tests.', group: 
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
   failFast = true
+
+  // this will go away once java-logging-appinsights is bumped to 5.x.x
+  environment 'APPINSIGHTS_INSTRUMENTATIONKEY', 'test'
 }
 
 task smoke(type: Test) {

--- a/charts/bulk-scan-orchestrator/values.aat.template.yaml
+++ b/charts/bulk-scan-orchestrator/values.aat.template.yaml
@@ -1,5 +1,6 @@
 java:
   environment:
+    APPINSIGHTS_INSTRUMENTATIONKEY: "00000000-0000-0000-0000-000000000000"
     S2S_NAME: "bulk_scan_orchestrator"
     S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
     IDAM_API_URL: "https://preprod-idamapi.reform.hmcts.net:3511"

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -12,8 +12,6 @@
   </rule>
   <rule ref="category/java/codestyle.xml">
     <exclude name="AtLeastOneConstructor" />
-    <exclude name="CommentDefaultAccessModifier" />
-    <exclude name="DefaultPackage" />
     <exclude name="LocalVariableCouldBeFinal" />
     <exclude name="LongVariable" />
     <exclude name="MethodArgumentCouldBeFinal" />

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -12,6 +12,8 @@
   </rule>
   <rule ref="category/java/codestyle.xml">
     <exclude name="AtLeastOneConstructor" />
+    <exclude name="CommentDefaultAccessModifier" />
+    <exclude name="DefaultPackage" />
     <exclude name="LocalVariableCouldBeFinal" />
     <exclude name="LongVariable" />
     <exclude name="MethodArgumentCouldBeFinal" />

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -60,7 +60,7 @@ locals {
     S2S_SECRET  = "${data.azurerm_key_vault_secret.s2s_secret.value}"
 
     ENVELOPES_QUEUE_CONNECTION_STRING           = "${data.terraform_remote_state.shared_infra.envelopes_queue_primary_listen_connection_string}"
-    ENVELOPES_QUEUE_MAX_DELIVERY_COUNT          = "${data.terraform_remote_state.shared_infra.envelopes_queue_max_delivery_count}"
+    ENVELOPES_QUEUE_MAX_DELIVERY_COUNT          = "${min(data.terraform_remote_state.shared_infra.envelopes_queue_max_delivery_count, var.envelopes_queue_max_delivery_count)}"
     PROCESSED_ENVELOPES_QUEUE_CONNECTION_STRING = "${data.terraform_remote_state.shared_infra.processed_envelopes_queue_primary_send_connection_string}"
 
     IDAM_API_URL              = "${var.idam_api_url}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -60,6 +60,7 @@ locals {
     S2S_SECRET  = "${data.azurerm_key_vault_secret.s2s_secret.value}"
 
     ENVELOPES_QUEUE_CONNECTION_STRING           = "${data.terraform_remote_state.shared_infra.envelopes_queue_primary_listen_connection_string}"
+    ENVELOPES_QUEUE_MAX_DELIVERY_COUNT          = "${data.terraform_remote_state.shared_infra.envelopes_queue_max_delivery_count}"
     PROCESSED_ENVELOPES_QUEUE_CONNECTION_STRING = "${data.terraform_remote_state.shared_infra.processed_envelopes_queue_primary_send_connection_string}"
 
     IDAM_API_URL              = "${var.idam_api_url}"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -3,3 +3,4 @@ idam_api_url = "https://idam-api.platform.hmcts.net"
 idam_client_redirect_uri = "https://rpe-bulk-scan-processor-prod.service.core-compute-prod.internal/oauth2/callback"
 
 delete_envelopes_dlq_messages_enabled = "false"
+envelopes_queue_max_delivery_count = "288" // * 5mins timeout -> at least 24h chance of triage

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -70,3 +70,9 @@ variable "delete_envelopes_dlq_messages_cron" {
 variable "delete_envelopes_dlq_messages_ttl" {
   default = "72h"
 }
+
+variable "envelopes_queue_max_delivery_count" {
+  type = "string"
+  default = "10"
+  description = "Application message consumption limit. Will be favoured in case server value is higher"
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/AppInsights.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/AppInsights.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.logging;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.azure.servicebus.IMessage;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.logging.appinsights.AbstractAppInsights;
+
+@Component
+public class AppInsights extends AbstractAppInsights {
+
+    static final String DEAD_LETTER_EVENT = "DeadLetter";
+
+    public AppInsights(TelemetryClient client) {
+        super(client);
+    }
+
+    public void trackDeadLetteredMessage(IMessage message, String queue, String reason, String description) {
+        telemetry.trackEvent(
+            DEAD_LETTER_EVENT,
+            ImmutableMap.of(
+                "reason", reason,
+                "description", description,
+                "messageId", message.getMessageId(),
+                "queue", queue
+            ),
+            ImmutableMap.of(
+                "deliveryCount", (double) (message.getDeliveryCount() + 1)
+            )
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -155,7 +155,7 @@ public class EnvelopeEventProcessor implements IMessageHandler {
                     deadLetterTheMessage(
                         message,
                         "Too many deliveries",
-                        "Breached the limit of message delivery count of " + deliveryCount
+                        "Reached limit of message delivery count of " + deliveryCount
                     );
                 }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -144,7 +144,7 @@ public class EnvelopeEventProcessor implements IMessageHandler {
             case POTENTIALLY_RECOVERABLE_FAILURE:
                 int deliveryCount = (int) message.getDeliveryCount() + 1;
 
-                if (deliveryCount < maxDeliveryCount - 5) {
+                if (deliveryCount < maxDeliveryCount) {
                     // do nothing - let the message lock expire
                     log.info(
                         "Allowing message with ID {} to return to queue (delivery attempt {})",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -136,6 +136,7 @@ public class EnvelopeEventProcessor implements IMessageHandler {
                     processingResult.exception.getMessage()
                 );
 
+                // log used for alert
                 log.info("Message with ID {} has been dead-lettered", message.getMessageId());
                 break;
             case POTENTIALLY_RECOVERABLE_FAILURE:
@@ -155,6 +156,7 @@ public class EnvelopeEventProcessor implements IMessageHandler {
                         "Breached the limit of message delivery count of " + deliveryCount
                     );
 
+                    // log used for alert
                     log.info("Message with ID {} has been dead-lettered", message.getMessageId());
                 }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,7 @@ azure:
     envelopes:
       connection-string: ${ENVELOPES_QUEUE_CONNECTION_STRING}
       queue-name: envelopes
+      max-delivery-count: ${ENVELOPES_QUEUE_MAX_DELIVERY_COUNT:10}
     processed-envelopes:
       connection-string: ${PROCESSED_ENVELOPES_QUEUE_CONNECTION_STRING}
       queue-name: processed-envelopes

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/AppInsightsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/AppInsightsTest.java
@@ -1,0 +1,62 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.logging;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.telemetry.TelemetryContext;
+import com.microsoft.azure.servicebus.IMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AppInsightsTest {
+
+    @Mock
+    private IMessage message;
+
+    @Mock
+    private TelemetryClient telemetryClient;
+
+    private AppInsights appInsights;
+
+    @BeforeEach
+    void setUp() {
+        TelemetryContext telemetryContext = new TelemetryContext();
+        telemetryContext.setInstrumentationKey("test");
+        when(telemetryClient.getContext()).thenReturn(telemetryContext);
+
+        appInsights = new AppInsights(telemetryClient);
+    }
+
+    @Test
+    void should_record_dead_letter_event() {
+        String messageId = "message id";
+        long deliveryCount = 5;
+        String queue = "queue name";
+        String reason = "some reason";
+        String description = "some description";
+
+        when(message.getMessageId()).thenReturn(messageId);
+        when(message.getDeliveryCount()).thenReturn(deliveryCount);
+
+        appInsights.trackDeadLetteredMessage(message, queue, reason, description);
+
+        verify(telemetryClient).trackEvent(
+            AppInsights.DEAD_LETTER_EVENT,
+            ImmutableMap.of(
+                "reason", reason,
+                "description", description,
+                "messageId", messageId,
+                "queue", queue
+            ),
+            ImmutableMap.of(
+                "deliveryCount", (double) (deliveryCount + 1)
+            )
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -183,7 +183,7 @@ public class EnvelopeEventProcessorTest {
     }
 
     @Test
-    public void should_not_finalize_the_message_when_recoverable_failure() throws Exception {
+    public void should_not_finalize_the_message_when_recoverable_failure() {
         Exception processingFailureCause = new RuntimeException(
             "exception of type treated as recoverable"
         );
@@ -243,7 +243,7 @@ public class EnvelopeEventProcessorTest {
     }
 
     @Test
-    public void should_send_message_with_envelope_id_when_processing_successful() throws Exception {
+    public void should_send_message_with_envelope_id_when_processing_successful() {
         // given
         String envelopeId = UUID.randomUUID().toString();
         IMessage message = mock(IMessage.class);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -225,13 +225,13 @@ public class EnvelopeEventProcessorTest {
         verify(messageOperations).deadLetter(
             someMessage.getLockToken(),
             "Too many deliveries",
-            "Breached the limit of message delivery count of 1"
+            "Reached limit of message delivery count of 1"
         );
         verify(appInsights).trackDeadLetteredMessage(
             someMessage,
             "envelopes",
             "Too many deliveries",
-            "Breached the limit of message delivery count of 1"
+            "Reached limit of message delivery count of 1"
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -207,7 +207,7 @@ public class EnvelopeEventProcessorTest {
             eventPublisherContainer,
             processedEnvelopeNotifier,
             messageOperations,
-            5,
+            1,
             appInsights
         );
         Exception processingFailureCause = new RuntimeException(


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DLQ Notification](https://tools.hmcts.net/jira/browse/BPS-532)

### Change description ###

Using output of max delivery count introduced since hmcts/bulk-scan-shared-infrastructure#78.

Joining two placements of deadlettering into one method and introducing `AppInsights` custom event so that querying azure will be separate from tons of traces. Efficient and more info can be added. This is first sample of what could be pushed and enough to have as ground base information

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
