### PR TITLE
Stop supporting CMC in sprod

### DIFF
--- a/infrastructure/sprod.tfvars
+++ b/infrastructure/sprod.tfvars
@@ -1,4 +1,4 @@
 capacity = "2"
 idam_api_url = "http://idam-api-idam-sprod.service.core-compute-idam-sprod.internal"
 idam_client_redirect_uri = "https://bulk-scan-orchestrator-sprod.service.core-compute-sprod.internal/oauth2/callback"
-supported_jurisdictions = ["SSCS", "BULKSCAN", "DIVORCE", "PROBATE", "CMC"]
+supported_jurisdictions = ["SSCS", "BULKSCAN", "DIVORCE", "PROBATE"]


### PR DESCRIPTION
### Change description ###

Stop supporting CMC in sprod. CMC doesn't have credentials set up in this environment, which is meant to go down soon, anyway.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
