### PR TITLE
Include IDAM response in jurisdiction-specific IDAM status

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationChecker.java
@@ -60,7 +60,7 @@ public class AuthenticationChecker {
                 e
             );
 
-            return new JurisdictionConfigurationStatus(jurisdiction, false, e.getMessage(), e.status());
+            return new JurisdictionConfigurationStatus(jurisdiction, false, e.contentUTF8(), e.status());
         } catch (Exception e) {
             log.error(
                 "An error occurred while authenticating {} jurisdiction with {} username",

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationCheckerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationCheckerTest.java
@@ -94,7 +94,7 @@ class AuthenticationCheckerTest {
         assertThat(status.jurisdiction).isEqualTo(LOCKED_ACCOUNT_JURISDICTION);
         assertThat(status.isCorrect).isFalse();
         assertThat(status.errorResponseStatus).isEqualTo(HttpStatus.LOCKED.value());
-        assertThat(status.errorDescription).isEqualTo(exception.getMessage());
+        assertThat(status.errorDescription).isEqualTo(exception.contentUTF8());
     }
 
     @Test
@@ -156,7 +156,7 @@ class AuthenticationCheckerTest {
             .errorStatus("method1", Response
                 .builder()
                 .request(mock(Request.class))
-                .body(new byte[0])
+                .body("Error response from IDAM".getBytes())
                 .headers(Collections.emptyMap())
                 .status(httpStatus)
                 .build()


### PR DESCRIPTION
### Change description ###

This PR is a copy of already approved https://github.com/hmcts/bulk-scan-orchestrator/pull/394, which was closed because of not being able to delete namespace, which in turn caused builds to fail.

Include IDAM response in jurisdiction-specific IDAM status. Currently, the status contains a generic FeignException message.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
