### PR TITLE
Unit test cover branches

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -47,7 +47,7 @@ withPipeline(type, product, component) {
       def subscription = env.SUBSCRIPTION_NAME
       def aksServiceName = dockerImage.getAksServiceName().toLowerCase()
       def sbNamespaceSecret = "servicebus-secret-namespace-${aksServiceName}"
-      def namespace = new TeamNames().getNameNormalizedOrThrow(product)
+      def namespace = new TeamNames(this).getNameSpace(product)
 
       def kubectl = new Kubectl(this, subscription, namespace)
       kubectl.login()

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.vavr.control.Validation;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -184,6 +185,28 @@ class CallbackValidationsTest {
             expectedValueOrError,
             CallbackValidations::hasServiceNameInCaseTypeId,
             expectedValueOrError
+        );
+    }
+
+    @Test
+    void invalidJurisdictionTest() {
+        checkValidation(
+            createCaseWith(b -> b.jurisdiction(null)),
+            false,
+            null,
+            CallbackValidations::hasJurisdiction,
+            "Internal Error: invalid jurisdiction supplied: null"
+        );
+    }
+
+    @Test
+    void noCaseIdTest() {
+        checkValidation(
+            createCaseWith(b -> b.id(null)),
+            false,
+            null,
+            CallbackValidations::hasAnId,
+            "Exception case has no Id"
         );
     }
 


### PR DESCRIPTION
### Change description ###

Cover branches in existing (parameterised) unit test with edge case:

- empty jurisdiction
- empty case id

Origin/reason of this PR:

Sonarqube started to complain on master that new code is less than desired to be covered. Which is not entirely true but fair in current PR - those bits are not covered

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
