### PR TITLE
Excluding check for default accessor

### DIFF
--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -15,6 +15,7 @@
   </rule>
   <rule ref="category/java/codestyle.xml">
     <exclude name="AtLeastOneConstructor" />
+    <exclude name="CommentDefaultAccessModifier" />
     <exclude name="LocalVariableCouldBeFinal" />
     <exclude name="LongVariable" />
     <exclude name="MethodArgumentCouldBeFinal" />


### PR DESCRIPTION
### Change description ###

This is really not a requirement anymore. As a developer one should be aware how to use and define accessors.

More/Less accurate comparison of pmd issues as metrics gathered while switching branches here and there:

Task  | Before | After
----- | ------ | -----
Fun   | 63     | 56
Int   | 42     | 33
Main  | 287    | 263
Smoke | 4      | 3
Unit  | 317    | 235

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
