### PR TITLE
Rename `InvalidExceptionRecordResponse` to `TransformationErrorResponse`

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/InvalidCaseDataException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/InvalidCaseDataException.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpStatusCodeException;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.InvalidExceptionRecordResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.TransformationErrorResponse;
 
 public class InvalidCaseDataException extends RuntimeException {
 
@@ -10,11 +10,11 @@ public class InvalidCaseDataException extends RuntimeException {
 
     private final HttpStatus status;
 
-    private final transient InvalidExceptionRecordResponse response;
+    private final transient TransformationErrorResponse response;
 
     public InvalidCaseDataException(
         HttpStatusCodeException cause,
-        InvalidExceptionRecordResponse response
+        TransformationErrorResponse response
     ) {
         super(cause);
         this.status = cause.getStatusCode();
@@ -25,7 +25,7 @@ public class InvalidCaseDataException extends RuntimeException {
         return status;
     }
 
-    public InvalidExceptionRecordResponse getResponse() {
+    public TransformationErrorResponse getResponse() {
         return response;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClient.java
@@ -10,8 +10,8 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.InvalidExceptionRecordResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.TransformationErrorResponse;
 
 import java.io.IOException;
 
@@ -66,7 +66,7 @@ public class TransformationClient {
             if (ex.getStatusCode().equals(UNPROCESSABLE_ENTITY) || ex.getStatusCode().equals(BAD_REQUEST)) {
                 throw new InvalidCaseDataException(
                     ex,
-                    objectMapper.readValue(ex.getResponseBodyAsByteArray(), InvalidExceptionRecordResponse.class)
+                    objectMapper.readValue(ex.getResponseBodyAsByteArray(), TransformationErrorResponse.class)
                 );
             }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/response/TransformationErrorResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/response/TransformationErrorResponse.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-public class InvalidExceptionRecordResponse {
+public class TransformationErrorResponse {
 
     public final List<String> errors;
     public final List<String> warnings;
 
-    public InvalidExceptionRecordResponse(
+    public TransformationErrorResponse(
         @JsonProperty("errors") List<String> errors,
         @JsonProperty("warnings") List<String> warnings
     ) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationDataTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationDataTest.java
@@ -6,8 +6,8 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.req
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.OcrDataField;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.CaseCreationDetails;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.InvalidExceptionRecordResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.TransformationErrorResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
 
 import java.time.Instant;
@@ -32,7 +32,7 @@ public class TransformationDataTest {
 
     @Test
     public void testInvalidFormatTransformationResponse() {
-        InvalidExceptionRecordResponse response = new InvalidExceptionRecordResponse(
+        TransformationErrorResponse response = new TransformationErrorResponse(
             singletonList("Invalid Exception Record"),
             Collections.emptyList()
         );


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create client for transformation API in orchestrator](https://tools.hmcts.net/jira/browse/BPS-753)

### Change description ###

Rename response object as discussed previously

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
