### PR TITLE
Create a service for checking if jurisdictions' accounts are not locked

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,10 +156,11 @@ repositories {
 // it is important to specify logback classic and core packages explicitly as libraries like spring boot
 // enforces it's own (older) version which is not recommended.
 def versions = [
-  reformLogging   : '5.0.1',
-  springBoot      : springBoot.class.package.implementationVersion,
-  springfoxSwagger: '2.9.2',
-  junit           : '5.3.2'
+  reformLogging     : '5.0.1',
+  springBoot        : springBoot.class.package.implementationVersion,
+  springHystrix     : '2.1.1.RELEASE',
+  springfoxSwagger  : '2.9.2',
+  junit             : '5.3.2'
 ]
 
 dependencyManagement {
@@ -188,6 +189,7 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: versions.springBoot
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-json', version: versions.springBoot
+  compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: versions.springHystrix
 
   compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
@@ -199,7 +201,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.6.2'
   compile group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version:'0.0.3'
   compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version:'0.0.4'
-  
+
   compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.8'
   compile group: 'io.vavr', name: 'vavr', version: '0.10.0'
 

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -37,3 +37,7 @@ idam:
 
 document_management.url: http://dm-store:4460
 test-url: ${TEST_URL:http://localhost:8582}
+
+task:
+  check-no-account-locked:
+    check-validity-duration: PT5M

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/QueueProcessingReadinessCheckerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/QueueProcessingReadinessCheckerTest.java
@@ -1,0 +1,89 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.config.IntegrationTest;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.out.JurisdictionConfigurationStatus;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AuthenticationChecker;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(SpringExtension.class)
+@IntegrationTest
+public class QueueProcessingReadinessCheckerTest {
+
+    private static final List<JurisdictionConfigurationStatus> STATUS_WITHOUT_ANY_LOCKED_ACCOUNT =
+        ImmutableList.of(
+            new JurisdictionConfigurationStatus(
+                "jurisdiction1",
+                false,
+                "forbidden",
+                HttpStatus.FORBIDDEN.value()
+            ),
+            new JurisdictionConfigurationStatus(
+                "jurisdiction2",
+                true
+            )
+        );
+
+    private static final List<JurisdictionConfigurationStatus> STATUS_WITH_LOCKED_ACCOUNT =
+        ImmutableList.of(
+            new JurisdictionConfigurationStatus(
+                "jurisdiction1",
+                false,
+                "locked",
+                HttpStatus.LOCKED.value()
+            )
+        );
+
+    @SpyBean
+    private AuthenticationChecker authenticationChecker;
+
+    @Autowired
+    private QueueProcessingReadinessChecker queueProcessingReadinessChecker;
+
+    @Test
+    public void should_start_returning_false_when_account_gets_locked() throws Exception {
+        given(authenticationChecker.checkSignInForAllJurisdictions())
+            .willReturn(STATUS_WITHOUT_ANY_LOCKED_ACCOUNT)
+            .willReturn(STATUS_WITH_LOCKED_ACCOUNT)
+            .willReturn(STATUS_WITHOUT_ANY_LOCKED_ACCOUNT);
+
+        assertThat(queueProcessingReadinessChecker.isNoAccountLockedInIdam()).isTrue();
+        assertThat(queueProcessingReadinessChecker.isNoAccountLockedInIdam()).isFalse();
+
+        // give hystrix enough time to conclude that it needs to open the circuit (based on stats)
+        Thread.sleep(500);
+
+        // even though authenticationChecker should return 'not locked' results from now on,
+        // the circuit should remain open
+        assertThat(queueProcessingReadinessChecker.isNoAccountLockedInIdam()).isFalse();
+        assertThat(queueProcessingReadinessChecker.isNoAccountLockedInIdam()).isFalse();
+
+        verify(authenticationChecker, times(2)).checkSignInForAllJurisdictions();
+    }
+
+    @Test
+    public void should_keep_returning_true_when_no_account_is_locked() throws Exception {
+        given(authenticationChecker.checkSignInForAllJurisdictions())
+            .willReturn(STATUS_WITHOUT_ANY_LOCKED_ACCOUNT);
+
+        int numberOfChecks = 10;
+
+        for (int i = 0; i < numberOfChecks; i++) {
+            assertThat(queueProcessingReadinessChecker.isNoAccountLockedInIdam()).isTrue();
+        }
+
+        verify(authenticationChecker, times(numberOfChecks)).checkSignInForAllJurisdictions();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/Application.java
@@ -2,10 +2,12 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableCircuitBreaker
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 public class Application {
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/QueueProcessingReadinessChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/QueueProcessingReadinessChecker.java
@@ -1,0 +1,110 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services;
+
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AccountLockedException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AuthenticationChecker;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.stream.Collectors.toList;
+import static org.springframework.http.HttpStatus.LOCKED;
+
+@Service
+public class QueueProcessingReadinessChecker {
+
+    private static final String CHECK_ACCOUNT_NOT_LOCKED_COMMAND_KEY = "check-no-account-locked";
+    private static final Logger log = LoggerFactory.getLogger(QueueProcessingReadinessChecker.class);
+
+    private final AuthenticationChecker authenticationChecker;
+    private final Duration noAccountLockedCheckValidityDuration;
+
+    private LocalDateTime noAccountLockedCheckExpiry = LocalDateTime.now();
+
+    public QueueProcessingReadinessChecker(
+        AuthenticationChecker authenticationChecker,
+        @Value("${task.check-no-account-locked.check-validity-duration:PT0S}")
+            Duration noAccountLockedCheckValidityDuration
+    ) {
+        this.authenticationChecker = authenticationChecker;
+        this.noAccountLockedCheckValidityDuration = noAccountLockedCheckValidityDuration;
+    }
+
+    /**
+     * Checks if no jurisdiction-specific account is locked in IDAM.
+     * <p>
+     * When an account is locked in IDAM, the processing of the queue must be paused,
+     * in order to let the account get unlocked (through inactivity).
+     * </p>
+     *
+     * @return true if no account is locked in IDAM. Otherwise, throws AccountLockedException in order to
+     *         open the circuit and let Hystrix manage the problem.
+     */
+    @HystrixCommand(
+        commandKey = CHECK_ACCOUNT_NOT_LOCKED_COMMAND_KEY,
+        fallbackMethod = "isNoAccountLockedInIdamFallback"
+    )
+    public boolean isNoAccountLockedInIdam() throws AccountLockedException {
+        try {
+            if (hasNoAccountLockedCheckExpired()) {
+                assertNoAccountIsLockedInIdam();
+            }
+        } catch (AccountLockedException e) {
+            // let hystrix open the circuit
+            throw e;
+        } catch (Exception e) {
+            // just log the exception, but don't let it block queue processing
+            log.error("Failed to check if jurisdictions' accounts are locked in IDAM.", e);
+        }
+
+        return true;
+    }
+
+    private void assertNoAccountIsLockedInIdam() throws AccountLockedException {
+        List<String> jurisdictionsWithLockedAccounts = getJurisdictionsWithLockedAccounts();
+
+        if (jurisdictionsWithLockedAccounts.isEmpty()) {
+            updateNoAccountLockedCheckExpiry();
+        } else {
+            String errorMessage = String.format(
+                "Some jurisdictions' accounts are locked in IDAM. "
+                    + "This will pause queue processing. Jurisdictions with locked accounts: [%s]",
+                String.join(",", jurisdictionsWithLockedAccounts)
+            );
+
+            log.error(errorMessage);
+
+            // open the circuit
+            throw new AccountLockedException(errorMessage);
+        }
+    }
+
+    public boolean isNoAccountLockedInIdamFallback() {
+        log.warn("Executing fallback method for {} command", CHECK_ACCOUNT_NOT_LOCKED_COMMAND_KEY);
+        return false;
+    }
+
+    private List<String> getJurisdictionsWithLockedAccounts() {
+        return authenticationChecker
+            .checkSignInForAllJurisdictions()
+            .stream()
+            .filter(status -> Objects.equals(status.errorResponseStatus, LOCKED.value()))
+            .map(status -> status.jurisdiction)
+            .collect(toList());
+    }
+
+    private boolean hasNoAccountLockedCheckExpired() {
+        return !LocalDateTime.now().isBefore(noAccountLockedCheckExpiry);
+    }
+
+    private void updateNoAccountLockedCheckExpiry() {
+        this.noAccountLockedCheckExpiry =
+            LocalDateTime.now().plus(noAccountLockedCheckValidityDuration);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/QueueProcessingReadinessChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/QueueProcessingReadinessChecker.java
@@ -57,6 +57,7 @@ public class QueueProcessingReadinessChecker {
         try {
             if (hasNoAccountLockedCheckExpired()) {
                 assertNoAccountIsLockedInIdam();
+                updateNoAccountLockedCheckExpiry();
             }
 
             return true;
@@ -73,9 +74,7 @@ public class QueueProcessingReadinessChecker {
     private void assertNoAccountIsLockedInIdam() throws AccountLockedException {
         List<String> jurisdictionsWithLockedAccounts = getJurisdictionsWithLockedAccounts();
 
-        if (jurisdictionsWithLockedAccounts.isEmpty()) {
-            updateNoAccountLockedCheckExpiry();
-        } else {
+        if (!jurisdictionsWithLockedAccounts.isEmpty()) {
             String errorMessage = String.format(
                 "Some jurisdictions' accounts are locked in IDAM. "
                     + "This will pause queue processing. Jurisdictions with locked accounts: [%s]",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AccountLockedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AccountLockedException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam;
+
+public class AccountLockedException extends Exception {
+
+    public AccountLockedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,3 +63,7 @@ hystrix:
         requestVolumeThreshold: 1
         sleepWindowInMilliseconds: 4200000 # suspend processing for 70 minutes when an account is locked
         errorThresholdPercentage: 1
+
+task:
+  check-no-account-locked:
+    check-validity-duration: PT5M # only ensure this often that no account is locked in IDAM

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -51,3 +51,15 @@ scheduling:
       enabled: ${DELETE_ENVELOPES_DLQ_MESSAGES_ENABLED:false}
       cron: ${DELETE_ENVELOPES_DLQ_MESSAGES_CRON}
       ttl: ${DELETE_ENVELOPES_DLQ_MESSAGES_TTL}
+
+hystrix:
+  command:
+    default:
+      execution.timeout.enabled: false
+      fallback.enabled: true
+      circuitBreaker.enabled: true
+    check-no-account-locked:
+      circuitBreaker:
+        requestVolumeThreshold: 1
+        sleepWindowInMilliseconds: 4200000 # suspend processing for 70 minutes when an account is locked
+        errorThresholdPercentage: 1

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -61,7 +61,9 @@ hystrix:
     check-no-account-locked:
       circuitBreaker:
         requestVolumeThreshold: 1
-        sleepWindowInMilliseconds: 4200000 # suspend processing for 70 minutes when an account is locked
+        # suspend processing for 120 minutes when an account is locked - this will give us one hour
+        # to apply necessary changes and redeploy (IDAM keeps the lock for one hour of inactivity)
+        sleepWindowInMilliseconds: 7200000
         errorThresholdPercentage: 1
 
 task:

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/QueueProcessingReadinessCheckerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/QueueProcessingReadinessCheckerTest.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.out.JurisdictionConfigurationStatus;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AccountLockedException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AuthenticationChecker;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueueProcessingReadinessCheckerTest {
+
+    @Mock
+    private AuthenticationChecker authenticationChecker;
+
+    private QueueProcessingReadinessChecker processingReadinessChecker;
+
+    @Before
+    public void setUp() {
+        processingReadinessChecker =
+            new QueueProcessingReadinessChecker(authenticationChecker, Duration.ofMinutes(1));
+    }
+
+    @Test
+    public void isNoAccountLockedInIdam_returns_true_when_no_account_is_locked() throws Exception {
+        List<JurisdictionConfigurationStatus> noAccountLockedStatus = Arrays.asList(
+            new JurisdictionConfigurationStatus("jurisdiction1", true, null, 200),
+            new JurisdictionConfigurationStatus("jurisdiction2", false, "forbidden", 403)
+        );
+
+        given(authenticationChecker.checkSignInForAllJurisdictions()).willReturn(noAccountLockedStatus);
+
+        assertThat(processingReadinessChecker.isNoAccountLockedInIdam()).isTrue();
+    }
+
+    @Test
+    public void isNoAccountLockedInIdam_throws_exception_when_an_account_is_locked() {
+        List<JurisdictionConfigurationStatus> oneAccountLockedStatus = Arrays.asList(
+            new JurisdictionConfigurationStatus("jurisdiction1", true, null, 200),
+            new JurisdictionConfigurationStatus("jurisdiction2", false, "forbidden", 403),
+            new JurisdictionConfigurationStatus("jurisdiction3", false, "locked", 423)
+        );
+
+        given(authenticationChecker.checkSignInForAllJurisdictions()).willReturn(oneAccountLockedStatus);
+
+        String expectedErrorMessage = "Some jurisdictions' accounts are locked in IDAM. "
+            + "This will pause queue processing. Jurisdictions with locked accounts: [jurisdiction3]";
+
+        assertThatThrownBy(() -> processingReadinessChecker.isNoAccountLockedInIdam())
+            .isInstanceOf(AccountLockedException.class)
+            .hasMessage(expectedErrorMessage);
+    }
+
+    @Test
+    public void isNoAccountLockedInIdamFallback_returns_false() {
+        assertThat(
+            processingReadinessChecker.isNoAccountLockedInIdamFallback()
+        ).isFalse();
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/QueueProcessingReadinessCheckerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/QueueProcessingReadinessCheckerTest.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.out.JurisdictionConfigurationStatus;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AccountLockedException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AuthenticationChecker;
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class QueueProcessingReadinessCheckerTest {
 
     @Mock
@@ -25,7 +25,7 @@ public class QueueProcessingReadinessCheckerTest {
 
     private QueueProcessingReadinessChecker processingReadinessChecker;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         processingReadinessChecker =
             new QueueProcessingReadinessChecker(authenticationChecker, Duration.ofMinutes(1));

--- a/src/test/resources/application-integration.yaml
+++ b/src/test/resources/application-integration.yaml
@@ -25,3 +25,18 @@ azure:
   servicebus:
     envelopes:
       max-delivery-count: 10
+
+hystrix:
+  command:
+    default:
+      execution.timeout.enabled: false
+      fallback.enabled: true
+      circuitBreaker.enabled: true
+      metrics.rollingStats:
+        timeInMilliseconds: 500
+        numBuckets: 5
+    check-no-account-locked:
+      circuitBreaker:
+        requestVolumeThreshold: 1
+        sleepWindowInMilliseconds: 100000
+        errorThresholdPercentage: 1

--- a/src/test/resources/application-integration.yaml
+++ b/src/test/resources/application-integration.yaml
@@ -40,3 +40,7 @@ hystrix:
         requestVolumeThreshold: 1
         sleepWindowInMilliseconds: 100000
         errorThresholdPercentage: 1
+
+task:
+  check-no-account-locked:
+    check-validity-duration: PT0S


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-563

### Change description ###

Create a service for checking if jurisdictions' accounts are not locked in IDAM. This service is managed by Hystrix, which will provide a proxy to it.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
