### PR TITLE
Fix Dlq functional test verification

### DIFF
--- a/charts/bulk-scan-orchestrator/values.aat.template.yaml
+++ b/charts/bulk-scan-orchestrator/values.aat.template.yaml
@@ -8,3 +8,6 @@ java:
     CORE_CASE_DATA_API_URL: "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
     DOCUMENT_MANAGEMENT_URL: "http://dm-store-aat.service.core-compute-aat.internal"
     QUEUE_READ_INTERVAL: "30000"
+    DELETE_ENVELOPES_DLQ_MESSAGES_ENABLED: "true"
+    DELETE_ENVELOPES_DLQ_MESSAGES_CRON: "0 * * * * *"
+    DELETE_ENVELOPES_DLQ_MESSAGES_TTL: "10s"

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -6,4 +6,4 @@ supported_jurisdictions = ["SSCS", "BULKSCAN", "DIVORCE", "PROBATE"]
 delete_envelopes_dlq_messages_enabled = "true"
 # Run the dlq scheduler every minute
 delete_envelopes_dlq_messages_cron = "0 * * * * *"
-delete_envelopes_dlq_messages_ttl = "30s"
+delete_envelopes_dlq_messages_ttl = "10s"

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CleanupDlqMessagesTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CleanupDlqMessagesTest.java
@@ -65,7 +65,7 @@ public class CleanupDlqMessagesTest {
         try {
             messageReceiver = dlqReceiverProvider.get();
             message = messageReceiver.receive();
-            return message != null;
+            return message == null;
         } finally {
             if (messageReceiver != null) {
                 try {


### PR DESCRIPTION
### Change description ###
The dlq cleanup task functional test should verify that there are no messages in dlq.
The assert is doing the opposite at the moment.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
