### PR TITLE
Updated dlq provider supplier to throw exception 

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
@@ -43,10 +43,10 @@ public class FunctionalQueueConfig {
                 );
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                throw new ConnectionException("Unable to connect to the dlq", e);
             } catch (ServiceBusException e) {
                 throw new ConnectionException("Unable to connect to the dlq", e);
             }
-            return null;
         };
 
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/DlqReceiverProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/DlqReceiverProvider.java
@@ -6,8 +6,6 @@ import com.microsoft.azure.servicebus.ReceiveMode;
 import com.microsoft.azure.servicebus.primitives.ConnectionStringBuilder;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -18,8 +16,6 @@ import java.util.function.Supplier;
 @Component
 @Profile("!nosb") // do not register handler for the nosb (test) profile
 public class DlqReceiverProvider implements Supplier<IMessageReceiver> {
-
-    private static final Logger log = LoggerFactory.getLogger(DlqReceiverProvider.class);
 
     private final String connectionString;
     private final String queueName;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/DlqReceiverProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/DlqReceiverProvider.java
@@ -40,11 +40,10 @@ public class DlqReceiverProvider implements Supplier<IMessageReceiver> {
                 ReceiveMode.PEEKLOCK
             );
         } catch (InterruptedException e) {
-            log.error("Unable to connect to the dlq", e);
             Thread.currentThread().interrupt();
+            throw new ConnectionException("Unable to connect to the dlq", e);
         } catch (ServiceBusException e) {
             throw new ConnectionException("Unable to connect to the dlq", e);
         }
-        return null;
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-538

### Change description ###
The `DlqReceiverrProvider` is returning null in case `InterruptedException`. 
Updated `DlqReceiverrProvider` to throw an exception to avoid `NullPointerException`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
