### PR TITLE
Replace current use of event id validator with new one

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -27,11 +27,11 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackVal
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasSearchCaseReference;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasSearchCaseReferenceType;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasServiceNameInCaseTypeId;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasValidEventId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.checkForDuplicatesOrElse;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.concatDocuments;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.getDocumentNumbers;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.getScannedDocuments;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.isAttachToCaseEvent;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes.CCD_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes.EXTERNAL_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.ATTACH_TO_CASE_REFERENCE;
@@ -62,7 +62,7 @@ public class AttachCaseCallbackService {
         CaseDetails exceptionRecord,
         String eventId
     ) {
-        Validation<String, Void> eventIdValidation = hasValidEventId(eventId);
+        Validation<String, Void> eventIdValidation = isAttachToCaseEvent(eventId);
 
         if (eventIdValidation.isInvalid()) {
             String eventIdValidationError = eventIdValidation.getError();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -130,12 +130,6 @@ final class CallbackValidations {
             ).orElseGet(() -> invalid("No journey classification supplied"));
     }
 
-    @Nonnull
-    static Validation<String, Void> hasValidEventId(String eventId) {
-        return EVENT_ID_ATTACH_TO_CASE.equalsIgnoreCase(eventId)
-            ? valid(null) : invalid(format("The %s event is not supported. Please contact service team", eventId));
-    }
-
     private static Optional<String> getJourneyClassification(CaseDetails theCase) {
         return Optional.ofNullable(theCase)
             .map(CaseDetails::getData)

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
@@ -218,30 +218,6 @@ class CallbackValidationsTest {
         );
     }
 
-    private static Object[][] eventIdTestParams() {
-        return new Object[][]{
-            {"Invalid event id", "invalid_event_id", false, "The invalid_event_id event is not supported. Please contact service team"},
-            {"Valid event id", "attachToExistingCase", true, null},
-        };
-    }
-
-    @ParameterizedTest(name = "{0}: valid:{2} error/value:{3}")
-    @MethodSource("eventIdTestParams")
-    void eventIdTest(
-        String caseDescription,
-        String eventId,
-        boolean valid,
-        String expectedValueOrError
-    ) {
-        checkValidation(
-            eventId,
-            valid,
-            expectedValueOrError,
-            CallbackValidations::hasValidEventId,
-            expectedValueOrError
-        );
-    }
-
     @Test
     void invalidJurisdictionTest() {
         checkValidation(
@@ -277,16 +253,6 @@ class CallbackValidationsTest {
                                      boolean valid,
                                      T realValue,
                                      Function<CaseDetails, Validation<String, ?>> validationMethod,
-                                     String errorString) {
-        Validation<String, ?> validation = validationMethod.apply(input);
-
-        softAssertions(valid, realValue, errorString, validation);
-    }
-
-    private <T> void checkValidation(String input,
-                                     boolean valid,
-                                     T realValue,
-                                     Function<String, Validation<String, ?>> validationMethod,
                                      String errorString) {
         Validation<String, ?> validation = validationMethod.apply(input);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create Case: pre-validation of callback request](https://tools.hmcts.net/jira/browse/BPS-738)

### Change description ###

Replace validation of `attachToExistingCase` event id validation to new validator. `createCase` event validation is coming in next PR when new service for new callback is introduced

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
