### PR TITLE
Add a class for finding a case for an envelope

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseFinder.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseFinder.java
@@ -1,0 +1,122 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class CaseFinder {
+
+    private static final Logger log = LoggerFactory.getLogger(CaseFinder.class);
+
+    private final CcdApi ccdApi;
+
+    public CaseFinder(CcdApi ccdApi) {
+        this.ccdApi = ccdApi;
+    }
+
+    public Optional<CaseDetails> findCase(Envelope envelope) {
+        Optional<CaseDetails> caseDetails = Strings.isNullOrEmpty(envelope.caseRef)
+            ? Optional.empty()
+            : getCaseByCcdId(envelope.caseRef, envelope.jurisdiction);
+
+        if (caseDetails.isPresent()) {
+            return caseDetails;
+        } else if (!Strings.isNullOrEmpty(envelope.legacyCaseRef)) {
+            return getCaseByLegacyId(envelope);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<CaseDetails> getCaseByLegacyId(Envelope envelope) {
+        List<Long> ccdCaseRefs =
+            ccdApi.getCaseRefsByLegacyId(envelope.legacyCaseRef, envelope.container);
+
+        if (ccdCaseRefs.size() == 1) {
+            Long caseCcdRef = ccdCaseRefs.get(0);
+
+            Optional<CaseDetails> details =
+                getCaseByCcdId(String.valueOf(caseCcdRef), envelope.jurisdiction);
+
+            logCaseRetrievalResultBasedOnLegacyIdSearch(
+                details.isPresent(),
+                caseCcdRef,
+                envelope.legacyCaseRef,
+                envelope.id);
+
+            return details;
+        } else {
+            logWrongNumberOfSearchResultsByLegacyId(
+                ccdCaseRefs,
+                envelope.legacyCaseRef,
+                envelope.id
+            );
+
+            return Optional.empty();
+        }
+    }
+
+    private void logWrongNumberOfSearchResultsByLegacyId(
+        List<Long> ccdCaseIds,
+        String legacyCaseRef,
+        String envelopeId
+    ) {
+        if (ccdCaseIds.isEmpty()) {
+            log.info(
+                "Case not found by legacy ID '{}'. Envelope ID: '{}'",
+                legacyCaseRef,
+                envelopeId
+            );
+        } else {
+            log.warn(
+                "Multiple cases found for legacy ID '{}'. Envelope ID: '{}'",
+                legacyCaseRef,
+                envelopeId
+            );
+        }
+    }
+
+    private void logCaseRetrievalResultBasedOnLegacyIdSearch(
+        boolean caseFound,
+        Long ccdCaseRef,
+        String legacyCaseRef,
+        String envelopeId
+    ) {
+        if (caseFound) {
+            log.info(
+                "Found case for legacy ID '{}'. Case CCD ID: '{}'. Envelope ID: '{}'",
+                legacyCaseRef,
+                ccdCaseRef,
+                envelopeId
+            );
+        } else {
+            String messageFormat =
+                "Case was found by legacy ID, but subsequent read from CCD couldn't find it. "
+                    + "Legacy ID: '{}', CCD ID: '{}', Envelope ID: '{}'";
+
+            log.warn(
+                messageFormat,
+                legacyCaseRef,
+                ccdCaseRef,
+                envelopeId
+            );
+        }
+    }
+
+    private Optional<CaseDetails> getCaseByCcdId(String ccdCaseRef, String jurisdiction) {
+        try {
+            return Optional.of(ccdApi.getCase(ccdCaseRef, jurisdiction));
+        } catch (CaseNotFoundException e) {
+            return Optional.empty();
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseFinder.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseFinder.java
@@ -101,7 +101,7 @@ public class CaseFinder {
                 "Case was found by legacy ID, but subsequent read from CCD couldn't find it. "
                     + "Legacy ID: '{}', CCD ID: '{}', Envelope ID: '{}'";
 
-            log.warn(
+            log.error(
                 messageFormat,
                 legacyCaseRef,
                 ccdCaseRef,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseFinderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseFinderTest.java
@@ -1,0 +1,213 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+public class CaseFinderTest {
+
+    private static final String JURISDICTION = "BULKSCAN";
+    private static final String SERVICE = "bulkscan";
+    private static final String CASE_REF = "123123123";
+    private static final String LEGACY_CASE_REF = "legacy-id-123";
+
+    @Mock
+    private CcdApi ccdApi;
+
+    private CaseFinder caseFinder;
+
+    @BeforeEach
+    public void setUp() {
+        caseFinder = new CaseFinder(ccdApi);
+    }
+
+    @Test
+    public void should_search_case_by_ccd_id_when_envelope_has_it() {
+        given(ccdApi.getCase(CASE_REF, JURISDICTION))
+            .willReturn(CaseDetails.builder().build());
+
+        caseFinder.findCase(
+            envelope(CASE_REF, null)
+        );
+
+        verify(ccdApi).getCase(CASE_REF, JURISDICTION);
+    }
+
+    @Test
+    public void should_return_case_when_found_by_ccd_id() {
+        CaseDetails expectedCase = mock(CaseDetails.class);
+        given(ccdApi.getCase(CASE_REF, JURISDICTION)).willReturn(expectedCase);
+
+        Optional<CaseDetails> result = caseFinder.findCase(
+            envelope(CASE_REF, LEGACY_CASE_REF)
+        );
+
+        assertThat(result).hasValue(expectedCase);
+    }
+
+    @Test
+    public void should_return_empty_when_case_not_found_by_ccd_id_and_legacy_id_is_absent() {
+        given(ccdApi.getCase(CASE_REF, JURISDICTION)).willThrow(
+            new CaseNotFoundException("Case not found")
+        );
+
+        Optional<CaseDetails> result = caseFinder.findCase(
+            envelope(CASE_REF, null)
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void should_return_empty_when_neither_id_is_present() {
+        Optional<CaseDetails> result = caseFinder.findCase(
+            envelope(null, null)
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void should_search_case_by_legacy_id_when_legacy_id_is_present_and_ccd_id_is_not() {
+        // given
+        given(ccdApi.getCaseRefsByLegacyId(LEGACY_CASE_REF, SERVICE))
+            .willReturn(emptyList());
+
+        // when
+        caseFinder.findCase(
+            envelope(null, LEGACY_CASE_REF)
+        );
+
+        // then
+        verify(ccdApi).getCaseRefsByLegacyId(LEGACY_CASE_REF, SERVICE);
+        verifyNoMoreInteractions(ccdApi);
+    }
+
+    @Test
+    public void should_search_case_by_legacy_id_when_not_found_by_ccd_id() {
+        // given
+        given(ccdApi.getCase(CASE_REF, JURISDICTION)).willThrow(
+            new CaseNotFoundException("Case not found")
+        );
+
+        given(ccdApi.getCaseRefsByLegacyId(LEGACY_CASE_REF, SERVICE))
+            .willReturn(emptyList());
+
+        // when
+        caseFinder.findCase(
+            envelope(CASE_REF, LEGACY_CASE_REF)
+        );
+
+        // then
+        InOrder inOrder = inOrder(ccdApi);
+        inOrder.verify(ccdApi).getCase(CASE_REF, JURISDICTION);
+        inOrder.verify(ccdApi).getCaseRefsByLegacyId(LEGACY_CASE_REF, SERVICE);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void should_return_empty_when_legacy_id_search_has_no_results() {
+        given(ccdApi.getCaseRefsByLegacyId(LEGACY_CASE_REF, SERVICE))
+            .willReturn(emptyList());
+
+        Optional<CaseDetails> result = caseFinder.findCase(
+            envelope(null, LEGACY_CASE_REF)
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void should_retrieve_case_by_ccd_id_when_search_by_legacy_id_has_one_result() {
+        // given
+        given(ccdApi.getCaseRefsByLegacyId(LEGACY_CASE_REF, SERVICE))
+            .willReturn(Arrays.asList(Long.parseLong(CASE_REF)));
+
+        CaseDetails expectedCase = CaseDetails.builder().build();
+
+        given(ccdApi.getCase(CASE_REF, JURISDICTION)).willReturn(expectedCase);
+
+        // when
+        caseFinder.findCase(
+            envelope(null, LEGACY_CASE_REF)
+        );
+
+        // then
+        InOrder inOrder = inOrder(ccdApi);
+        inOrder.verify(ccdApi).getCaseRefsByLegacyId(LEGACY_CASE_REF, SERVICE);
+        inOrder.verify(ccdApi).getCase(CASE_REF, JURISDICTION);
+    }
+
+    @Test
+    public void should_return_case_when_found_by_legacy_id() {
+        // given
+        given(ccdApi.getCaseRefsByLegacyId(LEGACY_CASE_REF, SERVICE))
+            .willReturn(Arrays.asList(Long.parseLong(CASE_REF)));
+
+        CaseDetails expectedCase = CaseDetails.builder().build();
+        given(ccdApi.getCase(CASE_REF, JURISDICTION)).willReturn(expectedCase);
+
+        // when
+        Optional<CaseDetails> result = caseFinder.findCase(
+            envelope(null, LEGACY_CASE_REF)
+        );
+
+        // then
+        assertThat(result).hasValue(expectedCase);
+    }
+
+    @Test
+    public void should_return_empty_when_case_retrieval_based_on_legacy_id_results_does_not_find_case() {
+        // given
+        given(ccdApi.getCaseRefsByLegacyId(LEGACY_CASE_REF, SERVICE))
+            .willReturn(Arrays.asList(Long.parseLong(CASE_REF)));
+
+        given(ccdApi.getCase(CASE_REF, JURISDICTION)).willThrow(
+            new CaseNotFoundException("Case not found")
+        );
+
+        // when
+        Optional<CaseDetails> result = caseFinder.findCase(
+            envelope(null, LEGACY_CASE_REF)
+        );
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    private Envelope envelope(String caseRef, String legacyCaseRef) {
+        return new Envelope(
+            "id123",
+            caseRef,
+            legacyCaseRef,
+            "pobox123",
+            JURISDICTION,
+            SERVICE,
+            "zip-file-name.zip",
+            Instant.now(),
+            Instant.now(),
+            Classification.SUPPLEMENTARY_EVIDENCE,
+            emptyList(),
+            emptyList()
+        );
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-588

### Change description ###

Add a class for finding a case based on the content of the envelope (`caseRef` and `legacyCaseRef` being the crucial criteria). This class will completely replace `CaseRetriever`, which currently duplicates some functionality of `CcdApi`.

This class is not used yet - that will be change in the next PR.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
