### PR TITLE
Use clearer names when handling envelopes

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -34,7 +34,10 @@ class AttachDocsToSupplementaryEvidence {
         this.ccdApi = ccdApi;
     }
 
-    public void publish(Envelope envelope, CaseDetails existingCase) {
+    /**
+     * Attaches document from given envelope to existing case.
+     */
+    public void attach(Envelope envelope, CaseDetails existingCase) {
         if (mapper.getDocsToAdd(getDocuments(existingCase), envelope.documents).isEmpty()) {
             log.warn("Envelope {} has no new documents. CCD Case {} not updated", envelope.id, existingCase.getId());
         } else {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -35,7 +35,7 @@ class AttachDocsToSupplementaryEvidence {
     }
 
     /**
-     * Attaches document from given envelope to existing case.
+     * Attaches documents from given envelope to existing case.
      */
     public void attach(Envelope envelope, CaseDetails existingCase) {
         if (mapper.getDocsToAdd(getDocuments(existingCase), envelope.documents).isEmpty()) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -34,7 +34,10 @@ public class CreateExceptionRecord {
         this.ccdApi = ccdApi;
     }
 
-    public void publish(Envelope envelope) {
+    /**
+     * Creates an Exception Record from given envelope.
+     */
+    public void createFrom(Envelope envelope) {
         log.info("Creating exception record for envelope {}", envelope.id);
 
         CcdAuthenticator authenticator = ccdApi.authenticateJurisdiction(envelope.jurisdiction);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandler.java
@@ -9,16 +9,16 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 @Service
 public class EnvelopeHandler {
 
-    private final AttachDocsToSupplementaryEvidence attachDocsPublisher;
+    private final AttachDocsToSupplementaryEvidence evidenceAttacher;
     private final CreateExceptionRecord exceptionRecordCreator;
     private final CaseRetriever caseRetriever;
 
     public EnvelopeHandler(
-        AttachDocsToSupplementaryEvidence attachDocsPublisher,
+        AttachDocsToSupplementaryEvidence evidenceAttacher,
         CreateExceptionRecord exceptionRecordCreator,
         CaseRetriever caseRetriever
     ) {
-        this.attachDocsPublisher = attachDocsPublisher;
+        this.evidenceAttacher = evidenceAttacher;
         this.exceptionRecordCreator = exceptionRecordCreator;
         this.caseRetriever = caseRetriever;
     }
@@ -31,15 +31,15 @@ public class EnvelopeHandler {
                     : caseRetriever.retrieve(envelope.jurisdiction, envelope.caseRef);
 
                 if (caseDetails == null) {
-                    exceptionRecordCreator.publish(envelope);
+                    exceptionRecordCreator.createFrom(envelope);
                 } else {
-                    attachDocsPublisher.publish(envelope, caseDetails);
+                    evidenceAttacher.attach(envelope, caseDetails);
                 }
 
                 break;
             case EXCEPTION:
             case NEW_APPLICATION:
-                exceptionRecordCreator.publish(envelope);
+                exceptionRecordCreator.createFrom(envelope);
                 break;
             default:
                 throw new UnknownClassificationException(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
@@ -39,15 +39,15 @@ class AttachDocsToSupplementaryEvidenceTest {
     @Mock
     private SupplementaryEvidenceMapper mapper;
 
-    private AttachDocsToSupplementaryEvidence eventPublisher;
+    private AttachDocsToSupplementaryEvidence attacher;
 
     @BeforeEach
     void setUp() {
-        this.eventPublisher = new AttachDocsToSupplementaryEvidence(mapper, ccdApi);
+        this.attacher = new AttachDocsToSupplementaryEvidence(mapper, ccdApi);
     }
 
     @Test
-    void createSupplementaryEvidence_starts_and_submits_event() {
+    void should_start_and_submit_event_for_valid_envelope() {
         // given
         given(ccdApi.authenticateJurisdiction(any())).willReturn(AUTH_DETAILS);
 
@@ -75,7 +75,7 @@ class AttachDocsToSupplementaryEvidenceTest {
         given(mapper.getDocsToAdd(any(), any())).willReturn(envelope.documents);
 
         // when
-        eventPublisher.publish(envelope, caseDetails);
+        attacher.attach(envelope, caseDetails);
 
         // then
         verify(ccdApi).startEvent(
@@ -113,7 +113,7 @@ class AttachDocsToSupplementaryEvidenceTest {
             .willReturn(emptyList()); // no new docs
 
         // when
-        eventPublisher.publish(envelope, existingCase);
+        attacher.attach(envelope, existingCase);
 
         // then
         verify(ccdApi, never()).startEvent(any(), any(), any(), any(), any());

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandlerTest.java
@@ -56,7 +56,7 @@ class EnvelopeHandlerTest {
         envelopeHandler.handleEnvelope(envelope);
 
         // then
-        verify(attachDocsToSupplementaryEvidence).publish(envelope, caseDetails);
+        verify(attachDocsToSupplementaryEvidence).attach(envelope, caseDetails);
     }
 
     @Test
@@ -69,7 +69,7 @@ class EnvelopeHandlerTest {
         envelopeHandler.handleEnvelope(envelope);
 
         // then
-        verify(this.createExceptionRecord).publish(envelope);
+        verify(this.createExceptionRecord).createFrom(envelope);
     }
 
     @Test
@@ -81,7 +81,7 @@ class EnvelopeHandlerTest {
         envelopeHandler.handleEnvelope(envelope);
 
         // then
-        verify(this.createExceptionRecord).publish(envelope);
+        verify(this.createExceptionRecord).createFrom(envelope);
         verify(caseRetriever, never()).retrieve(JURSIDICTION, CASE_REF);
     }
 
@@ -94,7 +94,7 @@ class EnvelopeHandlerTest {
         envelopeHandler.handleEnvelope(envelope);
 
         // then
-        verify(this.createExceptionRecord).publish(envelope);
+        verify(this.createExceptionRecord).createFrom(envelope);
         verify(caseRetriever, never()).retrieve(any(), any());
     }
 


### PR DESCRIPTION
A follow up on the refactoring (both recent and previous).
With abstract base class removed methods no longer need to share the same name.
Also renamed some variable and tests.