### PR TITLE
Bump `checkstyle` plugin to 8.24

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ task smoke(type: Test) {
 
 checkstyle {
   maxWarnings = 0
-  toolVersion = '8.19'
+  toolVersion = '8.24'
   // need to set configDir to rootDir otherwise submodule will use submodule/config/checkstyle
   configDir = new File(rootDir, 'config/checkstyle')
 }
@@ -178,10 +178,6 @@ dependencyManagement {
     // CVE-2019-12814
     dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9.2') {
       entry 'jackson-databind'
-    }
-    // CVE-2019-10086
-    dependencySet(group: 'commons-beanutils', version: '1.9.4') {
-      entry 'commons-beanutils'
     }
     // solves: CVE-2017-13098, CVE-2018-1000180, CVE-2018-1000613
     dependencySet(group: 'org.bouncycastle', version: '1.62') {

--- a/build.gradle
+++ b/build.gradle
@@ -179,6 +179,10 @@ dependencyManagement {
     dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.9.2') {
       entry 'jackson-databind'
     }
+    // CVE-2019-10086
+    dependencySet(group: 'commons-beanutils', version: '1.9.4') {
+      entry 'commons-beanutils'
+    }
     // solves: CVE-2017-13098, CVE-2018-1000180, CVE-2018-1000613
     dependencySet(group: 'org.bouncycastle', version: '1.62') {
       entry 'bcprov-jdk15on'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-  "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-  "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+  "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
@@ -32,6 +32,11 @@
     <property name="eachLine" value="true"/>
   </module>
 
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="120"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
   <module name="SuppressWarningsFilter" />
   <module name="TreeWalker">
     <module name="UnusedImports"/>
@@ -49,10 +54,6 @@
       <property name="allowEscapesForControlCharacters" value="true"/>
       <property name="allowByTailComment" value="true"/>
       <property name="allowNonPrintableEscapes" value="true"/>
-    </module>
-    <module name="LineLength">
-      <property name="max" value="120"/>
-      <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
     <module name="AvoidStarImport"/>
     <module name="OneTopLevelClass"/>
@@ -229,6 +230,7 @@
       <property name="allowSamelineMultipleAnnotations" value="true"/>
     </module>
     <module name="NonEmptyAtclauseDescription"/>
+    <module name="InvalidJavadocPosition"/>
     <module name="JavadocTagContinuationIndentation"/>
     <module name="SummaryJavadoc">
       <property name="forbiddenSummaryFragments"
@@ -245,9 +247,13 @@
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingThrowsTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
-      <property name="minLineCount" value="2"/>
       <property name="allowedAnnotations" value="Override, Test"/>
       <property name="allowThrowsTagsForSubclasses" value="true"/>
+    </module>
+    <module name="MissingJavadocMethod">
+      <property name="scope" value="nothing"/>
+      <property name="minLineCount" value="2"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
     </module>
     <module name="MethodName">
       <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>


### PR DESCRIPTION
### Change description ###

Even though not pulled in directly, still complains. Could be shaded so will have to suppress in case build errors

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
