### PR TITLE
Add extra info to error

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
@@ -305,13 +305,14 @@ class AttachExceptionRecordToExistingCaseTest {
 
     @Test
     void should_fail_when_exception_record_is_already_attached_to_a_case() throws Exception {
+        String caseRef = "1234567890123456";
         givenThat(
             ccdGetExceptionRecord()
                 .willReturn(
                     // return an exception record already attached to some case
                     okJson(
                         MAPPER.writeValueAsString(
-                            exceptionRecordDetails("1234567890123456")
+                            exceptionRecordDetails(caseRef)
                         )
                     )
                 )
@@ -322,7 +323,7 @@ class AttachExceptionRecordToExistingCaseTest {
             .post("/callback/{type}", "attach_case")
             .then()
             .statusCode(200)
-            .body("errors", hasItem("Exception record is already attached to a case"));
+            .body("errors", hasItem("Exception record is already attached to case " + caseRef));
     }
 
     @DisplayName("Should create error if type in incorrect")

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -115,8 +115,10 @@ public class AttachCaseCallbackService {
             exceptionRecordJurisdiction
         );
 
-        if (isExceptionRecordAttachedToCase(fetchedExceptionRecord)) {
-            throw new AlreadyAttachedToCaseException("Exception record is already attached to a case");
+        Object attachToCaseRef = fetchedExceptionRecord.getData().get(ATTACH_CASE_REFERENCE_FIELD_NAME);
+
+        if (attachToCaseRef != null && Strings.isNotEmpty(attachToCaseRef.toString())) {
+            throw new AlreadyAttachedToCaseException("Exception record is already attached to case " + attachToCaseRef);
         }
     }
 
@@ -155,11 +157,4 @@ public class AttachCaseCallbackService {
         );
     }
 
-    private boolean isExceptionRecordAttachedToCase(CaseDetails exceptionRecordDetails) {
-        Object attachToCaseReference = exceptionRecordDetails
-            .getData()
-            .get(ATTACH_CASE_REFERENCE_FIELD_NAME);
-
-        return attachToCaseReference != null && Strings.isNotEmpty(attachToCaseReference.toString());
-    }
 }


### PR DESCRIPTION
When user tries to attach exception record to a case when it's already attached
provide the ref number of that case.