### PR TITLE
Updated validation to handle empty list

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
@@ -44,6 +44,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -763,6 +764,8 @@ class AttachExceptionRecordToExistingCaseTest {
             caseData.put("scanOCRData", singletonList(
                 ImmutableMap.of("first_name", "John")
             ));
+        } else {
+            caseData.put("scanOCRData", emptyList());
         }
 
         caseData.put("scannedDocuments", ImmutableList.of(EXCEPTION_RECORD_DOC));

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
 import io.vavr.control.Validation;
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -142,10 +143,12 @@ final class CallbackValidations {
             .map(c -> (String) c);
     }
 
+    @SuppressWarnings("unchecked")
     private static boolean exceptionRecordHasOcr(CaseDetails theCase) {
         return Optional.ofNullable(theCase)
             .map(CaseDetails::getData)
-            .map(data -> data.get("scanOCRData"))
-            .isPresent();
+            .map(data -> (List<Map<String, Object>>) data.get("scanOCRData"))
+            .map(CollectionUtils::isNotEmpty)
+            .orElse(false);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
@@ -196,6 +196,7 @@ class CallbackValidationsTest {
             {"Invalid journey classification", createCaseWith(b -> b.data(ImmutableMap.of(JOURNEY_CLASSIFICATION, "invalid_classification"))), false, "Invalid journey classification invalid_classification"},
             {"Valid journey classification(supplementary evidence)", createCaseWith(b -> b.data(ImmutableMap.of(JOURNEY_CLASSIFICATION, "SUPPLEMENTARY_EVIDENCE"))), true, null},
             {"Valid journey classification(exception without ocr)", createCaseWith(b -> b.data(ImmutableMap.of(JOURNEY_CLASSIFICATION, CLASSIFICATION_EXCEPTION))), true, null},
+            {"Valid journey classification(exception with empty ocr list)", createCaseWith(b -> b.data(ImmutableMap.of(JOURNEY_CLASSIFICATION, CLASSIFICATION_EXCEPTION, "scanOCRData", emptyList()))), true, null},
             {"Invalid action-Valid journey classification(exception with ocr)", createCaseWith(b -> b.data(caseDataWithOcr())), false, "The 'attach to case' event is not supported for exception records with OCR"}
         };
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-721

### Change description ###

- CCD sends an empty OCR list when there is no OCR and hence we need to handle this scenario. 

- Previously we were checking only for the presence of OCR in the case data and not if it is empty or not


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```