### PR TITLE
Create a task for consuming envelopes queue

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -51,6 +51,16 @@ public class EnvelopeEventProcessor implements IMessageHandler {
         this.appInsights = appInsights;
     }
 
+    /**
+     * Reads and processes next message from the queue.
+     *
+     * @return false if there was no message to process. Otherwise true.
+     */
+    public boolean processNextMessage() throws ServiceBusException, InterruptedException {
+        // TODO: implement
+        return false;
+    }
+
     @Override
     public CompletableFuture<Void> onMessageAsync(IMessage message) {
         /*

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTask.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.tasks;
+
+import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.EnvelopeEventProcessor;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.QueueProcessingReadinessChecker;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AccountLockedException;
+
+@ConditionalOnProperty(value = "scheduling.task.consume-envelopes-queue.enabled", matchIfMissing = true)
+public class EnvelopesQueueConsumeTask {
+
+    private static final Logger log = LoggerFactory.getLogger(EnvelopesQueueConsumeTask.class);
+
+    private final EnvelopeEventProcessor envelopeEventProcessor;
+    private final QueueProcessingReadinessChecker processingReadinessChecker;
+
+    public EnvelopesQueueConsumeTask(
+        EnvelopeEventProcessor envelopeEventProcessor,
+        QueueProcessingReadinessChecker processingReadinessChecker
+    ) {
+        this.envelopeEventProcessor = envelopeEventProcessor;
+        this.processingReadinessChecker = processingReadinessChecker;
+    }
+
+    @Scheduled(fixedDelay = 1000)
+    public void consumeMessages() throws ServiceBusException, InterruptedException {
+        try {
+            boolean queueMayHaveMessages = true;
+
+            while (queueMayHaveMessages && isReadyForConsumingMessages()) {
+                queueMayHaveMessages = envelopeEventProcessor.processNextMessage();
+            }
+        } catch (Exception e) {
+            log.error("An error occurred when running the 'consume messages' task", e);
+        }
+    }
+
+    private boolean isReadyForConsumingMessages() throws AccountLockedException {
+        // TODO: add S2S and IDAM health checks
+        return processingReadinessChecker.isNoAccountLockedInIdam();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTaskTest.java
@@ -1,0 +1,78 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.tasks;
+
+import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.EnvelopeEventProcessor;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.QueueProcessingReadinessChecker;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AccountLockedException;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(SpringExtension.class)
+public class EnvelopesQueueConsumeTaskTest {
+
+    @Mock
+    private EnvelopeEventProcessor envelopeEventProcessor;
+
+    @Mock
+    private QueueProcessingReadinessChecker processingReadinessChecker;
+
+    private EnvelopesQueueConsumeTask queueConsumeTask;
+
+    @BeforeEach
+    public void setUp() throws AccountLockedException {
+        queueConsumeTask = new EnvelopesQueueConsumeTask(
+            envelopeEventProcessor,
+            processingReadinessChecker
+        );
+
+        given(processingReadinessChecker.isNoAccountLockedInIdam()).willReturn(true);
+    }
+
+    @Test
+    public void consumeMessages_processes_messages_until_envelope_processor_returns_false() throws Exception {
+        // given
+        given(envelopeEventProcessor.processNextMessage()).willReturn(true, true, true, false);
+
+        // when
+        queueConsumeTask.consumeMessages();
+
+        // then
+        verify(envelopeEventProcessor, times(4)).processNextMessage();
+        verify(processingReadinessChecker, times(4)).isNoAccountLockedInIdam();
+    }
+
+    @Test
+    public void consumeMessages_does_not_process_when_account_locked_in_idam() throws Exception {
+        // given
+        given(processingReadinessChecker.isNoAccountLockedInIdam()).willReturn(false);
+
+        // when
+        queueConsumeTask.consumeMessages();
+
+        // then
+        verify(processingReadinessChecker, times(1)).isNoAccountLockedInIdam();
+        verify(envelopeEventProcessor, never()).processNextMessage();
+    }
+
+    @Test
+    public void consumeMessages_stops_processing_when_envelope_processor_throws_exception() throws Exception {
+        // given
+        willThrow(new ServiceBusException(true)).given(envelopeEventProcessor).processNextMessage();
+
+        // when
+        queueConsumeTask.consumeMessages();
+
+        // then
+        verify(envelopeEventProcessor, times(1)).processNextMessage();
+        verify(processingReadinessChecker, times(1)).isNoAccountLockedInIdam();
+    }
+}

--- a/src/test/resources/application-integration.yaml
+++ b/src/test/resources/application-integration.yaml
@@ -20,6 +20,8 @@ scheduling:
       enabled: true
       cron: "*/1 * * * * *"
       ttl: 10s
+    consume-envelopes-queue:
+      enabled: false
 
 azure:
   servicebus:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-563

### Change description ###

Create a task for consuming envelopes queue. The task only does it when no jurisdiction account is locked in IDAM.

This is a part of a bigger change that also makes EnvelopeEventProcessor responsible for reading messages from the queue. The complete intended change can be found here: https://github.com/hmcts/bulk-scan-orchestrator/compare/feature/introduce-circuit-breaker

The task is not a service, yet, so this change has no effect on how the application works (needs `@Service` annotation to be added).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
