### PR TITLE
Added cmc jurisdiction to supported jurisdiction to enable cmc in prod

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -56,7 +56,7 @@ variable "s2s_name" {
 variable "supported_jurisdictions" {
   type = "list"
   description = "Jurisdictions to be supported by Bulk Scan in the given environment. Bulk Scan will only be able to map these ones to IDAM user credentials"
-  default = ["SSCS", "BULKSCAN", "PROBATE", "DIVORCE", "FINREM"]
+  default = ["SSCS", "BULKSCAN", "PROBATE", "DIVORCE", "FINREM", "CMC"]
 }
 
 variable "delete_envelopes_dlq_messages_enabled" {


### PR DESCRIPTION

### Change description ###

-  Set `idam-users-cmc-username` and `idam-users-cmc-password` secrets on prod vault.

- Enabled CMC on prod.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```