### PR TITLE
Remove `microserviceName` from terraform output file

### DIFF
--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,7 +1,3 @@
-output "microserviceName" {
-  value = "${var.component}"
-}
-
 // region: settings for functional tests
 
 output "ENVELOPES_QUEUE_WRITE_CONN_STRING" {


### PR DESCRIPTION
### Change description ###

This output is deprecated and never was actually used in this service

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
