### PR TITLE
Suppress javax.activation

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -17,6 +17,15 @@
   </suppress>
 
   <suppress>
+    <notes><![CDATA[Nested dependency of adal4j. Microsoft needs to update strong relation of this library in ServiceBus]]></notes>
+    <gav regex="true">^org\.apache\.sling:org\.apache\.sling\.javax\.activation:0\.1\.0$</gav>
+    <cve>CVE-2013-4390</cve>
+    <cve>CVE-2016-0956</cve>
+    <cve>CVE-2016-5394</cve>
+    <cve>CVE-2016-6798</cve>
+  </suppress>
+
+  <suppress>
     <notes><![CDATA[No fix is available]]></notes>
     <gav regex="true">^org\.springframework\.security:spring-security-rsa:1\.0\.8\.RELEASE$</gav>
     <cve>CVE-2011-2731</cve>


### PR DESCRIPTION
### Change description ###

Newly reported as vulnerability. Insight scan:

```bash
javax.activation:activation:1.1
\--- javax.mail:mail:1.4.7
     \--- com.nimbusds:oauth2-oidc-sdk:5.24.1
          \--- com.microsoft.azure:adal4j:1.3.0
               \--- com.microsoft.azure:azure-servicebus:1.2.13
                    \--- compileClasspath
```

Even in next major service bus (I mean version 2) release same `adal4j` dependency is used so no quick fix in the future 😞. Not trying to bump it to any other version between current and currently latest (`1.6.4`)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
