### PR TITLE
Introduce new validator for event id

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidator.java
@@ -20,12 +20,12 @@ public final class EventIdValidator {
 
     @Nonnull
     static Validation<String, Void> isAttachToCaseEvent(String eventId) {
-        return hasValidEventId(EVENT_ID_ATTACH_TO_CASE::equalsIgnoreCase, eventId);
+        return hasValidEventId(EVENT_ID_ATTACH_TO_CASE::equals, eventId);
     }
 
     @Nonnull
     static Validation<String, Void> isCreateCaseEvent(String eventId) {
-        return hasValidEventId(EVENT_ID_CREATE_CASE::equalsIgnoreCase, eventId);
+        return hasValidEventId(EVENT_ID_CREATE_CASE::equals, eventId);
     }
 
     @Nonnull

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidator.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import io.vavr.control.Validation;
+
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+
+import static io.vavr.control.Validation.invalid;
+import static io.vavr.control.Validation.valid;
+import static java.lang.String.format;
+
+public final class EventIdValidator {
+
+    private static final String EVENT_ID_ATTACH_TO_CASE = "attachToExistingCase";
+    private static final String EVENT_ID_CREATE_CASE = "createCase";
+
+    private EventIdValidator() {
+        // utility class constructor
+    }
+
+    @Nonnull
+    static Validation<String, Void> isAttachToCaseEvent(String eventId) {
+        return hasValidEventId(EVENT_ID_ATTACH_TO_CASE::equalsIgnoreCase, eventId);
+    }
+
+    @Nonnull
+    static Validation<String, Void> isCreateCaseEvent(String eventId) {
+        return hasValidEventId(EVENT_ID_CREATE_CASE::equalsIgnoreCase, eventId);
+    }
+
+    @Nonnull
+    private static Validation<String, Void> hasValidEventId(Function<String, Boolean> isValid, String eventId) {
+        return isValid.apply(eventId)
+            ? valid(null)
+            : invalid(format("The %s event is not supported. Please contact service team", eventId));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidatorTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import io.vavr.control.Validation;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventIdValidatorTest {
+
+    private static Object[][] attachToCaseEventIdTestParams() {
+        return new Object[][]{
+            {"Invalid 'Attach to Case' event id", "invalid_event_id", false},
+            {"Valid 'Attach to Case' event id", "attachToExistingCase", true}
+        };
+    }
+
+    @ParameterizedTest(name = "{0}: valid:{2}")
+    @MethodSource("attachToCaseEventIdTestParams")
+    void attachToCaseEventIdTest(String caseDescription, String eventId, boolean expectedIsValid) {
+        assertEventIdValidation(EventIdValidator.isAttachToCaseEvent(eventId), expectedIsValid);
+    }
+
+    private static Object[][] createCaseEventIdTestParams() {
+        return new Object[][]{
+            {"Invalid 'Create Case' event id", "invalid_event_id", false},
+            {"Valid 'Create Case' event id", "createCase", true}
+        };
+    }
+
+    @ParameterizedTest(name = "{0}: valid:{2}")
+    @MethodSource("createCaseEventIdTestParams")
+    void createCaseEventIdTest(String caseDescription, String eventId, boolean expectedIsValid) {
+        assertEventIdValidation(EventIdValidator.isCreateCaseEvent(eventId), expectedIsValid);
+    }
+
+    private void assertEventIdValidation(Validation<String, Void> validation, boolean expectedIsValid) {
+        assertThat(validation.isValid()).isEqualTo(expectedIsValid);
+
+        if (validation.isInvalid()) {
+            assertThat(validation.getError()).isEqualTo(
+                "The invalid_event_id event is not supported. Please contact service team"
+            );
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidatorTest.java
@@ -11,6 +11,7 @@ class EventIdValidatorTest {
     private static Object[][] attachToCaseEventIdTestParams() {
         return new Object[][]{
             {"Invalid 'Attach to Case' event id", "invalid_event_id", false},
+            {"Invalid 'Attach to Case' event id", "AttachToExistingCase", false},
             {"Valid 'Attach to Case' event id", "attachToExistingCase", true}
         };
     }
@@ -18,12 +19,16 @@ class EventIdValidatorTest {
     @ParameterizedTest(name = "{0}: valid:{2}")
     @MethodSource("attachToCaseEventIdTestParams")
     void attachToCaseEventIdTest(String caseDescription, String eventId, boolean expectedIsValid) {
-        assertEventIdValidation(EventIdValidator.isAttachToCaseEvent(eventId), expectedIsValid);
+        Validation<String, Void> validation = EventIdValidator.isAttachToCaseEvent(eventId);
+
+        assertThat(validation.isValid()).isEqualTo(expectedIsValid);
+        assertErrorMessage(validation, eventId);
     }
 
     private static Object[][] createCaseEventIdTestParams() {
         return new Object[][]{
             {"Invalid 'Create Case' event id", "invalid_event_id", false},
+            {"Valid 'Create Case' event id", "CreateCase", false},
             {"Valid 'Create Case' event id", "createCase", true}
         };
     }
@@ -31,15 +36,17 @@ class EventIdValidatorTest {
     @ParameterizedTest(name = "{0}: valid:{2}")
     @MethodSource("createCaseEventIdTestParams")
     void createCaseEventIdTest(String caseDescription, String eventId, boolean expectedIsValid) {
-        assertEventIdValidation(EventIdValidator.isCreateCaseEvent(eventId), expectedIsValid);
+        Validation<String, Void> validation = EventIdValidator.isCreateCaseEvent(eventId);
+
+        assertThat(validation.isValid()).isEqualTo(expectedIsValid);
+        assertErrorMessage(validation, eventId);
     }
 
-    private void assertEventIdValidation(Validation<String, Void> validation, boolean expectedIsValid) {
-        assertThat(validation.isValid()).isEqualTo(expectedIsValid);
-
+    private void assertErrorMessage(Validation<String, Void> validation, String expectedEventId) {
         if (validation.isInvalid()) {
             assertThat(validation.getError()).isEqualTo(
-                "The invalid_event_id event is not supported. Please contact service team"
+                "The %s event is not supported. Please contact service team",
+                expectedEventId
             );
         }
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create Case: pre-validation of callback request](https://tools.hmcts.net/jira/browse/BPS-738)

### Change description ###

Requirement to validate new event id screams for some unification together with existing one. Introducing separate validator just for event id. Event ID is the most important instant rejection required validation so makes sense to extract it out to be stand-alone

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
