### PR TITLE
Pause processing messages when IDAM rejects log-in attempts

### DIFF
--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -40,5 +40,5 @@ document_management.url: http://dm-store:4460
 test-url: ${TEST_URL:http://localhost:8582}
 
 task:
-  check-no-account-locked:
+  check-jurisdiction-log-in:
     check-validity-duration: PT5M

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/out/JurisdictionConfigurationStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/out/JurisdictionConfigurationStatus.java
@@ -33,4 +33,10 @@ public class JurisdictionConfigurationStatus {
     ) {
         this(jurisdiction, isCorrect, null, null);
     }
+
+    public boolean isClientError() {
+        return errorResponseStatus != null
+            && errorResponseStatus >= 400
+            && errorResponseStatus < 500;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/QueueProcessingReadinessChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/QueueProcessingReadinessChecker.java
@@ -92,8 +92,7 @@ public class QueueProcessingReadinessChecker {
         return authenticationChecker
             .checkSignInForAllJurisdictions()
             .stream()
-            // any 4xx error is a rejection
-            .filter(status -> status.errorResponseStatus != null && status.errorResponseStatus / 100 == 4)
+            .filter(status -> status.isClientError())
             .map(status -> status.jurisdiction)
             .collect(toList());
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AccountLockedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AccountLockedException.java
@@ -1,8 +1,0 @@
-package uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam;
-
-public class AccountLockedException extends Exception {
-
-    public AccountLockedException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/LogInAttemptRejectedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/LogInAttemptRejectedException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam;
+
+public class LogInAttemptRejectedException extends Exception {
+
+    public LogInAttemptRejectedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTask.java
@@ -8,7 +8,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.EnvelopeEventProcessor;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.QueueProcessingReadinessChecker;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AccountLockedException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.LogInAttemptRejectedException;
 
 @Service
 @ConditionalOnProperty(value = "scheduling.task.consume-envelopes-queue.enabled", matchIfMissing = true)
@@ -40,8 +40,8 @@ public class EnvelopesQueueConsumeTask {
         }
     }
 
-    private boolean isReadyForConsumingMessages() throws AccountLockedException {
+    private boolean isReadyForConsumingMessages() throws LogInAttemptRejectedException {
         // TODO: add S2S and IDAM health checks
-        return processingReadinessChecker.isNoAccountLockedInIdam();
+        return processingReadinessChecker.isNoLogInAttemptRejectedByIdam();
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,14 +58,12 @@ hystrix:
       execution.timeout.enabled: false
       fallback.enabled: true
       circuitBreaker.enabled: true
-    check-no-account-locked:
+    check-jurisdiction-log-in:
       circuitBreaker:
         requestVolumeThreshold: 1
-        # suspend processing for 120 minutes when an account is locked - this will give us one hour
-        # to apply necessary changes and redeploy (IDAM keeps the lock for one hour of inactivity)
-        sleepWindowInMilliseconds: 7200000
+        sleepWindowInMilliseconds: 300000 # pause processing for 5 minutes if IDAM rejects log-in attempts
         errorThresholdPercentage: 1
 
 task:
-  check-no-account-locked:
-    check-validity-duration: PT5M # only ensure this often that no account is locked in IDAM
+  check-jurisdiction-log-in:
+    check-validity-duration: PT5M # only ensure this often that no log-in attempt is rejected by IDAM

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTaskTest.java
@@ -8,7 +8,7 @@ import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.EnvelopeEventProcessor;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.QueueProcessingReadinessChecker;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.AccountLockedException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.LogInAttemptRejectedException;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
@@ -28,13 +28,13 @@ public class EnvelopesQueueConsumeTaskTest {
     private EnvelopesQueueConsumeTask queueConsumeTask;
 
     @BeforeEach
-    public void setUp() throws AccountLockedException {
+    public void setUp() throws LogInAttemptRejectedException {
         queueConsumeTask = new EnvelopesQueueConsumeTask(
             envelopeEventProcessor,
             processingReadinessChecker
         );
 
-        given(processingReadinessChecker.isNoAccountLockedInIdam()).willReturn(true);
+        given(processingReadinessChecker.isNoLogInAttemptRejectedByIdam()).willReturn(true);
     }
 
     @Test
@@ -47,19 +47,19 @@ public class EnvelopesQueueConsumeTaskTest {
 
         // then
         verify(envelopeEventProcessor, times(4)).processNextMessage();
-        verify(processingReadinessChecker, times(4)).isNoAccountLockedInIdam();
+        verify(processingReadinessChecker, times(4)).isNoLogInAttemptRejectedByIdam();
     }
 
     @Test
     public void consumeMessages_does_not_process_when_account_locked_in_idam() throws Exception {
         // given
-        given(processingReadinessChecker.isNoAccountLockedInIdam()).willReturn(false);
+        given(processingReadinessChecker.isNoLogInAttemptRejectedByIdam()).willReturn(false);
 
         // when
         queueConsumeTask.consumeMessages();
 
         // then
-        verify(processingReadinessChecker, times(1)).isNoAccountLockedInIdam();
+        verify(processingReadinessChecker, times(1)).isNoLogInAttemptRejectedByIdam();
         verify(envelopeEventProcessor, never()).processNextMessage();
     }
 
@@ -73,6 +73,6 @@ public class EnvelopesQueueConsumeTaskTest {
 
         // then
         verify(envelopeEventProcessor, times(1)).processNextMessage();
-        verify(processingReadinessChecker, times(1)).isNoAccountLockedInIdam();
+        verify(processingReadinessChecker, times(1)).isNoLogInAttemptRejectedByIdam();
     }
 }

--- a/src/test/resources/application-integration.yaml
+++ b/src/test/resources/application-integration.yaml
@@ -37,12 +37,12 @@ hystrix:
       metrics.rollingStats:
         timeInMilliseconds: 500
         numBuckets: 5
-    check-no-account-locked:
+    check-jurisdiction-log-in:
       circuitBreaker:
         requestVolumeThreshold: 1
         sleepWindowInMilliseconds: 100000
         errorThresholdPercentage: 1
 
 task:
-  check-no-account-locked:
+  check-jurisdiction-log-in:
     check-validity-duration: PT0S


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-563

### Change description ###

Pause processing messages when IDAM rejects log-in attempts of any of the jurisdictions' accounts. The pause will take 5 minutes, after which the orchestrator will check again.

Any 4xx response from IDAM to log-in attempt is considered rejection.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
