### PR TITLE
Disable cmc on demo

### DIFF
--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,3 +1,3 @@
 idam_api_url = "https://idam-api.demo.platform.hmcts.net"
 idam_client_redirect_uri = "https://bulk-scan-orchestrator-demo.service.core-compute-demo.internal/oauth2/callback"
-supported_jurisdictions = ["SSCS", "BULKSCAN", "DIVORCE", "PROBATE", "CMC"]
+supported_jurisdictions = ["SSCS", "BULKSCAN", "DIVORCE", "PROBATE"]


### PR DESCRIPTION
CMC idam user is not configured yet on demo and this is causing the deployment to fail. So disabling the CMC on demo.