### PR TITLE
Rename TeamConfig 

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -4,7 +4,7 @@
 import uk.gov.hmcts.contino.GradleBuilder
 import uk.gov.hmcts.contino.Kubectl
 import uk.gov.hmcts.contino.DockerImage
-import uk.gov.hmcts.contino.TeamNames
+import uk.gov.hmcts.pipeline.TeamConfig
 
 def type = "java"
 def product = "bulk-scan"
@@ -47,7 +47,7 @@ withPipeline(type, product, component) {
       def subscription = env.SUBSCRIPTION_NAME
       def aksServiceName = dockerImage.getAksServiceName().toLowerCase()
       def sbNamespaceSecret = "servicebus-secret-namespace-${aksServiceName}"
-      def namespace = new TeamNames(this).getNameSpace(product)
+      def namespace = new TeamConfig(this).getNameSpace(product)
 
       def kubectl = new Kubectl(this, subscription, namespace)
       kubectl.login()


### PR DESCRIPTION
Jenkins Library has been updated to rename and repackage TeamNames as part of hmcts/cnp-jenkins-library#523 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
