### PR TITLE
Remove junit4 dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,12 +205,14 @@ dependencies {
 
   annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
 
-  testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot)
+  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, {
+    exclude group: 'junit', module: 'junit'
+  }
+
   testCompile group: 'com.typesafe', name: 'config', version: '1.3.3'
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
-  testCompile group: 'org.junit.vintage', name: 'junit-vintage-engine', version: versions.junit
   testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '2.26.0'
   testCompile group: 'org.assertj', name: 'assertj-core', version: '3.12.2'
   testCompile group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '2.1.1.RELEASE'


### PR DESCRIPTION
### Change description ###

JUnit4 dependency became retired:

- unit tests #378 
- integration tests #379 
- functional and smoke tests #380 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
