### PR TITLE
Downgrade azurerm provider to version 1.22.1

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "1.23.0"
+  version = "=1.22.1"
 }
 
 # Make sure the resource group exists


### PR DESCRIPTION
### Change description ###

Downgrade azurerm provider to version 1.22.1

Version 1.23.0 causes common problems.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
