### PR TITLE
Migrate ServiceBus `(get|set)Body` functions to new methods

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessor.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.logging.AppInsights;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.EnvelopeHandler;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.IProcessedEnvelopeNotifier;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.MessageBodyRetriever;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.NotificationSendingException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.exceptions.InvalidMessageException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.exceptions.MessageProcessingException;
@@ -67,14 +68,13 @@ public class EnvelopeEventProcessor {
         return message != null;
     }
 
-    @SuppressWarnings("squid:CallToDeprecatedMethod") // for sonarqube complaining about deprecated things being used
     private MessageProcessingResult process(IMessage message) {
         log.info("Started processing message with ID {}", message.getMessageId());
 
         Envelope envelope = null;
 
         try {
-            envelope = parse(message.getBody());
+            envelope = parse(MessageBodyRetriever.getBinaryData(message.getMessageBody()));
             logMessageParsed(message, envelope);
             envelopeHandler.handleEnvelope(envelope);
             processedEnvelopeNotifier.notify(envelope.id);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/MessageBodyRetriever.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/MessageBodyRetriever.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus;
+
+import com.microsoft.azure.servicebus.MessageBody;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+
+public final class MessageBodyRetriever {
+
+    public static byte[] getBinaryData(MessageBody messageBody) {
+        List<byte[]> binaryData = messageBody.getBinaryData();
+
+        return CollectionUtils.isEmpty(binaryData) ? null : binaryData.get(0);
+    }
+
+    private MessageBodyRetriever() {
+        // utility class construct
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/CleanupEnvelopesDlqTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/CleanupEnvelopesDlqTask.java
@@ -10,6 +10,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.EnvelopeParser;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.MessageBodyRetriever;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.exceptions.ConnectionException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.exceptions.InvalidMessageException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
@@ -82,10 +83,11 @@ public class CleanupEnvelopesDlqTask {
         }
     }
 
-    @SuppressWarnings("squid:CallToDeprecatedMethod") // for sonarqube complaining about deprecated things being used
     private void logMessage(IMessage msg) {
         try {
-            Envelope envelope = EnvelopeParser.parse(msg.getBody());
+            Envelope envelope = EnvelopeParser.parse(
+                MessageBodyRetriever.getBinaryData(msg.getMessageBody())
+            );
 
             log.info(
                 "Completing dlq message. messageId: {}, Envelope ID: {}, File name: {}, Jurisdiction: {},"

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTask.java
@@ -34,17 +34,20 @@ public class EnvelopesQueueConsumeTask {
             while (queueMayHaveMessages && isReadyForConsumingMessages()) {
                 queueMayHaveMessages = envelopeEventProcessor.processNextMessage();
             }
-        } catch (Exception e) {
-            log.error("An error occurred when running the 'consume messages' task", e);
-
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
+        } catch (InterruptedException exception) {
+            logTaskError(exception);
+            Thread.currentThread().interrupt();
+        } catch (Exception exception) {
+            logTaskError(exception);
         }
     }
 
     private boolean isReadyForConsumingMessages() throws LogInAttemptRejectedException {
         // TODO: add S2S and IDAM health checks
         return processingReadinessChecker.isNoLogInAttemptRejectedByIdam();
+    }
+
+    private void logTaskError(Exception exception) {
+        log.error("An error occurred when running the 'consume messages' task", exception);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTask.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.tasks;
 
-import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -28,7 +27,7 @@ public class EnvelopesQueueConsumeTask {
     }
 
     @Scheduled(fixedDelay = 1000)
-    public void consumeMessages() throws ServiceBusException, InterruptedException {
+    public void consumeMessages() {
         try {
             boolean queueMayHaveMessages = true;
 
@@ -37,6 +36,10 @@ public class EnvelopesQueueConsumeTask {
             }
         } catch (Exception e) {
             log.error("An error occurred when running the 'consume messages' task", e);
+
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/EnvelopeEventProcessorTest.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.google.common.collect.ImmutableList;
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IMessageReceiver;
+import com.microsoft.azure.servicebus.MessageBody;
 import com.microsoft.azure.servicebus.primitives.ServiceBusException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,7 +92,8 @@ class EnvelopeEventProcessorTest {
     @Test
     public void should_not_throw_exception_when_queue_message_is_invalid() throws Exception {
         IMessage invalidMessage = mock(IMessage.class);
-        given(invalidMessage.getBody()).willReturn("foo".getBytes());
+        given(invalidMessage.getMessageBody())
+            .willReturn(MessageBody.fromBinaryData(ImmutableList.of("foo".getBytes())));
         given(messageReceiver.receive()).willReturn(invalidMessage);
 
         assertThat(processor.processNextMessage()).isTrue();
@@ -126,7 +129,9 @@ class EnvelopeEventProcessorTest {
     public void should_dead_letter_the_message_when_unrecoverable_failure() throws Exception {
         // given
         IMessage message = mock(IMessage.class);
-        given(message.getBody()).willReturn("invalid body".getBytes(Charset.defaultCharset()));
+        given(message.getMessageBody()).willReturn(
+            MessageBody.fromBinaryData(ImmutableList.of("invalid body".getBytes(Charset.defaultCharset())))
+        );
         given(message.getLockToken()).willReturn(UUID.randomUUID());
         given(messageReceiver.receive()).willReturn(message);
 
@@ -249,7 +254,9 @@ class EnvelopeEventProcessorTest {
         // given
         String envelopeId = UUID.randomUUID().toString();
         IMessage message = mock(IMessage.class);
-        given(message.getBody()).willReturn(envelopeJson(NEW_APPLICATION, "caseRef123", envelopeId));
+        given(message.getMessageBody()).willReturn(
+            MessageBody.fromBinaryData(ImmutableList.of(envelopeJson(NEW_APPLICATION, "caseRef123", envelopeId)))
+        );
         given(message.getLockToken()).willReturn(UUID.randomUUID());
         given(messageReceiver.receive()).willReturn(message);
 
@@ -287,7 +294,8 @@ class EnvelopeEventProcessorTest {
 
     private IMessage getValidMessage() {
         IMessage message = mock(IMessage.class);
-        given(message.getBody()).willReturn(envelopeJson());
+        given(message.getMessageBody())
+            .willReturn(MessageBody.fromBinaryData(ImmutableList.of(envelopeJson())));
         return message;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/ProcessedEnvelopeNotifierTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/ProcessedEnvelopeNotifierTest.java
@@ -50,7 +50,7 @@ class ProcessedEnvelopeNotifierTest {
         assertThat(message.getMessageId()).isEqualTo(envelopeId);
         assertThat(message.getContentType()).isEqualTo("application/json");
 
-        String messageBodyJson = new String(message.getBody());
+        String messageBodyJson = new String(MessageBodyRetriever.getBinaryData(message.getMessageBody()));
         String expectedMessageBodyJson = String.format("{\"id\":\"%s\"}", envelopeId);
         JSONAssert.assertEquals(expectedMessageBodyJson, messageBodyJson, JSONCompareMode.LENIENT);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/CleanupEnvelopesDlqTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/CleanupEnvelopesDlqTaskTest.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.tasks;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.azure.servicebus.IMessage;
 import com.microsoft.azure.servicebus.IMessageReceiver;
+import com.microsoft.azure.servicebus.MessageBody;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,7 +64,8 @@ class CleanupEnvelopesDlqTaskTest {
         //given
         UUID uuid = UUID.randomUUID();
         given(message.getLockToken()).willReturn(uuid);
-        given(message.getBody()).willReturn(SampleData.envelopeJson());
+        given(message.getMessageBody())
+            .willReturn(MessageBody.fromBinaryData(ImmutableList.of(SampleData.envelopeJson())));
         given(message.getProperties())
             .willReturn(
                 ImmutableMap.of(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/tasks/EnvelopesQueueConsumeTaskTest.java
@@ -75,4 +75,18 @@ public class EnvelopesQueueConsumeTaskTest {
         verify(envelopeEventProcessor, times(1)).processNextMessage();
         verify(processingReadinessChecker, times(1)).isNoLogInAttemptRejectedByIdam();
     }
+
+    @Test
+    public void consumeMessages_stops_processing_when_envelope_processor_throws_interrupted_exception()
+        throws Exception {
+        // given
+        willThrow(new InterruptedException()).given(envelopeEventProcessor).processNextMessage();
+
+        // when
+        queueConsumeTask.consumeMessages();
+
+        // then
+        verify(envelopeEventProcessor, times(1)).processNextMessage();
+        verify(processingReadinessChecker, times(1)).isNoLogInAttemptRejectedByIdam();
+    }
 }


### PR DESCRIPTION
### Change description ###

Reference hmcts/bulk-scan-processor#643

Bonus: remove suppressed checked exceptions and call `interrupt` in relevant case

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
