### PR TITLE
Feature/add delivery date to scanned document

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
@@ -106,8 +106,9 @@ class AttachExceptionRecordToExistingCaseTest {
         CaseDetails caseDetails =
             ccdCaseCreator.createCase(
                 singletonList(
-                    new Document("certificate1.pdf", "154565768", "other", null, Instant.now(), documentUuid, Instant.now())
-                ),
+                    new Document(
+                        "certificate1.pdf", "154565768", "other", null, Instant.now(), documentUuid, Instant.now()
+                    )),
                 Instant.now()
             );
         CaseDetails exceptionRecord = createExceptionRecord("envelopes/supplementary-evidence-envelope.json");
@@ -144,10 +145,10 @@ class AttachExceptionRecordToExistingCaseTest {
      * reference type - CCD ID, external ID or no type provided.
      *
      * @param searchCaseReferenceType Specifies how the exception record should reference the case.
-     *                                Possible values can be found in
-     * @see uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes
-     * and correspond to ReferenceType list in exception record definition.
-     * If null, case is referenced the old way - via attachToCaseReference field
+     *      Possible values can be found in
+     *      @see uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes
+     *      and correspond to ReferenceType list in exception record definition.
+     *      If null, case is referenced the old way - via attachToCaseReference field
      */
     private void verifyExceptionRecordAttachesToCase(String searchCaseReferenceType) throws Exception {
         //given
@@ -171,10 +172,10 @@ class AttachExceptionRecordToExistingCaseTest {
      * Hits the services callback endpoint with a request to attach exception record to a case.
      *
      * @param searchCaseReferenceType Specifies how the exception record should reference the case.
-     *                                Possible values can be found in
-     * @see uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes
-     * and correspond to ReferenceType list in exception record definition.
-     * If null, case is referenced the old way - via attachToCaseReference field
+     *      Possible values can be found in
+     *      @see uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes
+     *      and correspond to ReferenceType list in exception record definition.
+     *      If null, case is referenced the old way - via attachToCaseReference field
      */
     private void invokeCallbackEndpoint(
         CaseDetails targetCaseDetails,

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
@@ -85,7 +85,7 @@ class AttachExceptionRecordToExistingCaseTest {
     @Test
     public void should_attach_exception_record_to_the_existing_case_with_no_evidence() throws Exception {
         //given
-        CaseDetails caseDetails = ccdCaseCreator.createCase(emptyList());
+        CaseDetails caseDetails = ccdCaseCreator.createCase(emptyList(), Instant.now());
         CaseDetails exceptionRecord = createExceptionRecord("envelopes/supplementary-evidence-envelope.json");
 
         // when
@@ -104,9 +104,12 @@ class AttachExceptionRecordToExistingCaseTest {
     public void should_attach_exception_record_to_the_existing_case_with_evidence_documents() throws Exception {
         //given
         CaseDetails caseDetails =
-            ccdCaseCreator.createCase(singletonList(
-                new Document("certificate1.pdf", "154565768", "other", null, Instant.now(), documentUuid)
-            ));
+            ccdCaseCreator.createCase(
+                singletonList(
+                    new Document("certificate1.pdf", "154565768", "other", null, Instant.now(), documentUuid, Instant.now())
+                ),
+                Instant.now()
+            );
         CaseDetails exceptionRecord = createExceptionRecord("envelopes/supplementary-evidence-envelope.json");
 
         // when
@@ -141,14 +144,14 @@ class AttachExceptionRecordToExistingCaseTest {
      * reference type - CCD ID, external ID or no type provided.
      *
      * @param searchCaseReferenceType Specifies how the exception record should reference the case.
-     *      Possible values can be found in
-     *      @see uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes
-     *      and correspond to ReferenceType list in exception record definition.
-     *      If null, case is referenced the old way - via attachToCaseReference field
+     *                                Possible values can be found in
+     * @see uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes
+     * and correspond to ReferenceType list in exception record definition.
+     * If null, case is referenced the old way - via attachToCaseReference field
      */
     private void verifyExceptionRecordAttachesToCase(String searchCaseReferenceType) throws Exception {
         //given
-        CaseDetails caseDetails = ccdCaseCreator.createCase(emptyList());
+        CaseDetails caseDetails = ccdCaseCreator.createCase(emptyList(), Instant.now());
 
         CaseDetails exceptionRecord = createExceptionRecord("envelopes/supplementary-evidence-envelope.json");
 
@@ -168,10 +171,10 @@ class AttachExceptionRecordToExistingCaseTest {
      * Hits the services callback endpoint with a request to attach exception record to a case.
      *
      * @param searchCaseReferenceType Specifies how the exception record should reference the case.
-     *      Possible values can be found in
-     *      @see uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes
-     *      and correspond to ReferenceType list in exception record definition.
-     *      If null, case is referenced the old way - via attachToCaseReference field
+     *                                Possible values can be found in
+     * @see uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes
+     * and correspond to ReferenceType list in exception record definition.
+     * If null, case is referenced the old way - via attachToCaseReference field
      */
     private void invokeCallbackEndpoint(
         CaseDetails targetCaseDetails,

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
@@ -48,7 +48,7 @@ class SupplementaryEvidenceTest {
     public void should_attach_supplementary_evidence_to_the_case_with_no_evidence_docs() throws Exception {
         //given
         String dmUrl = dmUploadService.uploadToDmStore("Evidence2.pdf", "documents/supplementary-evidence.pdf");
-        CaseDetails caseDetails = ccdCaseCreator.createCase(emptyList());
+        CaseDetails caseDetails = ccdCaseCreator.createCase(emptyList(), Instant.now());
 
         // when
         envelopeMessager.sendMessageFromFile(
@@ -77,7 +77,9 @@ class SupplementaryEvidenceTest {
         CaseDetails caseDetails =
             ccdCaseCreator.createCase(
                 singletonList(
-                    new Document("evidence.pdf", "123", "other", null, Instant.now(), documentUuid, Instant.now())));
+                    new Document("evidence.pdf", "123", "other", null, Instant.now(), documentUuid, Instant.now())
+                ),
+                Instant.now());
 
         // when
         envelopeMessager.sendMessageFromFile(

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
@@ -102,7 +102,7 @@ class SupplementaryEvidenceTest {
         //given
         String dmUrl = dmUploadService.uploadToDmStore("Evidence2.pdf", "documents/supplementary-evidence.pdf");
         assertThat(dmUrl).isNotNull();
-        CaseDetails caseDetails = ccdCaseCreator.createCase(emptyList());
+        CaseDetails caseDetails = ccdCaseCreator.createCase(emptyList(), Instant.now());
         String legacyId = (String) caseDetails.getData().get("legacyId");
         assertThat(legacyId).isNotEmpty();
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SupplementaryEvidenceTest.java
@@ -77,7 +77,7 @@ class SupplementaryEvidenceTest {
         CaseDetails caseDetails =
             ccdCaseCreator.createCase(
                 singletonList(
-                    new Document("evidence.pdf", "123", "other", null, Instant.now(), documentUuid)));
+                    new Document("evidence.pdf", "123", "other", null, Instant.now(), documentUuid, Instant.now())));
 
         // when
         envelopeMessager.sendMessageFromFile(

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataExtractor.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataExtractor.java
@@ -61,6 +61,7 @@ public class CaseDataExtractor {
             document.subtype,
             ZonedDateTime.ofInstant(document.scannedAt, ZoneId.systemDefault()).toLocalDateTime(),
             new CcdDocument(String.join("/", dmUrl, contextPath, document.uuid)),
+            ZonedDateTime.ofInstant(document.deliveryDate, ZoneId.systemDefault()).toLocalDateTime(),
             null
         );
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataExtractor.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataExtractor.java
@@ -31,7 +31,10 @@ public class CaseDataExtractor {
 
     public static List<ScannedDocument> getScannedDocuments(Envelope envelope, String dmUrl, String contextPath) {
         List<Document> documents = envelope.documents;
-        return documents.stream().map(document -> mapDocument(document, dmUrl, contextPath, envelope.deliveryDate)).collect(toList());
+        return documents
+            .stream()
+            .map(document -> mapDocument(document, dmUrl, contextPath, envelope.deliveryDate))
+            .collect(toList());
     }
 
     @SuppressWarnings("unchecked")
@@ -54,7 +57,12 @@ public class CaseDataExtractor {
         }
     }
 
-    private static ScannedDocument mapDocument(Document document, String dmUrl, String contextPath, Instant deliveryDate) {
+    private static ScannedDocument mapDocument(
+        Document document,
+        String dmUrl,
+        String contextPath,
+        Instant deliveryDate
+    ) {
         return new ScannedDocument(
             document.fileName,
             document.controlNumber,

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataExtractor.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataExtractor.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Docum
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -30,7 +31,7 @@ public class CaseDataExtractor {
 
     public static List<ScannedDocument> getScannedDocuments(Envelope envelope, String dmUrl, String contextPath) {
         List<Document> documents = envelope.documents;
-        return documents.stream().map(document -> mapDocument(document, dmUrl, contextPath)).collect(toList());
+        return documents.stream().map(document -> mapDocument(document, dmUrl, contextPath, envelope.deliveryDate)).collect(toList());
     }
 
     @SuppressWarnings("unchecked")
@@ -53,7 +54,7 @@ public class CaseDataExtractor {
         }
     }
 
-    private static ScannedDocument mapDocument(Document document, String dmUrl, String contextPath) {
+    private static ScannedDocument mapDocument(Document document, String dmUrl, String contextPath, Instant deliveryDate) {
         return new ScannedDocument(
             document.fileName,
             document.controlNumber,

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCaseCreator.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCaseCreator.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,19 +45,19 @@ public class CcdCaseCreator {
         this.supplementaryEvidenceMapper = supplementaryEvidenceMapper;
     }
 
-    public CaseDetails createCase(List<Document> documents) {
-        String legacyId = "legacy-id-" + (long)(Math.random() * 100_000_000d);
-        return createCase(legacyId, documents);
+    public CaseDetails createCase(List<Document> documents, Instant deliveryDate) {
+        String legacyId = "legacy-id-" + (long) (Math.random() * 100_000_000d);
+        return createCase(legacyId, documents, deliveryDate);
     }
 
-    public CaseDetails createCase(String legacyId, List<Document> documents) {
+    public CaseDetails createCase(String legacyId, List<Document> documents, Instant deliveryDate) {
         log.info("Creating new case");
         CcdAuthenticator authenticator = ccdAuthenticatorFactory.createForJurisdiction(JURISDICTION);
 
         StartEventResponse startEventResponse = startEventForCreateCase(authenticator);
         log.info("Started {} event for creating a new case", startEventResponse.getEventId());
 
-        CaseDataContent caseDataContent = prepareCaseData(startEventResponse, documents, legacyId);
+        CaseDataContent caseDataContent = prepareCaseData(startEventResponse, documents, legacyId, deliveryDate);
 
         CaseDetails caseDetails = submitNewCase(authenticator, caseDataContent);
         log.info("Submitted {} event for creating a new case", startEventResponse.getEventId());
@@ -67,10 +68,11 @@ public class CcdCaseCreator {
     private CaseDataContent prepareCaseData(
         StartEventResponse startEventResponse,
         List<Document> documents,
-        String legacyId
+        String legacyId,
+        Instant deliveryDate
     ) {
         SupplementaryEvidence supplementaryEvidence =
-            supplementaryEvidenceMapper.map(emptyList(), documents);
+            supplementaryEvidenceMapper.map(emptyList(), documents, deliveryDate);
 
         Map<String, Object> eventData = new HashMap<>();
         eventData.put("evidenceHandled", supplementaryEvidence.evidenceHandled);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -58,7 +58,8 @@ public class ScannedDocumentsHelper {
                 doc.type,
                 doc.subtype,
                 doc.scannedDate == null ? null : doc.scannedDate.atZone(ZoneId.systemDefault()).toInstant(),
-                doc.url == null ? null : StringUtils.substringAfterLast(doc.url.documentUrl, "/")
+                doc.url == null ? null : StringUtils.substringAfterLast(doc.url.documentUrl, "/"),
+                doc.deliveryDate == null ? null : doc.deliveryDate.atZone(ZoneId.systemDefault()).toInstant()
             );
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ScannedDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ScannedDocument.java
@@ -54,12 +54,11 @@ public class ScannedDocument {
             && Objects.equals(type, that.type)
             && Objects.equals(subtype, that.subtype)
             && Objects.equals(scannedDate, that.scannedDate)
-            && Objects.equals(url, that.url)
-            && Objects.equals(deliveryDate, that.deliveryDate);
+            && Objects.equals(url, that.url);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fileName, controlNumber, type, scannedDate, url, deliveryDate);
+        return Objects.hash(fileName, controlNumber, type, scannedDate, url);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ScannedDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ScannedDocument.java
@@ -17,6 +17,7 @@ public class ScannedDocument {
     public final String subtype;
     public final String exceptionReference;
     public final LocalDateTime scannedDate;
+    public final LocalDateTime deliveryDate;
     public final CcdDocument url;
 
     public ScannedDocument(
@@ -26,6 +27,7 @@ public class ScannedDocument {
         @JsonProperty("subtype") String subtype,
         @JsonProperty("scannedDate") LocalDateTime scannedDate,
         @JsonProperty("url") CcdDocument url,
+        @JsonProperty("deliveryDate") LocalDateTime deliveryDate,
         @JsonProperty("exceptionRecordReference") String exceptionReference
     ) {
         this.fileName = fileName;
@@ -34,6 +36,7 @@ public class ScannedDocument {
         this.subtype = subtype;
         this.scannedDate = scannedDate;
         this.url = url;
+        this.deliveryDate = deliveryDate;
         this.exceptionReference = exceptionReference;
     }
 
@@ -51,11 +54,12 @@ public class ScannedDocument {
             && Objects.equals(type, that.type)
             && Objects.equals(subtype, that.subtype)
             && Objects.equals(scannedDate, that.scannedDate)
-            && Objects.equals(url, that.url);
+            && Objects.equals(url, that.url)
+            && Objects.equals(deliveryDate, that.deliveryDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fileName, controlNumber, type, scannedDate, url);
+        return Objects.hash(fileName, controlNumber, type, scannedDate, url, deliveryDate);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapper.java
@@ -21,16 +21,17 @@ public class DocumentMapper {
     public static List<CcdCollectionElement<ScannedDocument>> mapDocuments(
         List<Document> documents,
         String dmApiUrl,
-        String contextPath
+        String contextPath,
+        Instant deliveryDate
     ) {
         return documents
             .stream()
-            .map(document -> mapDocument(document, dmApiUrl, contextPath))
+            .map(document -> mapDocument(document, dmApiUrl, contextPath, deliveryDate))
             .map(CcdCollectionElement::new)
             .collect(Collectors.toList());
     }
 
-    public static ScannedDocument mapDocument(Document document, String dmApiUrl, String contextPath) {
+    public static ScannedDocument mapDocument(Document document, String dmApiUrl, String contextPath, Instant deliveryDate) {
         if (document == null) {
             return null;
         } else {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapper.java
@@ -47,7 +47,7 @@ public class DocumentMapper {
                 document.subtype,
                 getLocalDateTime(document.scannedAt),
                 new CcdDocument(String.join("/", dmApiUrl, contextPath, document.uuid)),
-                getLocalDateTime(deliveryDate),
+                getLocalDateTime(document.deliveryDate != null ? document.deliveryDate : deliveryDate),
                 null
             );
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapper.java
@@ -41,6 +41,7 @@ public class DocumentMapper {
                 document.subtype,
                 getLocalDateTime(document.scannedAt),
                 new CcdDocument(String.join("/", dmApiUrl, contextPath, document.uuid)),
+                getLocalDateTime(document.deliveryDate),
                 null
             );
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapper.java
@@ -31,7 +31,12 @@ public class DocumentMapper {
             .collect(Collectors.toList());
     }
 
-    public static ScannedDocument mapDocument(Document document, String dmApiUrl, String contextPath, Instant deliveryDate) {
+    public static ScannedDocument mapDocument(
+        Document document,
+        String dmApiUrl,
+        String contextPath,
+        Instant deliveryDate
+    ) {
         if (document == null) {
             return null;
         } else {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -35,7 +35,7 @@ public class ExceptionRecordMapper {
             envelope.jurisdiction,
             getLocalDateTime(envelope.deliveryDate),
             getLocalDateTime(envelope.openingDate),
-            mapDocuments(envelope.documents, documentManagementUrl, contextPath),
+            mapDocuments(envelope.documents, documentManagementUrl, contextPath, envelope.deliveryDate),
             mapOcrData(envelope.ocrData)
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapper.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.SupplementaryEvidence;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -26,7 +27,7 @@ public class SupplementaryEvidenceMapper {
         this.contextPath = contextPath;
     }
 
-    public SupplementaryEvidence map(List<Document> existingDocs, List<Document> envelopeDocs) {
+    public SupplementaryEvidence map(List<Document> existingDocs, List<Document> envelopeDocs, Instant deliveryDate) {
         return new SupplementaryEvidence(
             mapDocuments(
                 Stream.concat(
@@ -34,7 +35,8 @@ public class SupplementaryEvidenceMapper {
                     getDocsToAdd(existingDocs, envelopeDocs).stream()
                 ).collect(toList()),
                 documentManagementUrl,
-                contextPath
+                contextPath,
+            deliveryDate
             )
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -79,7 +79,8 @@ class AttachDocsToSupplementaryEvidence {
     private CaseDataContent buildCaseDataContent(Envelope envelope, StartEventResponse startEventResponse) {
         CaseData caseData = mapper.map(
             getDocuments(startEventResponse.getCaseDetails()),
-            envelope.documents
+            envelope.documents,
+            envelope.deliveryDate
         );
         return CaseDataContent.builder()
             .eventToken(startEventResponse.getToken())

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Document.java
@@ -14,6 +14,7 @@ public class Document {
     public final String subtype;
     public final Instant scannedAt;
     public final String uuid;
+    public final Instant deliveryDate;
 
     // region constructor
     public Document(
@@ -22,7 +23,8 @@ public class Document {
         @JsonProperty(value = "type", required = true) String type,
         @JsonProperty(value = "subtype") String subtype,
         @JsonProperty(value = "scanned_at", required = true) Instant scannedAt,
-        @JsonProperty(value = "uuid", required = true) String uuid
+        @JsonProperty(value = "uuid", required = true) String uuid,
+        @JsonProperty(value = "delivery_date") Instant deliveryDate
     ) {
         this.fileName = fileName;
         this.controlNumber = controlNumber;
@@ -30,6 +32,7 @@ public class Document {
         this.subtype = subtype;
         this.scannedAt = scannedAt;
         this.uuid = uuid;
+        this.deliveryDate = deliveryDate;
     }
     // endregion
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -173,7 +173,8 @@ public class SampleData {
                     String.format("type_%s", index),
                     String.format("subtype_%s", index),
                     ZonedDateTime.parse("2018-10-01T00:00:00Z").plus(index, DAYS).toInstant(),
-                    String.format("uuid%s", index)
+                    String.format("uuid%s", index),
+                    ZonedDateTime.parse("2018-10-01T00:00:00Z").minus(index, DAYS).toInstant()
                 )
             ).limit(numberOfDocuments)
             .collect(Collectors.toList());

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
@@ -50,7 +50,8 @@ class ScannedDocumentsHelperTest {
             "Other",
             null,
             Instant.parse("2018-12-01T12:34:56.123Z"),
-            "863c495e-d05b-4376-9951-ea489360db6f"
+            "863c495e-d05b-4376-9951-ea489360db6f",
+            Instant.parse("2018-12-02T12:30:56.123Z")
         );
 
         assertThat(document).isEqualToComparingFieldByField(expectedDocument);
@@ -68,7 +69,7 @@ class ScannedDocumentsHelperTest {
         assertThat(documents).hasSize(1);
         assertThat(documents.get(0))
             .isEqualToComparingFieldByField(
-                new Document(null, null, null, null, null, null)
+                new Document(null, null, null, null, null, null, null)
             );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapperTest.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -22,7 +23,8 @@ class DocumentMapperTest {
             "type",
             "subtype",
             Instant.now(),
-            "uuid1"
+            "uuid1",
+            Instant.now()
         );
 
         // when
@@ -36,8 +38,9 @@ class DocumentMapperTest {
                     doc.controlNumber,
                     doc.type,
                     doc.subtype,
-                    ZonedDateTime.ofInstant(doc.scannedAt, ZoneId.systemDefault()).toLocalDateTime(),
+                    toLocalDateTime(doc.scannedAt),
                     new CcdDocument("https://localhost/files/" + doc.uuid),
+                    toLocalDateTime(doc.deliveryDate),
                     null // this should always be null;
                 )
             );
@@ -58,12 +61,16 @@ class DocumentMapperTest {
     @Test
     void should_map_null_scanned_date() {
         // given
-        Document doc = new Document("name.zip", "123", "type", "subtype", null, "uuid1");
+        Document doc = new Document("name.zip", "123", "type", "subtype", null, "uuid1", Instant.now());
 
         // when
         ScannedDocument result = DocumentMapper.mapDocument(doc, "https://localhost", "files");
 
         // then
         assertThat(result.scannedDate).isNull();
+    }
+
+    private LocalDateTime toLocalDateTime(Instant instant) {
+        return ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()).toLocalDateTime();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/DocumentMapperTest.java
@@ -17,6 +17,7 @@ class DocumentMapperTest {
     @Test
     void should_map_document_properly() {
         // given
+        Instant deliveryDate = Instant.now();
         Document doc = new Document(
             "name.zip",
             "123",
@@ -28,7 +29,7 @@ class DocumentMapperTest {
         );
 
         // when
-        ScannedDocument result = DocumentMapper.mapDocument(doc, "https://localhost", "files");
+        ScannedDocument result = DocumentMapper.mapDocument(doc, "https://localhost", "files", deliveryDate);
 
         // then
         assertThat(result)
@@ -52,7 +53,7 @@ class DocumentMapperTest {
         Document doc = null;
 
         // when
-        ScannedDocument result = DocumentMapper.mapDocument(doc, "https://localhost", "files");
+        ScannedDocument result = DocumentMapper.mapDocument(doc, "https://localhost", "files", Instant.now());
 
         // then
         assertThat(result).isNull();
@@ -64,7 +65,7 @@ class DocumentMapperTest {
         Document doc = new Document("name.zip", "123", "type", "subtype", null, "uuid1", Instant.now());
 
         // when
-        ScannedDocument result = DocumentMapper.mapDocument(doc, "https://localhost", "files");
+        ScannedDocument result = DocumentMapper.mapDocument(doc, "https://localhost", "files", Instant.now());
 
         // then
         assertThat(result.scannedDate).isNull();

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -101,8 +101,9 @@ class ExceptionRecordMapperTest {
                     scannedDocument.type,
                     scannedDocument.subtype,
                     scannedDocument.scannedDate.atZone(ZoneId.systemDefault()).toInstant(),
-                    StringUtils.substringAfterLast(scannedDocument.url.documentUrl, "/")
-                )
+                    StringUtils.substringAfterLast(scannedDocument.url.documentUrl, "/"),
+                    scannedDocument.deliveryDate.atZone(ZoneId.systemDefault()).toInstant()
+                    )
             ).collect(toList());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.tuple;
 class SupplementaryEvidenceMapperTest {
 
     private static final SupplementaryEvidenceMapper mapper = new SupplementaryEvidenceMapper("http://localhost", "files");
+    Instant deliveryDate = Instant.now();
 
     @Test
     void maps_all_fields_correctly() {
@@ -36,7 +37,7 @@ class SupplementaryEvidenceMapperTest {
             );
 
         // when
-        SupplementaryEvidence result = mapper.map(existingDocs, envelopeDocs);
+        SupplementaryEvidence result = mapper.map(existingDocs, envelopeDocs, deliveryDate);
 
         // then
         assertThat(result.evidenceHandled).isEqualTo("No");
@@ -76,7 +77,7 @@ class SupplementaryEvidenceMapperTest {
             );
 
         // when
-        SupplementaryEvidence result = mapper.map(existingDocs, envelopeDocs);
+        SupplementaryEvidence result = mapper.map(existingDocs, envelopeDocs, deliveryDate);
 
         // then
         assertThat(result.evidenceHandled).isEqualTo("No");
@@ -108,7 +109,7 @@ class SupplementaryEvidenceMapperTest {
             );
 
         // when
-        SupplementaryEvidence result = mapper.map(existingDocs, envelopeDocs);
+        SupplementaryEvidence result = mapper.map(existingDocs, envelopeDocs, deliveryDate);
 
         // then
         assertThat(result.scannedDocuments).hasSize(3); // only one doc should be added
@@ -128,7 +129,7 @@ class SupplementaryEvidenceMapperTest {
         List<Document> envelopeDocuments = emptyList();
 
         // when
-        SupplementaryEvidence result = mapper.map(existingDocuments, envelopeDocuments);
+        SupplementaryEvidence result = mapper.map(existingDocuments, envelopeDocuments, deliveryDate);
 
         // then
         assertThat(result.scannedDocuments).isEmpty();

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
@@ -66,15 +66,15 @@ class SupplementaryEvidenceMapperTest {
         // given
         List<Document> existingDocs =
             asList(
-                new Document("a.pdf", "aaa", "type_a", "subtype_a", now().plusSeconds(1), "uuida", now().minusSeconds(10),
-                new Document("b.pdf", "bbb", "type_b", "subtype_b", now().plusSeconds(2), "uuidb", now().minusSeconds(10)
+                new Document("a.pdf", "aaa", "type_a", "subtype_a", now().plusSeconds(1), "uuida", now().minusSeconds(10)),
+                new Document("b.pdf", "bbb", "type_b", "subtype_b", now().plusSeconds(2), "uuidb", now().minusSeconds(10))
             );
 
         List<Document> envelopeDocs =
             asList(
-                new Document("a1.pdf", "aaa1", "type_a1", "subtype_a1", now().plusSeconds(3), "uuida", now().minusSeconds(10), // same url!
+                new Document("a1.pdf", "aaa1", "type_a1", "subtype_a1", now().plusSeconds(3), "uuida", now().minusSeconds(10)), // same url!
                 new Document("b.pdf", "bbb1", "type_b", "subtype_b", now().plusSeconds(4), "uuidxxxxx", now().minusSeconds(10)
-            );
+            ));
 
         // when
         SupplementaryEvidence result = mapper.map(existingDocs, envelopeDocs, deliveryDate);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/SupplementaryEvidenceMapperTest.java
@@ -25,14 +25,14 @@ class SupplementaryEvidenceMapperTest {
         // given
         List<Document> existingDocs =
             asList(
-                new Document("a.pdf", "aaa", "type_a", "subtype_a", now().plusSeconds(1), "uuida"),
-                new Document("b.pdf", "bbb", "type_b", "subtype_b", now().plusSeconds(2), "uuidb")
+                new Document("a.pdf", "aaa", "type_a", "subtype_a", now().plusSeconds(1), "uuida", now().minusSeconds(10)),
+                new Document("b.pdf", "bbb", "type_b", "subtype_b", now().plusSeconds(2), "uuidb", now().minusSeconds(10))
             );
 
         List<Document> envelopeDocs =
             asList(
-                new Document("x.pdf", "xxx", "type_x", "subtype_x", now().plusSeconds(3), "uuidx"),
-                new Document("y.pdf", "yyy", "type_y", "subtype_y", now().plusSeconds(4), "uuidy")
+                new Document("x.pdf", "xxx", "type_x", "subtype_x", now().plusSeconds(3), "uuidx", now().minusSeconds(10)),
+                new Document("y.pdf", "yyy", "type_y", "subtype_y", now().plusSeconds(4), "uuidy", now().minusSeconds(10))
             );
 
         // when
@@ -49,13 +49,14 @@ class SupplementaryEvidenceMapperTest {
                     ccdDoc.value.type,
                     ccdDoc.value.subtype,
                     ccdDoc.value.scannedDate,
-                    ccdDoc.value.url.documentUrl
+                    ccdDoc.value.url.documentUrl,
+                    ccdDoc.value.deliveryDate
                 ))
             .containsExactly(
-                tuple("a.pdf", "aaa", "type_a", "subtype_a", toLocalDateTime(existingDocs.get(0).scannedAt), "http://localhost/files/uuida"),
-                tuple("b.pdf", "bbb", "type_b", "subtype_b", toLocalDateTime(existingDocs.get(1).scannedAt), "http://localhost/files/uuidb"),
-                tuple("x.pdf", "xxx", "type_x", "subtype_x", toLocalDateTime(envelopeDocs.get(0).scannedAt), "http://localhost/files/uuidx"),
-                tuple("y.pdf", "yyy", "type_y", "subtype_y", toLocalDateTime(envelopeDocs.get(1).scannedAt), "http://localhost/files/uuidy")
+                tuple("a.pdf", "aaa", "type_a", "subtype_a", toLocalDateTime(existingDocs.get(0).scannedAt), "http://localhost/files/uuida", toLocalDateTime(existingDocs.get(0).deliveryDate)),
+                tuple("b.pdf", "bbb", "type_b", "subtype_b", toLocalDateTime(existingDocs.get(1).scannedAt), "http://localhost/files/uuidb", toLocalDateTime(existingDocs.get(1).deliveryDate)),
+                tuple("x.pdf", "xxx", "type_x", "subtype_x", toLocalDateTime(envelopeDocs.get(0).scannedAt), "http://localhost/files/uuidx", toLocalDateTime(envelopeDocs.get(0).deliveryDate)),
+                tuple("y.pdf", "yyy", "type_y", "subtype_y", toLocalDateTime(envelopeDocs.get(1).scannedAt), "http://localhost/files/uuidy", toLocalDateTime(envelopeDocs.get(1).deliveryDate))
             );
     }
 
@@ -64,14 +65,14 @@ class SupplementaryEvidenceMapperTest {
         // given
         List<Document> existingDocs =
             asList(
-                new Document("a.pdf", "aaa", "type_a", "subtype_a", now().plusSeconds(1), "uuida"),
-                new Document("b.pdf", "bbb", "type_b", "subtype_b", now().plusSeconds(2), "uuidb")
+                new Document("a.pdf", "aaa", "type_a", "subtype_a", now().plusSeconds(1), "uuida", now().minusSeconds(10),
+                new Document("b.pdf", "bbb", "type_b", "subtype_b", now().plusSeconds(2), "uuidb", now().minusSeconds(10)
             );
 
         List<Document> envelopeDocs =
             asList(
-                new Document("a1.pdf", "aaa1", "type_a1", "subtype_a1", now().plusSeconds(3), "uuida"), // same url!
-                new Document("b.pdf", "bbb1", "type_b", "subtype_b", now().plusSeconds(4), "uuidxxxxx")
+                new Document("a1.pdf", "aaa1", "type_a1", "subtype_a1", now().plusSeconds(3), "uuida", now().minusSeconds(10), // same url!
+                new Document("b.pdf", "bbb1", "type_b", "subtype_b", now().plusSeconds(4), "uuidxxxxx", now().minusSeconds(10)
             );
 
         // when
@@ -96,14 +97,14 @@ class SupplementaryEvidenceMapperTest {
         // given
         List<Document> existingDocs =
             asList(
-                new Document("a.pdf", "AAA", "type_a", "subtype_a", now().plusSeconds(1), "uuida"),
-                new Document("b.pdf", "BBB", "type_b", "subtype_b", now().plusSeconds(2), "uuidb")
+                new Document("a.pdf", "AAA", "type_a", "subtype_a", now().plusSeconds(1), "uuida", now().minusSeconds(10)),
+                new Document("b.pdf", "BBB", "type_b", "subtype_b", now().plusSeconds(2), "uuidb", now().minusSeconds(10))
             );
 
         List<Document> envelopeDocs =
             asList(
-                new Document("c.pdf", "AAA", "type_c", "subtype_c", now().plusSeconds(3), "uuidc"), // same control number!
-                new Document("d.pdf", "DDD", "type_d", "subtype_d", now().plusSeconds(4), "uuidd")
+                new Document("c.pdf", "AAA", "type_c", "subtype_c", now().plusSeconds(3), "uuidc", now().minusSeconds(10)), // same control number!
+                new Document("d.pdf", "DDD", "type_d", "subtype_d", now().plusSeconds(4), "uuidd", now().minusSeconds(10))
             );
 
         // when

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
@@ -96,7 +96,7 @@ class AttachDocsToSupplementaryEvidenceTest {
             caseDataContentCaptor.capture()
         );
 
-        verify(mapper).map(emptyList(), envelope.documents);
+        verify(mapper).map(emptyList(), envelope.documents, envelope.deliveryDate);
 
         CaseDataContent caseDataContent = caseDataContentCaptor.getValue();
         assertThat(caseDataContent.getEventToken()).isEqualTo(eventToken);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/EnvelopeParserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/EnvelopeParserTest.java
@@ -30,6 +30,7 @@ class EnvelopeParserTest {
 
     private Envelope envelope;
     private Instant scannedAt = ZonedDateTime.parse("2018-10-01T00:00:00.100Z").toInstant();
+    private Instant deliveryDate = ZonedDateTime.parse("2018-10-01T00:00:00.100Z").toInstant();
 
     @BeforeAll
     static void init() {
@@ -56,7 +57,8 @@ class EnvelopeParserTest {
                     "doc1_type",
                     "doc1_subtype",
                     scannedAt,
-                    "doc1uuid"
+                    "doc1uuid",
+                    deliveryDate
                 ),
                 new Document(
                     "doc2_file_name",
@@ -64,7 +66,8 @@ class EnvelopeParserTest {
                     "doc2_type",
                     null,
                     scannedAt,
-                    "doc2uuid"
+                    "doc2uuid",
+                    deliveryDate
                 )
             ),
             ImmutableList.of(
@@ -111,7 +114,8 @@ class EnvelopeParserTest {
                     doc.type,
                     doc.subtype,
                     doc.scannedAt,
-                    doc.uuid)
+                    doc.uuid,
+                    doc.deliveryDate)
             )
             .containsOnly(
                 tuple(
@@ -120,7 +124,8 @@ class EnvelopeParserTest {
                     "doc1_type",
                     "doc1_subtype",
                     scannedAt,
-                    "doc1uuid"
+                    "doc1uuid",
+                    deliveryDate
                 ),
                 tuple(
                     "doc2_file_name",
@@ -128,7 +133,8 @@ class EnvelopeParserTest {
                     "doc2_type",
                     null,
                     scannedAt,
-                    "doc2uuid"
+                    "doc2uuid",
+                    deliveryDate
                 )
             );
     }
@@ -240,7 +246,8 @@ class EnvelopeParserTest {
             .put("type", doc.type)
             .put("subtype", doc.subtype)
             .put("scanned_at", toIso8601(doc.scannedAt))
-            .put("uuid", doc.uuid);
+            .put("uuid", doc.uuid)
+            .put("delivery_date", toIso8601(doc.deliveryDate));
     }
 
     private JSONArray toOcrJson(List<OcrDataField> ocrDataFields) throws JSONException {

--- a/src/test/resources/case-data/null-fields-in-doc.json
+++ b/src/test/resources/case-data/null-fields-in-doc.json
@@ -8,7 +8,8 @@
           "type": null,
           "subtype": null,
           "scannedDate": null,
-          "uuid": null
+          "uuid": null,
+          "deliveryDate": null
         }
       }
     ]

--- a/src/test/resources/case-data/single-scanned-doc.json
+++ b/src/test/resources/case-data/single-scanned-doc.json
@@ -11,7 +11,8 @@
           "url": {
             "document_url": "https://doc-url-1.example.com/863c495e-d05b-4376-9951-ea489360db6f"
           },
-          "uuid": "863c495e-d05b-4376-9951-ea489360db6f"
+          "uuid": "863c495e-d05b-4376-9951-ea489360db6f",
+          "deliveryDate": "2018-12-02T12:30:56.123Z"
         }
       }
     ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-619


### Change description ###
Duplicate of https://github.com/hmcts/bulk-scan-orchestrator/pull/413
Added delivery date field to Scanned Document model and updated tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
