### PR TITLE
Stop retrying to connect to Service Bus queue

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/QueueConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/QueueConfig.java
@@ -1,11 +1,9 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.config;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.microsoft.azure.servicebus.IMessageHandler;
 import com.microsoft.azure.servicebus.MessageHandlerOptions;
 import com.microsoft.azure.servicebus.QueueClient;
-import com.microsoft.azure.servicebus.primitives.MessagingEntityNotFoundException;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +15,6 @@ import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
 
 /**
@@ -50,31 +47,10 @@ public class QueueConfig {
             namedThreadFactory
         );
 
-        // Note: retry init otherwise AKS setup fails as a queue is
-        // created in that environment only after deployment is complete.
-        int tries = 0;
-        while (true) {
-            try {
-                envelopesQueueClient.registerMessageHandler(
-                    messageHandler,
-                    new MessageHandlerOptions(1, false, Duration.ofMinutes(5)),
-                    executorService
-                );
-
-                return;
-            } catch (UnsupportedOperationException e) {
-                log.info("Register handler error: {}.", e.getMessage());
-                // trying to register again, ignore
-                return;
-            } catch (MessagingEntityNotFoundException e) {
-                tries++;
-                if (tries >= 5) {
-                    throw e;
-                }
-                log.info("Register handler error: {}. Retrying...", e.getMessage());
-                Uninterruptibles.sleepUninterruptibly(10L * tries, TimeUnit.SECONDS);
-            }
-        }
+        envelopesQueueClient.registerMessageHandler(
+            messageHandler,
+            new MessageHandlerOptions(1, false, Duration.ofMinutes(5)),
+            executorService
+        );
     }
-
 }


### PR DESCRIPTION
### Change description ###

Stop retrying to connect to Service Bus queue

This was necessary before Helm charts, but now it causes problems, as the application pretends to be healthy while being unable to connect to Service Bus (possibly not even having the connection string).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
