### PR TITLE
Attach supplementary evidence using case ref from found case

### DIFF
--- a/src/integrationTest/resources/ccd/response/sample-case.json
+++ b/src/integrationTest/resources/ccd/response/sample-case.json
@@ -1,5 +1,5 @@
 {
-  "id": 111,
+  "id": 1539007368674134,
   "jurisdiction": "BULKSCAN",
   "case_type_id": "Bulk_Scanned",
   "created_date": "2018-01-01T12:34:56.123Z",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -49,7 +49,7 @@ class AttachDocsToSupplementaryEvidence {
                 authenticator,
                 envelope.jurisdiction,
                 existingCase.getCaseTypeId(),
-                envelope.caseRef,
+                existingCase.getId().toString(),
                 EVENT_TYPE_ID
             );
 
@@ -57,14 +57,14 @@ class AttachDocsToSupplementaryEvidence {
                 "Started event in CCD for envelope ID: {}. File name: {}. Case ref: {}",
                 envelope.id,
                 envelope.zipFileName,
-                envelope.caseRef
+                existingCase.getId().toString()
             );
 
             ccdApi.submitEvent(
                 authenticator,
                 envelope.jurisdiction,
                 existingCase.getCaseTypeId(),
-                envelope.caseRef,
+                existingCase.getId().toString(),
                 buildCaseDataContent(envelope, startEventResp)
             );
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -57,7 +57,7 @@ class AttachDocsToSupplementaryEvidence {
                 "Started event in CCD for envelope ID: {}. File name: {}. Case ref: {}",
                 envelope.id,
                 envelope.zipFileName,
-                existingCase.getId().toString()
+                existingCase.getId()
             );
 
             ccdApi.submitEvent(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
@@ -68,8 +68,8 @@ class AttachDocsToSupplementaryEvidenceTest {
         given(ccdApi.startEvent(any(), any(), any(), any(), any())).willReturn(startEventResponse);
         given(ccdApi.submitEvent(any(), any(), any(), any(), any())).willReturn(caseDetails);
 
-        Long caseId = 123456L;
-        given(caseDetails.getId()).willReturn(caseId);
+        String caseId = "1539007368674134";
+        given(caseDetails.getId()).willReturn(Long.parseLong(caseId));
 
         Envelope envelope = SampleData.envelope(2);
 
@@ -83,7 +83,7 @@ class AttachDocsToSupplementaryEvidenceTest {
             AUTH_DETAILS,
             envelope.jurisdiction,
             CASE_TYPE_ID,
-            caseId.toString(),
+            caseId,
             EVENT_TYPE_ID
         );
         ArgumentCaptor<CaseDataContent> caseDataContentCaptor = ArgumentCaptor.forClass(CaseDataContent.class);
@@ -92,7 +92,7 @@ class AttachDocsToSupplementaryEvidenceTest {
             eq(AUTH_DETAILS),
             eq(envelope.jurisdiction),
             eq(CASE_TYPE_ID),
-            eq(caseId.toString()),
+            eq(caseId),
             caseDataContentCaptor.capture()
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
@@ -68,7 +68,8 @@ class AttachDocsToSupplementaryEvidenceTest {
         given(ccdApi.startEvent(any(), any(), any(), any(), any())).willReturn(startEventResponse);
         given(ccdApi.submitEvent(any(), any(), any(), any(), any())).willReturn(caseDetails);
 
-        given(caseDetails.getId()).willReturn(1L);
+        Long caseId = 123456L;
+        given(caseDetails.getId()).willReturn(caseId);
 
         Envelope envelope = SampleData.envelope(2);
 
@@ -82,7 +83,7 @@ class AttachDocsToSupplementaryEvidenceTest {
             AUTH_DETAILS,
             envelope.jurisdiction,
             CASE_TYPE_ID,
-            envelope.caseRef,
+            caseId.toString(),
             EVENT_TYPE_ID
         );
         ArgumentCaptor<CaseDataContent> caseDataContentCaptor = ArgumentCaptor.forClass(CaseDataContent.class);
@@ -91,7 +92,7 @@ class AttachDocsToSupplementaryEvidenceTest {
             eq(AUTH_DETAILS),
             eq(envelope.jurisdiction),
             eq(CASE_TYPE_ID),
-            eq(envelope.caseRef),
+            eq(caseId.toString()),
             caseDataContentCaptor.capture()
         );
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-588

### Change description ###

Attach supplementary evidence using case ref from found case, instead of case ref from the envelope, which might be null.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
