### PR TITLE
Add functional test for Cleanup dlq task

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -56,6 +56,7 @@ withPipeline(type, product, component) {
       // Get envelopes queue connection string
       def sbConnectionStr = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.connectionString}")
       env.ENVELOPES_QUEUE_WRITE_CONN_STRING = "${sbConnectionStr};EntityPath=envelopes"
+      env.ENVELOPES_QUEUE_READ_CONN_STRING = "${sbConnectionStr};EntityPath=envelopes"
     }
   }
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -55,6 +55,7 @@ withPipeline(type, product, component) {
 
       // Get envelopes queue connection string
       def sbConnectionStr = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.connectionString}")
+      env.ENVELOPES_QUEUE_READ_CONN_STRING = "${sbConnectionStr};EntityPath=envelopes"
       env.ENVELOPES_QUEUE_WRITE_CONN_STRING = "${sbConnectionStr};EntityPath=envelopes"
     }
   }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -55,7 +55,6 @@ withPipeline(type, product, component) {
 
       // Get envelopes queue connection string
       def sbConnectionStr = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.connectionString}")
-      env.ENVELOPES_QUEUE_READ_CONN_STRING = "${sbConnectionStr};EntityPath=envelopes"
       env.ENVELOPES_QUEUE_WRITE_CONN_STRING = "${sbConnectionStr};EntityPath=envelopes"
     }
   }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -56,7 +56,6 @@ withPipeline(type, product, component) {
       // Get envelopes queue connection string
       def sbConnectionStr = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.connectionString}")
       env.ENVELOPES_QUEUE_WRITE_CONN_STRING = "${sbConnectionStr};EntityPath=envelopes"
-      env.ENVELOPES_QUEUE_READ_CONN_STRING = "${sbConnectionStr};EntityPath=envelopes"
     }
   }
 

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -16,6 +16,10 @@ output "ENVELOPES_QUEUE_WRITE_CONN_STRING" {
   value = "${data.azurerm_key_vault_secret.envelopes_queue_send_conn_str.value}"
 }
 
+output "ENVELOPES_QUEUE_READ_CONN_STRING" {
+  value = "${data.azurerm_key_vault_secret.envelopes_queue_listen_conn_str.value}"
+}
+
 output "core_case_data_api_url" {
   value = "${local.ccdApiUrl}"
 }

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -16,6 +16,10 @@ output "ENVELOPES_QUEUE_WRITE_CONN_STRING" {
   value = "${data.terraform_remote_state.shared_infra.queue_primary_send_connection_string}"
 }
 
+output "ENVELOPES_QUEUE_READ_CONN_STRING" {
+  value = "${data.terraform_remote_state.shared_infra.queue_primary_listen_connection_string}"
+}
+
 output "core_case_data_api_url" {
   value = "${local.ccdApiUrl}"
 }

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -16,10 +16,6 @@ output "ENVELOPES_QUEUE_WRITE_CONN_STRING" {
   value = "${data.terraform_remote_state.shared_infra.queue_primary_send_connection_string}"
 }
 
