### PR TITLE
Use latest (9.0.19) of embed tomcat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,12 @@ dependencyManagement {
     dependencySet(group: 'org.mockito', version: '2.26.0') {
       entry 'mockito-core'
     }
+    // CVE-2019-0232 - command line injections on windows
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.19') {
+      entry 'tomcat-embed-core'
+      entry 'tomcat-embed-el'
+      entry 'tomcat-embed-websocket'
+    }
   }
 }
 


### PR DESCRIPTION
### Change description ###

New vulnerability discovered including `9.0.17` of tomcat embed coming in along with spring boot framework. Jumping _bugfix_ version to latest fixes the issue

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
