### PR TITLE
Extract a service for checking jurisdiction-specific authentication in Idam

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/endpoints/IdamConfigStatusEndpointTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/endpoints/IdamConfigStatusEndpointTest.java
@@ -37,14 +37,16 @@ public class IdamConfigStatusEndpointTest {
         assertThat(responseNode.isArray()).isTrue();
         assertThat(ImmutableList.copyOf(responseNode.elements())).hasSize(1);
 
+        JsonNode statusNode = responseNode.get(0);
+
         JurisdictionConfigurationStatus actual = new JurisdictionConfigurationStatus(
-            responseNode.get(0).get("jurisdiction").asText(),
-            responseNode.get(0).get("is_correct").asBoolean(),
-            responseNode.get(0).get("error_description").isNull() ? null : "must be null - failure"
+            statusNode.get("jurisdiction").asText(),
+            statusNode.get("is_correct").asBoolean(),
+            statusNode.get("error_description").isNull() ? null : statusNode.get("error_description").asText()
         );
 
         assertThat(actual).isEqualToComparingFieldByField(
-            new JurisdictionConfigurationStatus("bulkscan", true)
+            new JurisdictionConfigurationStatus("bulkscan", true, null)
         );
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/endpoints/IdamConfigStatusEndpointTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/endpoints/IdamConfigStatusEndpointTest.java
@@ -42,11 +42,12 @@ public class IdamConfigStatusEndpointTest {
         JurisdictionConfigurationStatus actual = new JurisdictionConfigurationStatus(
             statusNode.get("jurisdiction").asText(),
             statusNode.get("is_correct").asBoolean(),
-            statusNode.get("error_description").isNull() ? null : statusNode.get("error_description").asText()
+            statusNode.get("error_description").isNull() ? null : statusNode.get("error_description").asText(),
+            statusNode.get("error_response_status").isNull() ? null : statusNode.get("error_response_status").asInt()
         );
 
         assertThat(actual).isEqualToComparingFieldByField(
-            new JurisdictionConfigurationStatus("bulkscan", true, null)
+            new JurisdictionConfigurationStatus("bulkscan", true, null, null)
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/endpoints/IdamConfigStatusEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/endpoints/IdamConfigStatusEndpoint.java
@@ -1,83 +1,31 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.endpoints;
 
-import feign.FeignException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.out.JurisdictionConfigurationStatus;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.Credential;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.JurisdictionToUserMapping;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.NoUserConfiguredException;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AuthenticationChecker;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Component
 @Endpoint(id = "idam-config-status")
-@EnableConfigurationProperties(JurisdictionToUserMapping.class)
 public class IdamConfigStatusEndpoint {
 
-    private static final Logger log = LoggerFactory.getLogger(IdamConfigStatusEndpoint.class);
+    private final AuthenticationChecker authenticationChecker;
 
-    private final JurisdictionToUserMapping jurisdictionMapping;
-    private final IdamClient idamClient;
-
-    public IdamConfigStatusEndpoint(
-        JurisdictionToUserMapping mapping,
-        IdamClient idamClient
-    ) {
-        jurisdictionMapping = mapping;
-        this.idamClient = idamClient;
+    public IdamConfigStatusEndpoint(AuthenticationChecker authenticationChecker) {
+        this.authenticationChecker = authenticationChecker;
     }
 
     @ReadOperation
     public List<JurisdictionConfigurationStatus> jurisdictions() {
-        return jurisdictionMapping.getUsers()
-            .entrySet()
-            .stream()
-            .map(entry -> checkCredentials(entry.getKey(), entry.getValue()))
-            .collect(Collectors.toList());
+        return authenticationChecker.checkSignInForAllJurisdictions();
     }
 
     @ReadOperation
     public JurisdictionConfigurationStatus jurisdiction(@Selector String jurisdiction) {
-        try {
-            return checkCredentials(jurisdiction, jurisdictionMapping.getUser(jurisdiction));
-        } catch (NoUserConfiguredException exception) {
-            return new JurisdictionConfigurationStatus(jurisdiction, false, exception.getMessage());
-        }
-    }
-
-    private JurisdictionConfigurationStatus checkCredentials(String jurisdiction, Credential credential) {
-        try {
-            idamClient.authenticateUser(credential.getUsername(), credential.getPassword());
-
-            log.debug("Successful authentication of {} jurisdiction", jurisdiction);
-
-            return new JurisdictionConfigurationStatus(jurisdiction, true);
-        } catch (FeignException exception) {
-            log.warn(
-                "An error occurred while authenticating {} jurisdiction with {} username",
-                jurisdiction,
-                credential.getUsername(),
-                exception
-            );
-
-            return new JurisdictionConfigurationStatus(jurisdiction, false, exception.getMessage());
-        } catch (Exception exception) {
-            log.error(
-                "An error occurred while authenticating {} jurisdiction with {} username",
-                jurisdiction,
-                credential.getUsername(),
-                exception
-            );
-
-            return new JurisdictionConfigurationStatus(jurisdiction, false, exception.getMessage());
-        }
+        return authenticationChecker.checkSignInForJurisdiction(jurisdiction);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/out/JurisdictionConfigurationStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/out/JurisdictionConfigurationStatus.java
@@ -12,20 +12,25 @@ public class JurisdictionConfigurationStatus {
     @JsonProperty("error_description")
     public final String errorDescription;
 
+    @JsonProperty("error_response_status")
+    public final Integer errorResponseStatus;
+
     public JurisdictionConfigurationStatus(
         String jurisdiction,
         boolean isCorrect,
-        String errorDescription
+        String errorDescription,
+        Integer errorResponseStatus
     ) {
         this.jurisdiction = jurisdiction;
         this.isCorrect = isCorrect;
         this.errorDescription = errorDescription;
+        this.errorResponseStatus = errorResponseStatus;
     }
 
     public JurisdictionConfigurationStatus(
         String jurisdiction,
         boolean isCorrect
     ) {
-        this(jurisdiction, isCorrect, null);
+        this(jurisdiction, isCorrect, null, null);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationChecker.java
@@ -41,7 +41,7 @@ public class AuthenticationChecker {
         try {
             return checkSignIn(jurisdiction, jurisdictionMapping.getUser(jurisdiction));
         } catch (NoUserConfiguredException exception) {
-            return new JurisdictionConfigurationStatus(jurisdiction, false, exception.getMessage());
+            return new JurisdictionConfigurationStatus(jurisdiction, false, exception.getMessage(), null);
         }
     }
 
@@ -52,24 +52,24 @@ public class AuthenticationChecker {
             log.debug("Successful authentication of {} jurisdiction", jurisdiction);
 
             return new JurisdictionConfigurationStatus(jurisdiction, true);
-        } catch (FeignException exception) {
+        } catch (FeignException e) {
             log.warn(
                 "An error occurred while authenticating {} jurisdiction with {} username",
                 jurisdiction,
                 credential.getUsername(),
-                exception
+                e
             );
 
-            return new JurisdictionConfigurationStatus(jurisdiction, false, exception.getMessage());
-        } catch (Exception exception) {
+            return new JurisdictionConfigurationStatus(jurisdiction, false, e.getMessage(), e.status());
+        } catch (Exception e) {
             log.error(
                 "An error occurred while authenticating {} jurisdiction with {} username",
                 jurisdiction,
                 credential.getUsername(),
-                exception
+                e
             );
 
-            return new JurisdictionConfigurationStatus(jurisdiction, false, exception.getMessage());
+            return new JurisdictionConfigurationStatus(jurisdiction, false, e.getMessage(), null);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationChecker.java
@@ -1,0 +1,75 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam;
+
+import feign.FeignException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.endpoints.IdamConfigStatusEndpoint;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.out.JurisdictionConfigurationStatus;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@EnableConfigurationProperties(JurisdictionToUserMapping.class)
+public class AuthenticationChecker {
+
+    private static final Logger log = LoggerFactory.getLogger(IdamConfigStatusEndpoint.class);
+
+    private final JurisdictionToUserMapping jurisdictionMapping;
+    private final IdamClient idamClient;
+
+    public AuthenticationChecker(
+        JurisdictionToUserMapping jurisdictionMapping,
+        IdamClient idamClient
+    ) {
+        this.jurisdictionMapping = jurisdictionMapping;
+        this.idamClient = idamClient;
+    }
+
+    public List<JurisdictionConfigurationStatus> checkSignInForAllJurisdictions() {
+        return jurisdictionMapping.getUsers()
+            .entrySet()
+            .stream()
+            .map(entry -> checkSignIn(entry.getKey(), entry.getValue()))
+            .collect(Collectors.toList());
+    }
+
+    public JurisdictionConfigurationStatus checkSignInForJurisdiction(String jurisdiction) {
+        try {
+            return checkSignIn(jurisdiction, jurisdictionMapping.getUser(jurisdiction));
+        } catch (NoUserConfiguredException exception) {
+            return new JurisdictionConfigurationStatus(jurisdiction, false, exception.getMessage());
+        }
+    }
+
+    private JurisdictionConfigurationStatus checkSignIn(String jurisdiction, Credential credential) {
+        try {
+            idamClient.authenticateUser(credential.getUsername(), credential.getPassword());
+
+            log.debug("Successful authentication of {} jurisdiction", jurisdiction);
+
+            return new JurisdictionConfigurationStatus(jurisdiction, true);
+        } catch (FeignException exception) {
+            log.warn(
+                "An error occurred while authenticating {} jurisdiction with {} username",
+                jurisdiction,
+                credential.getUsername(),
+                exception
+            );
+
+            return new JurisdictionConfigurationStatus(jurisdiction, false, exception.getMessage());
+        } catch (Exception exception) {
+            log.error(
+                "An error occurred while authenticating {} jurisdiction with {} username",
+                jurisdiction,
+                credential.getUsername(),
+                exception
+            );
+
+            return new JurisdictionConfigurationStatus(jurisdiction, false, exception.getMessage());
+        }
+    }
+}

--- a/src/smokeTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/IdamConfigStatusTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/IdamConfigStatusTest.java
@@ -6,7 +6,6 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.out.JurisdictionConfigurationStatus;
 import uk.gov.hmcts.reform.logging.appinsights.SyntheticHeaders;
 
 import java.io.IOException;
@@ -32,20 +31,17 @@ public class IdamConfigStatusTest {
         ObjectMapper mapper = new ObjectMapper();
 
         mapper.readTree(response).elements().forEachRemaining(responseStatus -> {
-            JurisdictionConfigurationStatus status = new JurisdictionConfigurationStatus(
-                responseStatus.get("jurisdiction").asText(),
-                responseStatus.get("is_correct").asBoolean(),
-                responseStatus.get("error_description").asText()
-            );
+            String jurisdiction = responseStatus.get("jurisdiction").asText();
+            boolean isCorrect = responseStatus.get("is_correct").asBoolean();
+            String errorDescription = responseStatus.get("error_description").asText();
 
-            assertThat(status.isCorrect)
+            assertThat(isCorrect)
                 .withFailMessage(
                     "Misconfigured %s jurisdiction, error description: %s. Check the logs for more details",
-                    status.jurisdiction,
-                    status.errorDescription
+                    jurisdiction,
+                    errorDescription
                 )
                 .isTrue();
-            }
-        );
+        });
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/endpoints/IdamConfigStatusEndpointTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/endpoints/IdamConfigStatusEndpointTest.java
@@ -1,130 +1,62 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.endpoints;
 
-import com.google.common.collect.ImmutableMap;
-import feign.FeignException;
-import feign.Request;
-import feign.Response;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.out.JurisdictionConfigurationStatus;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.JurisdictionToUserMapping;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AuthenticationChecker;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.never;
-import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.willReturn;
-import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-@ExtendWith(MockitoExtension.class)
+@RunWith(MockitoJUnitRunner.class)
 public class IdamConfigStatusEndpointTest {
 
-    private static final String VALID_JURISDICTION = "jurisdiction";
-
-    private static final String INVALID_JURISDICTION = "something else";
-
-    private static final JurisdictionConfigurationStatus VALID_RESPONSE = new JurisdictionConfigurationStatus(
-        VALID_JURISDICTION, true
-    );
-
-    private static final JurisdictionConfigurationStatus INVALID_RESPONSE = new JurisdictionConfigurationStatus(
-        INVALID_JURISDICTION, false, "oh no"
-    );
-
     @Mock
-    private IdamClient idamClient;
+    private AuthenticationChecker authenticationChecker;
 
     private IdamConfigStatusEndpoint endpoint;
 
-    @BeforeEach
+    @Before
     public void setUp() {
-        Map<String, Map<String, String>> users = ImmutableMap.of(
-            VALID_JURISDICTION, ImmutableMap.of(
-                "username", "username",
-                "password", "password"
-            ),
-            INVALID_JURISDICTION, ImmutableMap.of(
-                "username", "user",
-                "password", "pass"
-            )
-        );
-        JurisdictionToUserMapping mapping = new JurisdictionToUserMapping();
-        mapping.setUsers(users);
-
-        endpoint = new IdamConfigStatusEndpoint(mapping, idamClient);
+        endpoint = new IdamConfigStatusEndpoint(authenticationChecker);
     }
 
-    @DisplayName("Should respond with status message stating given jurisdiction is correctly configured")
     @Test
-    public void should_respond_accordingly_for_correct_jurisdiction_config() {
-        willReturn("token").given(idamClient).authenticateUser("username", "password");
+    public void jurisdiction_should_call_authenticator_to_get_result() {
+        // given
+        String jurisdiction = "jurisdiction1";
+        JurisdictionConfigurationStatus expectedStatus = mock(JurisdictionConfigurationStatus.class);
+        willReturn(expectedStatus).given(authenticationChecker).checkSignInForJurisdiction(jurisdiction);
 
-        assertThat(endpoint.jurisdiction(VALID_JURISDICTION)).isEqualToComparingFieldByField(VALID_RESPONSE);
+        // when
+        JurisdictionConfigurationStatus returnedStatus = endpoint.jurisdiction(jurisdiction);
+
+        // then
+        assertThat(returnedStatus).isSameAs(expectedStatus);
+        verify(authenticationChecker).checkSignInForJurisdiction(jurisdiction);
     }
 
-    @DisplayName("Should respond with expected status given jurisdiction is configured incorrectly")
     @Test
-    public void should_respond_accordingly_for_incorrect_jurisdiction_config() {
-        willThrow(new RuntimeException("oh no")).given(idamClient).authenticateUser("user", "pass");
+    public void jurisdictions_should_call_authenticator_to_get_result() {
+        // given
+        List<JurisdictionConfigurationStatus> expectedStatuses =
+            Arrays.asList(mock(JurisdictionConfigurationStatus.class));
 
-        assertThat(endpoint.jurisdiction(INVALID_JURISDICTION)).isEqualToComparingFieldByField(INVALID_RESPONSE);
-    }
+        willReturn(expectedStatuses).given(authenticationChecker).checkSignInForAllJurisdictions();
 
-    @DisplayName("Should respond with expected status given jurisdiction does not exist in the configuration setup")
-    @Test
-    public void should_respond_accordingly_for_jurisdiction_which_is_not_present_in_config() {
-        assertThat(endpoint.jurisdiction("not give access")).isEqualToComparingFieldByField(
-            new JurisdictionConfigurationStatus(
-                "not give access",
-                false,
-                "No user configured for jurisdiction: not give access"
-            )
-        );
-        verify(idamClient, never()).authenticateUser(anyString(), anyString());
-    }
+        // when
+        List<JurisdictionConfigurationStatus> returnedStatuses = endpoint.jurisdictions();
 
-    @DisplayName("Should respond with all configured jurisdictions and not crash with exceptions")
-    @Test
-    public void should_respond_without_failure_when_requesting_info_on_all_jurisdictions() {
-        willReturn("token").given(idamClient).authenticateUser("username", "password");
-        willThrow(new RuntimeException("oh no")).given(idamClient).authenticateUser("user", "pass");
-
-        assertThat(endpoint.jurisdictions())
-            .usingRecursiveFieldByFieldElementComparator()
-            .containsExactly(VALID_RESPONSE, INVALID_RESPONSE);
-    }
-
-    @DisplayName("Should respond with status message for given jurisdiction in case FeignException is received")
-    @Test
-    public void should_respond_as_incorrect_setup_when_feign_client_exception_is_received() {
-        FeignException exception = FeignException
-            .errorStatus("method key", Response
-                .builder()
-                .request(Mockito.mock(Request.class))
-                .body(new byte[0])
-                .headers(Collections.emptyMap())
-                .status(HttpStatus.FORBIDDEN.value())
-                .build()
-            );
-
-        willThrow(exception).given(idamClient).authenticateUser("user", "pass");
-
-        // not asserting an object as depends on feign version what message it has inside.
-        // plus it is not of importance for unit test.
-        // we have other cases covering the fact description is provided as expected.
-        assertThat(endpoint.jurisdiction(INVALID_JURISDICTION))
-            .extracting("jurisdiction", "isCorrect")
-            .containsExactly(tuple(INVALID_JURISDICTION, false).toArray());
+        // then
+        assertThat(returnedStatuses).isEqualTo(expectedStatuses);
+        verify(authenticationChecker).checkSignInForAllJurisdictions();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationCheckerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationCheckerTest.java
@@ -1,0 +1,161 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam;
+
+import com.google.common.collect.ImmutableMap;
+import feign.FeignException;
+import feign.Request;
+import feign.Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.out.JurisdictionConfigurationStatus;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuthenticationCheckerTest {
+
+    private static final String SUCCESSFUL_JURISDICTION = "jurisdiction";
+    private static final String SUCCESSFUL_JURISDICTION_USERNAME = "username1";
+    private static final String SUCCESSFUL_JURISDICTION_PASSWORD = "password1";
+
+    private static final String LOCKED_ACCOUNT_JURISDICTION = "locked";
+    private static final String LOCKED_ACCOUNT_JURISDICTION_USERNAME = "username2";
+    private static final String LOCKED_ACCOUNT_JURISDICTION_PASSWORD = "password2";
+
+    private static final Map<String, Map<String, String>> USERS = ImmutableMap.of(
+        SUCCESSFUL_JURISDICTION, ImmutableMap.of(
+            "username", SUCCESSFUL_JURISDICTION_USERNAME,
+            "password", SUCCESSFUL_JURISDICTION_PASSWORD
+        ),
+        LOCKED_ACCOUNT_JURISDICTION, ImmutableMap.of(
+            "username", LOCKED_ACCOUNT_JURISDICTION_USERNAME,
+            "password", LOCKED_ACCOUNT_JURISDICTION_PASSWORD
+        )
+    );
+
+    @Mock
+    private IdamClient idamClient;
+
+    private AuthenticationChecker authenticationChecker;
+
+    @Before
+    public void setUp() {
+        JurisdictionToUserMapping mapping = new JurisdictionToUserMapping();
+        mapping.setUsers(USERS);
+
+        authenticationChecker = new AuthenticationChecker(mapping, idamClient);
+    }
+
+    @Test
+    public void checkSignInForJurisdiction_should_return_success_for_successfully_authenticated_jurisdiction() {
+        willReturn("token")
+            .given(idamClient)
+            .authenticateUser(
+                SUCCESSFUL_JURISDICTION_USERNAME,
+                SUCCESSFUL_JURISDICTION_PASSWORD
+            );
+
+
+        JurisdictionConfigurationStatus status =
+            authenticationChecker.checkSignInForJurisdiction(SUCCESSFUL_JURISDICTION);
+
+        assertThat(status.jurisdiction).isEqualTo(SUCCESSFUL_JURISDICTION);
+        assertThat(status.isCorrect).isTrue();
+        assertThat(status.errorDescription).isNull();
+    }
+
+    @Test
+    public void checkSignInForJurisdiction_should_return_failure_for_unsuccessfully_authenticated_jurisdiction() {
+        FeignException exception = createFeignException(HttpStatus.LOCKED.value());
+
+        willThrow(exception)
+            .given(idamClient)
+            .authenticateUser(LOCKED_ACCOUNT_JURISDICTION_USERNAME, LOCKED_ACCOUNT_JURISDICTION_PASSWORD);
+
+        JurisdictionConfigurationStatus status =
+            authenticationChecker.checkSignInForJurisdiction(LOCKED_ACCOUNT_JURISDICTION);
+
+        assertThat(status.jurisdiction).isEqualTo(LOCKED_ACCOUNT_JURISDICTION);
+        assertThat(status.isCorrect).isFalse();
+        assertThat(status.errorDescription).isEqualTo(exception.getMessage());
+    }
+
+    @Test
+    public void checkSignInForJurisdiction_should_return_failure_for_jurisdiction_missing_in_config() {
+        String unknownJurisdiction = "unknown";
+
+        assertThat(
+            authenticationChecker.checkSignInForJurisdiction(unknownJurisdiction)
+        )
+            .isEqualToComparingFieldByField(
+                new JurisdictionConfigurationStatus(
+                    unknownJurisdiction,
+                    false,
+                    String.format("No user configured for jurisdiction: %s", unknownJurisdiction)
+                )
+            );
+
+        verify(idamClient, never()).authenticateUser(anyString(), anyString());
+    }
+
+    @Test
+    public void checkSignInForJurisdiction_should_return_failure_when_idam_call_fails() {
+        String errorMessage = "test exception";
+        RuntimeException exception = new RuntimeException(errorMessage);
+
+        willThrow(exception).given(idamClient).authenticateUser(any(), any());
+
+        assertThat(authenticationChecker.checkSignInForJurisdiction(LOCKED_ACCOUNT_JURISDICTION))
+            .isEqualToComparingFieldByField(new JurisdictionConfigurationStatus(
+                LOCKED_ACCOUNT_JURISDICTION,
+                false,
+                errorMessage
+            ));
+    }
+
+    @Test
+    public void checkSignInForAllJurisdictions_should_return_statuses_of_all_jurisdictions() {
+        willReturn("token")
+            .given(idamClient)
+            .authenticateUser(SUCCESSFUL_JURISDICTION_USERNAME, SUCCESSFUL_JURISDICTION_PASSWORD);
+
+        willThrow(createFeignException(HttpStatus.LOCKED.value()))
+            .given(idamClient)
+            .authenticateUser(LOCKED_ACCOUNT_JURISDICTION_USERNAME, LOCKED_ACCOUNT_JURISDICTION_PASSWORD);
+
+        assertThat(authenticationChecker.checkSignInForAllJurisdictions())
+            .extracting(status -> tuple(status.jurisdiction, status.isCorrect))
+            .containsExactlyInAnyOrder(
+                tuple(SUCCESSFUL_JURISDICTION, true),
+                tuple(LOCKED_ACCOUNT_JURISDICTION, false)
+            )
+            .as("Result should contain a correct entry for each configured jurisdiction");
+    }
+
+    private FeignException createFeignException(int httpStatus) {
+        return FeignException
+            .errorStatus("method1", Response
+                .builder()
+                .request(mock(Request.class))
+                .body(new byte[0])
+                .headers(Collections.emptyMap())
+                .status(httpStatus)
+                .build()
+            );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationCheckerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationCheckerTest.java
@@ -77,6 +77,7 @@ public class AuthenticationCheckerTest {
         assertThat(status.jurisdiction).isEqualTo(SUCCESSFUL_JURISDICTION);
         assertThat(status.isCorrect).isTrue();
         assertThat(status.errorDescription).isNull();
+        assertThat(status.errorResponseStatus).isNull();
     }
 
     @Test
@@ -92,6 +93,7 @@ public class AuthenticationCheckerTest {
 
         assertThat(status.jurisdiction).isEqualTo(LOCKED_ACCOUNT_JURISDICTION);
         assertThat(status.isCorrect).isFalse();
+        assertThat(status.errorResponseStatus).isEqualTo(HttpStatus.LOCKED.value());
         assertThat(status.errorDescription).isEqualTo(exception.getMessage());
     }
 
@@ -106,7 +108,8 @@ public class AuthenticationCheckerTest {
                 new JurisdictionConfigurationStatus(
                     unknownJurisdiction,
                     false,
-                    String.format("No user configured for jurisdiction: %s", unknownJurisdiction)
+                    String.format("No user configured for jurisdiction: %s", unknownJurisdiction),
+                    null
                 )
             );
 
@@ -124,7 +127,8 @@ public class AuthenticationCheckerTest {
             .isEqualToComparingFieldByField(new JurisdictionConfigurationStatus(
                 LOCKED_ACCOUNT_JURISDICTION,
                 false,
-                errorMessage
+                errorMessage,
+                null
             ));
     }
 
@@ -139,10 +143,10 @@ public class AuthenticationCheckerTest {
             .authenticateUser(LOCKED_ACCOUNT_JURISDICTION_USERNAME, LOCKED_ACCOUNT_JURISDICTION_PASSWORD);
 
         assertThat(authenticationChecker.checkSignInForAllJurisdictions())
-            .extracting(status -> tuple(status.jurisdiction, status.isCorrect))
+            .extracting(status -> tuple(status.jurisdiction, status.isCorrect, status.errorResponseStatus))
             .containsExactlyInAnyOrder(
-                tuple(SUCCESSFUL_JURISDICTION, true),
-                tuple(LOCKED_ACCOUNT_JURISDICTION, false)
+                tuple(SUCCESSFUL_JURISDICTION, true, null),
+                tuple(LOCKED_ACCOUNT_JURISDICTION, false, HttpStatus.LOCKED.value())
             )
             .as("Result should contain a correct entry for each configured jurisdiction");
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-563

### Change description ###

Extract a service for checking jurisdiction-specific authentication in Idam.

This functionality is needed to be accessible from code, as the status will determine whether to pause processing messages and for how long.

Also, add `errorResponseStatus` field to `JurisdictionConfigurationStatus` - the pausing decision will be made based on this field.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