-output "ENVELOPES_QUEUE_READ_CONN_STRING" {
-  value = "${data.terraform_remote_state.shared_infra.queue_primary_listen_connection_string}"
-}
-
 output "core_case_data_api_url" {
   value = "${local.ccdApiUrl}"
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CleanupDlqMessagesTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CleanupDlqMessagesTest.java
@@ -25,7 +25,7 @@ import static org.awaitility.Awaitility.await;
 @ActiveProfiles("nosb")  // no servicebus queue handler registration
 @Import(FunctionalQueueConfig.class)
 public class CleanupDlqMessagesTest {
-    private static final Logger log = LoggerFactory.getLogger(CleanupDlqMessagesTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CleanupDlqMessagesTest.class);
 
     @Autowired
     @Qualifier("dlqReceiver")
@@ -37,7 +37,7 @@ public class CleanupDlqMessagesTest {
     @Test
     public void testCleanupDlqTask() throws Exception {
         // when
-        log.info("Send invalid messages to envelopes queue. filename: envelopes/dead-letter-envelope.json");
+        LOG.info("Send invalid messages to envelopes queue. filename: envelopes/dead-letter-envelope.json");
 
         // invalid message, which will be sent to dead letter queue
         for (int i = 0; i < 10; i++) {
@@ -54,11 +54,11 @@ public class CleanupDlqMessagesTest {
             .atMost(4, TimeUnit.MINUTES)
             .pollDelay(120, TimeUnit.SECONDS)
             .pollInterval(15, TimeUnit.SECONDS)
-            .until(() -> verifyEnvelopesDlqIsEmpty());
+            .until(() -> verifyDlqIsEmpty());
     }
 
-    private boolean verifyEnvelopesDlqIsEmpty() throws ServiceBusException, InterruptedException {
-        log.info("Reading messages from envelopes Dead letter queue.");
+    private boolean verifyDlqIsEmpty() throws ServiceBusException, InterruptedException {
+        LOG.info("Reading messages from envelopes Dead letter queue.");
 
         IMessageReceiver messageReceiver = null;
         IMessage message = null;
@@ -75,7 +75,7 @@ public class CleanupDlqMessagesTest {
                     }
                     messageReceiver.close();
                 } catch (ServiceBusException e) {
-                    log.error("Error closing dlq connection", e);
+                    LOG.error("Error closing dlq connection", e);
                 }
             }
         }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CleanupDlqMessagesTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CleanupDlqMessagesTest.java
@@ -37,9 +37,8 @@ public class CleanupDlqMessagesTest {
     @Test
     public void testCleanupDlqTask() throws Exception {
         // when
-        LOG.info("Send invalid messages to envelopes queue. filename: envelopes/dead-letter-envelope.json");
-
-        // invalid message, which will be sent to dead letter queue
+        // Sending more than 1 invalid message so that we can make sure the dlq messages are completed
+        // even when the dlq task acquires lock on some messages
         for (int i = 0; i < 10; i++) {
             envelopeMessager.sendMessageFromFile(
                 "envelopes/dead-letter-envelope.json",

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CleanupDlqMessagesTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CleanupDlqMessagesTest.java
@@ -32,10 +32,6 @@ public class CleanupDlqMessagesTest {
     private Supplier<IMessageReceiver> dlqReceiverProvider;
 
     @Autowired
-    @Qualifier("envelopesReceiver")
-    private Supplier<IMessageReceiver> envelopesReceiverProvider;
-
-    @Autowired
     private EnvelopeMessager envelopeMessager;
 
     @Test
@@ -54,14 +50,14 @@ public class CleanupDlqMessagesTest {
         }
 
         // then
-        await("Message deleted from envelopes dead letter queue")
+        await("Dead lettered messages are completed from envelopes dlq.")
             .atMost(4, TimeUnit.MINUTES)
             .pollDelay(120, TimeUnit.SECONDS)
             .pollInterval(15, TimeUnit.SECONDS)
-            .until(() -> !verifyDlqMessagesExists());
+            .until(() -> verifyEnvelopesDlqIsEmpty());
     }
 
-    private boolean verifyDlqMessagesExists() throws ServiceBusException, InterruptedException {
+    private boolean verifyEnvelopesDlqIsEmpty() throws ServiceBusException, InterruptedException {
         log.info("Reading messages from envelopes Dead letter queue.");
 
         IMessageReceiver messageReceiver = null;

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CleanupDlqMessagesTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CleanupDlqMessagesTest.java
@@ -1,0 +1,87 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator;
+
+import com.microsoft.azure.servicebus.IMessage;
+import com.microsoft.azure.servicebus.IMessageReceiver;
+import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.helper.EnvelopeMessager;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.awaitility.Awaitility.await;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@ActiveProfiles("nosb")  // no servicebus queue handler registration
+@Import(FunctionalQueueConfig.class)
+public class CleanupDlqMessagesTest {
+    private static final Logger log = LoggerFactory.getLogger(CleanupDlqMessagesTest.class);
+
+    @Autowired
+    @Qualifier("dlqReceiver")
+    private Supplier<IMessageReceiver> dlqReceiverProvider;
+
+    @Autowired
+    @Qualifier("envelopesReceiver")
+    private Supplier<IMessageReceiver> envelopesReceiverProvider;
+
+    @Autowired
+    private EnvelopeMessager envelopeMessager;
+
+    @Test
+    public void testCleanupDlqTask() throws Exception {
+        // when
+        log.info("Send invalid messages to envelopes queue. filename: envelopes/dead-letter-envelope.json");
+
+        // invalid message, which will be sent to dead letter queue
+        for (int i = 0; i < 10; i++) {
+            envelopeMessager.sendMessageFromFile(
+                "envelopes/dead-letter-envelope.json",
+                "1234",
+                null,
+                null
+            );
+        }
+
+        // then
+        await("Message deleted from envelopes dead letter queue")
+            .atMost(4, TimeUnit.MINUTES)
+            .pollDelay(120, TimeUnit.SECONDS)
+            .pollInterval(15, TimeUnit.SECONDS)
+            .until(() -> !verifyDlqMessagesExists());
+    }
+
+    private boolean verifyDlqMessagesExists() throws ServiceBusException, InterruptedException {
+        log.info("Reading messages from envelopes Dead letter queue.");
+
+        IMessageReceiver messageReceiver = null;
+        IMessage message = null;
+
+        try {
+            messageReceiver = dlqReceiverProvider.get();
+            message = messageReceiver.receive();
+            return message != null;
+        } finally {
+            if (messageReceiver != null) {
+                try {
+                    if (message != null) {
+                        messageReceiver.abandon(message.getLockToken());
+                    }
+                    messageReceiver.close();
+                } catch (ServiceBusException e) {
+                    log.error("Error closing dlq connection", e);
+                }
+            }
+        }
+    }
+}

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
@@ -26,7 +26,7 @@ public class FunctionalQueueConfig {
     private String queueReadConnectionString;
 
     @Bean
-    QueueClient testWriteClient() throws ServiceBusException, InterruptedException {
+    public QueueClient testWriteClient() throws ServiceBusException, InterruptedException {
         return new QueueClient(
             new ConnectionStringBuilder(queueWriteConnectionString),
             ReceiveMode.PEEKLOCK
@@ -34,7 +34,7 @@ public class FunctionalQueueConfig {
     }
 
     @Bean(name = "dlqReceiver")
-    Supplier<IMessageReceiver> dlqReceiverProvider() {
+    public Supplier<IMessageReceiver> dlqReceiverProvider() {
         return () -> {
             try {
                 return ClientFactory.createMessageReceiverFromConnectionStringBuilder(
@@ -49,23 +49,6 @@ public class FunctionalQueueConfig {
             return null;
         };
 
-    }
-
-    @Bean(name = "envelopesReceiver")
-    public Supplier<IMessageReceiver> envelopesReceiverProvider() {
-        return () -> {
-            try {
-                return ClientFactory.createMessageReceiverFromConnectionStringBuilder(
-                    new ConnectionStringBuilder(queueReadConnectionString),
-                    ReceiveMode.PEEKLOCK
-                );
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } catch (ServiceBusException e) {
-                throw new ConnectionException("Unable to connect to the envelopes queue", e);
-            }
-            return null;
-        };
     }
 
     @Bean

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
@@ -22,6 +22,9 @@ public class FunctionalQueueConfig {
     @Value("${queue.envelopes.write-connection-string}")
     private String queueWriteConnectionString;
 
+    @Value("${queue.envelopes.read-connection-string}")
+    private String queueReadConnectionString;
+
     @Bean
     public QueueClient testWriteClient() throws ServiceBusException, InterruptedException {
         return new QueueClient(
@@ -35,7 +38,7 @@ public class FunctionalQueueConfig {
         return () -> {
             try {
                 return ClientFactory.createMessageReceiverFromConnectionStringBuilder(
-                    new ConnectionStringBuilder(StringUtils.join(queueWriteConnectionString, "/$deadletterqueue")),
+                    new ConnectionStringBuilder(StringUtils.join(queueReadConnectionString, "/$deadletterqueue")),
                     ReceiveMode.PEEKLOCK
                 );
             } catch (InterruptedException e) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
@@ -1,14 +1,19 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator;
 
+import com.microsoft.azure.servicebus.ClientFactory;
 import com.microsoft.azure.servicebus.IMessageReceiver;
 import com.microsoft.azure.servicebus.QueueClient;
 import com.microsoft.azure.servicebus.ReceiveMode;
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.IProcessedEnvelopeNotifier;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.exceptions.ConnectionException;
+
+import java.util.function.Supplier;
 
 import static org.mockito.Mockito.mock;
 
@@ -16,6 +21,9 @@ public class FunctionalQueueConfig {
 
     @Value("${queue.envelopes.write-connection-string}")
     private String queueWriteConnectionString;
+
+    @Value("${azure.servicebus.envelopes.connection-string}")
+    private String queueReadConnectionString;
 
     @Bean
     QueueClient testWriteClient() throws ServiceBusException, InterruptedException {
@@ -25,11 +33,47 @@ public class FunctionalQueueConfig {
         );
     }
 
+    @Bean(name = "dlqReceiver")
+    Supplier<IMessageReceiver> dlqReceiverProvider() {
+        return () -> {
+            try {
+                return ClientFactory.createMessageReceiverFromConnectionStringBuilder(
+                    new ConnectionStringBuilder(StringUtils.join(queueReadConnectionString, "/$deadletterqueue")),
+                    ReceiveMode.PEEKLOCK
+                );
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (ServiceBusException e) {
+                throw new ConnectionException("Unable to connect to the dlq", e);
+            }
+            return null;
+        };
+
+    }
+
+    @Bean(name = "envelopesReceiver")
+    public Supplier<IMessageReceiver> envelopesReceiverProvider() {
+        return () -> {
+            try {
+                return ClientFactory.createMessageReceiverFromConnectionStringBuilder(
+                    new ConnectionStringBuilder(queueReadConnectionString),
+                    ReceiveMode.PEEKLOCK
+                );
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (ServiceBusException e) {
+                throw new ConnectionException("Unable to connect to the envelopes queue", e);
+            }
+            return null;
+        };
+    }
+
     @Bean
     @Profile("nosb") // apply only when Service Bus should not be used
     IProcessedEnvelopeNotifier testProcessedEnvelopeNotifier() {
         // return implementation that does nothing
-        return envelopeId -> { };
+        return envelopeId -> {
+        };
     }
 
     @Bean

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
@@ -22,9 +22,6 @@ public class FunctionalQueueConfig {
     @Value("${queue.envelopes.write-connection-string}")
     private String queueWriteConnectionString;
 
-    @Value("${queue.envelopes.read-connection-string}")
-    private String queueReadConnectionString;
-
     @Bean
     public QueueClient testWriteClient() throws ServiceBusException, InterruptedException {
         return new QueueClient(
@@ -38,7 +35,7 @@ public class FunctionalQueueConfig {
         return () -> {
             try {
                 return ClientFactory.createMessageReceiverFromConnectionStringBuilder(
-                    new ConnectionStringBuilder(StringUtils.join(queueReadConnectionString, "/$deadletterqueue")),
+                    new ConnectionStringBuilder(StringUtils.join(queueWriteConnectionString, "/$deadletterqueue")),
                     ReceiveMode.PEEKLOCK
                 );
             } catch (InterruptedException e) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
@@ -22,7 +22,7 @@ public class FunctionalQueueConfig {
     @Value("${queue.envelopes.write-connection-string}")
     private String queueWriteConnectionString;
 
-    @Value("${azure.servicebus.envelopes.connection-string}")
+    @Value("${queue.envelopes.read-connection-string}")
     private String queueReadConnectionString;
 
     @Bean

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -8,7 +8,6 @@ spring:
 queue:
   envelopes:
     write-connection-string: ${ENVELOPES_QUEUE_WRITE_CONN_STRING}
-    read-connection-string: ${ENVELOPES_QUEUE_READ_CONN_STRING}
 
 # because functional tests load up SpringBootTest
 azure:

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -8,13 +8,13 @@ spring:
 queue:
   envelopes:
     write-connection-string: ${ENVELOPES_QUEUE_WRITE_CONN_STRING}
+    read-connection-string: ${ENVELOPES_QUEUE_READ_CONN_STRING}
 
 # because functional tests load up SpringBootTest
 azure:
   servicebus:
     envelopes:
       max-delivery-count: 10
-      connection-string: ${ENVELOPES_QUEUE_READ_CONN_STRING}
 
 core_case_data:
   api:

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -14,6 +14,7 @@ azure:
   servicebus:
     envelopes:
       max-delivery-count: 10
+      connection-string: ${ENVELOPES_QUEUE_READ_CONN_STRING}
 
 core_case_data:
   api:

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -8,6 +8,7 @@ spring:
 queue:
   envelopes:
     write-connection-string: ${ENVELOPES_QUEUE_WRITE_CONN_STRING}
+    read-connection-string: ${ENVELOPES_QUEUE_READ_CONN_STRING}
 
 # because functional tests load up SpringBootTest
 azure:

--- a/src/functionalTest/resources/envelopes/dead-letter-envelope.json
+++ b/src/functionalTest/resources/envelopes/dead-letter-envelope.json
@@ -1,0 +1,19 @@
+{
+  "case_ref": "1234",
+  "po_box": "BULKSCAN PO BOX",
+  "jurisdiction": "BULKSCAN",
+  "classification": "SUPPLEMENTARY_EVIDENCE",
+  "zip_file_name": "zip-file-test-dlq.zip",
+  "delivery_date": "1970-01-01T00:00:00.000Z",
+  "opening_date": "1970-01-01T00:00:00.000Z",
+  "documents": [
+    {
+      "file_name": "certificate2.pdf",
+      "control_number": "1545657689",
+      "type": "other",
+      "subtype": null,
+      "scanned_at": "2018-01-01T11:20:00.000Z",
+      "url": "http://dm-store:4460/documents/ee69aee8-1a33-40dd-9af9-d90da1b104babc"
+    }
+  ]
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-538

### Change description ###
Duplicate of https://github.com/hmcts/bulk-scan-orchestrator/pull/353
Added functional test to verify if Dlq scheduler task is deleting the messages.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
