### PR TITLE
Configure concurrent jobs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/SchedulerConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/SchedulerConfig.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+public class SchedulerConfig implements SchedulingConfigurer {
+
+    private static final int POOL_SIZE = 10;
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(POOL_SIZE);
+        scheduler.initialize();
+
+        taskRegistrar.setTaskScheduler(scheduler);
+    }
+}


### PR DESCRIPTION
### Summary
By default, spring boot scheduler uses single thread and only one job can run at a time.
This change configures a thread pool which will allow running multiple jobs at the same time.

### Background
We currently have 2 jobs:
- `CleanupEnvelopesDlqTask`
- `EnvelopesQueueConsumeTask`

Due to a bug, the dlq cleanup job kept running for a long time, preventing the envelopes job from starting.


https://stackoverflow.com/a/35017579
https://crmepham.github.io/spring-boot-multi-thread-scheduling/
