### PR TITLE
Abandon dlq message when the message can't be completed

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/EnvelopeMessager.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/EnvelopeMessager.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.FunctionalQueueConfig;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData;
 
+import java.time.Instant;
 import java.util.UUID;
 
 @Service
@@ -48,9 +49,14 @@ public class EnvelopeMessager {
             updateCaseData.toString(),
             MediaType.APPLICATION_JSON_UTF8_VALUE
         );
-
-        logger.info("Sending message to queue for the Case ID {} for updating the case", caseRef);
         client.send(message);
+
+        logger.info(
+            "Sent message to queue for the Case ID {} for updating the case. MessageId: {} Current time: {}",
+            caseRef,
+            message.getMessageId(),
+            Instant.now()
+        );
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/CleanupEnvelopesDlqTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/CleanupEnvelopesDlqTask.java
@@ -53,7 +53,13 @@ public class CleanupEnvelopesDlqTask {
                     logMessage(message);
                     messageReceiver.complete(message.getLockToken());
                     completedCount++;
-                    log.info("Completed message from envelopes dlq. messageId: {}", message.getMessageId());
+                    log.info(
+                        "Completed message from envelopes dlq. messageId: {} Current time: {}",
+                        message.getMessageId(),
+                        Instant.now()
+                    );
+                } else {
+                    messageReceiver.abandon(message.getLockToken());
                 }
                 message = messageReceiver.receive();
             }
@@ -99,11 +105,13 @@ public class CleanupEnvelopesDlqTask {
         boolean canBeCompleted = createdTime.isBefore(cutoff);
 
         log.info(
-            "MessageId: {} Enqueued Time: {} ttl: {} can be completed? {}",
+            "MessageId: {} Enqueued Time: {} ttl: {} can be completed? {} Current time: {}",
             message.getMessageId(),
             createdTime,
             this.ttl,
-            canBeCompleted);
+            canBeCompleted,
+            Instant.now()
+        );
 
         return canBeCompleted;
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/CleanupEnvelopesDlqTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/CleanupEnvelopesDlqTaskTest.java
@@ -82,7 +82,7 @@ public class CleanupEnvelopesDlqTaskTest {
     }
 
     @Test
-    public void should_not_delete_messages_from_dead_letter_queue_when_the_ttl_is_less_than_duration()
+    public void should_call_abandon_message_when_the_ttl_is_less_than_duration()
         throws Exception {
         //given
         given(message.getEnqueuedTimeUtc())
@@ -95,6 +95,7 @@ public class CleanupEnvelopesDlqTaskTest {
         //then
         verify(messageReceiver, times(2)).receive();
         verify(messageReceiver, never()).complete(any());
+        verify(messageReceiver, times(1)).abandon(any());
         verify(messageReceiver, times(1)).close();
         verifyNoMoreInteractions(messageReceiver);
     }
@@ -110,6 +111,7 @@ public class CleanupEnvelopesDlqTaskTest {
         //then
         verify(messageReceiver, times(1)).receive();
         verify(messageReceiver, never()).complete(any());
+        verify(messageReceiver, never()).abandon(any());
         verify(messageReceiver, times(1)).close();
         verifyNoMoreInteractions(messageReceiver);
     }


### PR DESCRIPTION
### Change description ###
Abandon dlq message when the message can't be completed, 
so the lock on the message is released.
Added current time to log messages for debugging purpose.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
