### PR TITLE
Bump servicebus 1.2.13 -> 1.2.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,7 +217,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version:'0.0.4'
   compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version:'0.0.4'
 
-  compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.13'
+  compile group: 'com.microsoft.azure', name: 'azure-servicebus', version: '1.2.14'
   compile group: 'io.vavr', name: 'vavr', version: '0.10.0'
 
   annotationProcessor group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Migrate ServiceBus to v2 major release](https://tools.hmcts.net/jira/browse/BPS-643)

### Change description ###

Reference: hmcts/bulk-scan-processor#691

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
