### PR TITLE
Create validation methods required for attaching case by legacy ID

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -18,7 +18,7 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasAScannedRecord;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasAnId;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasCaseReference;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasAttachToCaseReference;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasJurisdiction;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.checkForDuplicatesOrElse;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.getDocumentNumbers;
@@ -48,7 +48,7 @@ public class AttachCaseCallbackService {
         return Validation
             .combine(
                 hasJurisdiction(exceptionRecord),
-                hasCaseReference(exceptionRecord),
+                hasAttachToCaseReference(exceptionRecord),
                 hasAnId(exceptionRecord),
                 hasAScannedRecord(exceptionRecord)
             )

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -6,7 +6,9 @@ import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 
 import static io.vavr.control.Validation.invalid;
@@ -14,6 +16,9 @@ import static io.vavr.control.Validation.valid;
 import static java.lang.String.format;
 
 final class CallbackValidations {
+
+    private static final String CASE_TYPE_ID_SUFFIX = "_ExceptionRecord";
+
     private static final Logger log = LoggerFactory.getLogger(CallbackValidations.class);
 
     private static final CaseReferenceValidator caseRefValidator = new CaseReferenceValidator();
@@ -45,8 +50,18 @@ final class CallbackValidations {
     }
 
     @Nonnull
-    static Validation<String, String> hasCaseReference(CaseDetails theCase) {
-        return caseRefValidator.validate(theCase);
+    static Validation<String, String> hasSearchCaseReferenceType(CaseDetails theCase) {
+        return caseRefValidator.validateCaseReferenceType(theCase);
+    }
+
+    @Nonnull
+    static Validation<String, String> hasSearchCaseReference(CaseDetails theCase) {
+        return caseRefValidator.validateSearchCaseReference(theCase);
+    }
+
+    @Nonnull
+    static Validation<String, String> hasAttachToCaseReference(CaseDetails theCase) {
+        return caseRefValidator.validateAttachToCaseReference(theCase);
     }
 
     @Nonnull
@@ -55,6 +70,28 @@ final class CallbackValidations {
             && theCase.getId() != null
             ? valid(theCase.getId())
             : invalid("Exception case has no Id");
+    }
+
+    @Nonnull
+    static Validation<String, String> hasServiceNameInCaseTypeId(CaseDetails theCase) {
+        return Optional
+            .ofNullable(theCase)
+            .map(CaseDetails::getCaseTypeId)
+            .filter(caseTypeId -> caseTypeId != null)
+            .map(caseTypeId -> {
+                if (caseTypeId.endsWith(CASE_TYPE_ID_SUFFIX)) {
+                    int serviceNameLength = caseTypeId.length() - CASE_TYPE_ID_SUFFIX.length();
+                    String serviceName = caseTypeId.substring(0, serviceNameLength).toLowerCase(Locale.getDefault());
+                    if (!serviceName.isEmpty()) {
+                        return Validation.<String, String>valid(serviceName);
+                    }
+                }
+
+                return Validation.<String, String>invalid(
+                    format("Case type ID (%s) has invalid format", caseTypeId)
+                );
+            })
+            .orElseGet(() -> invalid("No case type ID supplied"));
     }
 
     @Nonnull

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseReferenceValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseReferenceValidator.java
@@ -4,40 +4,97 @@ import com.google.common.base.Strings;
 import io.vavr.control.Validation;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import javax.annotation.Nonnull;
 
 import static io.vavr.control.Validation.invalid;
 import static java.lang.String.format;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes.CCD_CASE_REFERENCE;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes.EXTERNAL_CASE_REFERENCE;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.ATTACH_TO_CASE_REFERENCE;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SEARCH_CASE_REFERENCE;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SEARCH_CASE_REFERENCE_TYPE;
 
 class CaseReferenceValidator {
-    private static final String ATTACH_TO_CASE_REFERENCE = "attachToCaseReference";
+
+    private static final List<String> VALID_CASE_REFERENCE_TYPES = Arrays.asList(
+        CCD_CASE_REFERENCE,
+        EXTERNAL_CASE_REFERENCE
+    );
 
     @Nonnull
-    Validation<String, String> validate(CaseDetails theCase) {
-        return getCaseRef(theCase)
-            .flatMap(this::validateCaseRef)
+    Validation<String, String> validateAttachToCaseReference(CaseDetails theCase) {
+        return getCaseRef(theCase, ATTACH_TO_CASE_REFERENCE)
+            .map(this::validateCcdCaseRef)
             .orElseGet(() -> invalid("No case reference supplied"));
     }
 
-    private Optional<Validation<String, String>> validateCaseRef(Object caseRef) {
-        Optional<Validation<String, String>> valid = Optional.of(caseRef)
-            .filter(ref -> ref instanceof String)
-            .map(ref -> ((String) ref).replaceAll("[^0-9]", ""))
-            .map(Strings::emptyToNull)
-            .map(Validation::valid);
-        //This is done because java 8 does not have "Optional<T> orElse( Optional<T>)"
-        if (valid.isPresent()) {
-            return valid;
+    @Nonnull
+    Validation<String, String> validateSearchCaseReference(CaseDetails theCase) {
+        Validation<String, String> caseReferenceTypeValidation = validateCaseReferenceType(theCase);
+
+        if (caseReferenceTypeValidation.isValid()) {
+            Function<Object, Validation<String, String>> validationFunction =
+                CCD_CASE_REFERENCE.equals(caseReferenceTypeValidation.get())
+                    ? this::validateCcdCaseRef
+                    : this::validateExternalCaseRef;
+
+            return getCaseRef(theCase, SEARCH_CASE_REFERENCE)
+                .map(validationFunction)
+                .orElseGet(() -> invalid("No case reference supplied"));
         } else {
-            return Optional.of(invalid(format("Invalid case reference: '%s'", caseRef)));
+            return invalid("Cannot validate case reference due to the lack of valid case reference type");
         }
     }
 
-    private Optional<Object> getCaseRef(CaseDetails theCase) {
-        return Optional.ofNullable(theCase)
-            .map(CaseDetails::getData)
-            .map(data -> data.get(ATTACH_TO_CASE_REFERENCE));
+    @Nonnull
+    Validation<String, String> validateCaseReferenceType(CaseDetails theCase) {
+        return getSearchCaseReferenceType(theCase)
+            .map(searchCaseReferenceType -> {
+                    if (VALID_CASE_REFERENCE_TYPES.contains(searchCaseReferenceType)) {
+                        return Validation.<String, String>valid((String) searchCaseReferenceType);
+                    } else {
+                        return Validation.<String, String>invalid(
+                            "Invalid case reference type supplied: " + searchCaseReferenceType
+                        );
+                    }
+                }
+            ).orElseGet(() -> invalid("No case reference type supplied"));
     }
 
+    private Validation<String, String> validateCcdCaseRef(Object caseRef) {
+        return Optional.of(caseRef)
+            .filter(ref -> ref instanceof String)
+            .map(ref -> ((String) ref).replaceAll("[^0-9]", ""))
+            .filter(ref -> !Strings.isNullOrEmpty(ref))
+            .map(Validation::<String, String>valid)
+            .orElseGet(() -> invalid(format("Invalid case reference: '%s'", caseRef)));
+    }
+
+    private Validation<String, String> validateExternalCaseRef(Object caseRef) {
+        return Optional.of(caseRef)
+            .filter(ref -> ref instanceof String)
+            .map(ref -> ((String) ref).trim())
+            .filter(ref -> !Strings.isNullOrEmpty(ref))
+            .map(Validation::<String, String>valid)
+            .orElseGet(() -> invalid(format("Invalid external case reference: '%s'", caseRef)));
+    }
+
+    private Optional<Object> getCaseRef(CaseDetails theCase, String caseRefFieldName) {
+        return Optional.ofNullable(theCase)
+            .map(CaseDetails::getData)
+            .map(data -> data.get(caseRefFieldName));
+    }
+
+    private Optional<Object> getSearchCaseReferenceType(CaseDetails theCase) {
+        return Optional
+            .ofNullable(theCase)
+            .map(CaseDetails::getData)
+            .filter(data -> data != null)
+            .map(data -> data.get(SEARCH_CASE_REFERENCE_TYPE))
+            .filter(refType -> refType != null);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/definition/CaseReferenceTypes.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/definition/CaseReferenceTypes.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition;
+
+public final class CaseReferenceTypes {
+
+    public static final String CCD_CASE_REFERENCE = "ccdCaseReference";
+    public static final String EXTERNAL_CASE_REFERENCE = "externalCaseReference";
+
+    private CaseReferenceTypes() {
+        // hiding the constructor
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/definition/ExceptionRecordFields.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/definition/ExceptionRecordFields.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition;
+
+/**
+ * Constants representing exception record field names, as per CCD definition.
+ */
+public final class ExceptionRecordFields {
+
+    public static final String SEARCH_CASE_REFERENCE = "searchCaseReference";
+    public static final String SEARCH_CASE_REFERENCE_TYPE = "searchCaseReferenceType";
+    public static final String ATTACH_TO_CASE_REFERENCE = "attachToCaseReference";
+
+    private ExceptionRecordFields() {
+        // hiding the constructor
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/JurisdictionToUserMapping.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/JurisdictionToUserMapping.java
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.AbstractMap;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static java.util.Map.Entry;
@@ -27,7 +28,7 @@ public class JurisdictionToUserMapping {
     }
 
     private Entry<String, Credential> createEntry(Entry<String, Map<String, String>> entry) {
-        String key = entry.getKey().toLowerCase();
+        String key = entry.getKey().toLowerCase(Locale.getDefault());
         Credential cred = new Credential(entry.getValue().get("username"), entry.getValue().get("password"));
 
         return new AbstractMap.SimpleEntry<>(key, cred);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
@@ -18,10 +18,32 @@ class TestCaseBuilder {
         return builder.apply(CaseDetails.builder()).build();
     }
 
-    static CaseDetails caseWithReference(Object caseReference) {
+    static CaseDetails caseWithAttachReference(Object caseReference) {
         Map<String, Object> data = new HashMap<>();
         data.put("attachToCaseReference", caseReference);
         return createCaseWith(b -> b.data(data));
+    }
+
+    static CaseDetails caseWithSearchCaseReferenceType(Object searchCaseReferenceType) {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("searchCaseReferenceType", searchCaseReferenceType);
+        return createCaseWith(b -> b.data(caseData));
+    }
+
+    static CaseDetails caseWithCcdSearchCaseReference(Object searchCaseReference) {
+        return caseWithSearchCaseReference("ccdCaseReference", searchCaseReference);
+    }
+
+    static CaseDetails caseWithExternalSearchCaseReference(Object searchCaseReference) {
+        return caseWithSearchCaseReference("externalCaseReference", searchCaseReference);
+    }
+
+    static CaseDetails caseWithSearchCaseReference(Object searchCaseReferenceType, Object searchCaseReference) {
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put("searchCaseReference", searchCaseReference);
+        caseData.put("searchCaseReferenceType", searchCaseReferenceType);
+
+        return createCaseWith(b -> b.data(caseData));
     }
 
     static CaseDetails caseWithDocument(List<Map<String, Object>> caseReference) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-584

### Change description ###

Depending on which callback endpoint is used, the case will be validated by either:
- `attachToCaseReference` - the old one, which only contains CCD case references and currently serves a search field and a reference field
- `searchCaseReference` + `searchCaseReferenceType` - fields used for search purposes only. For this kind of search we also need to retrieve the service name from case type ID

This PR makes all the changes on the validation side for the above searches to be possible.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
