### PR TITLE
Remove vault values from output - not needed

### DIFF
--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -2,14 +2,6 @@ output "microserviceName" {
   value = "${var.component}"
 }
 
-output "vaultName" {
-  value = "${local.vaultName}"
-}
-
-output "vaultUri" {
-  value = "${data.azurerm_key_vault.key_vault.vault_uri}"
-}
-
 // region: settings for functional tests
 
 output "ENVELOPES_QUEUE_WRITE_CONN_STRING" {


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Update Jenkinsfiles to solve deprecated vault sets](https://tools.hmcts.net/jira/browse/BPS-775)

### Change description ###

Populating `vaultName` and `vaultUri` breaks the terraform apply step overriding vault names defined in Jenkinsfile config

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
