### PR TITLE
Downgrade spring-cloud-contract-wiremock to version 2.0.2.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ dependencies {
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
   testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '2.26.0'
   testCompile group: 'org.assertj', name: 'assertj-core', version: '3.12.2'
-  testCompile group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '2.1.1.RELEASE'
+  testCompile group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '2.0.2.RELEASE'
   testCompile group: 'org.awaitility', name: 'awaitility', version: '3.1.6'
   testCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.3.0'
 


### PR DESCRIPTION
### Change description ###

DO NOT MERGE UNTIL WE CAN SEE THAT THIS CHANGE HAS FIXED INTEGRATION TESTS.

Downgrade spring-cloud-contract-wiremock to version 2.0.2.RELEASE.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
