### PR TITLE
Rename queue message field and corresponding class field

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Envelope.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/Envelope.java
@@ -21,7 +21,7 @@ public class Envelope {
     public final Classification classification;
     public final List<Document> documents;
     public final List<OcrDataField> ocrData;
-    public final List<String> ocrValidationWarnings;
+    public final List<String> ocrDataValidationWarnings;
 
     public Envelope(
         @JsonProperty(value = "id", required = true) String id,
@@ -36,7 +36,7 @@ public class Envelope {
         @JsonProperty(value = "classification", required = true) Classification classification,
         @JsonProperty(value = "documents", required = true) List<Document> documents,
         @JsonProperty(value = "ocr_data") List<OcrDataField> ocrData,
-        @JsonProperty(value = "ocr_validation_warnings") List<String> ocrValidationWarnings
+        @JsonProperty(value = "ocr_data_validation_warnings") List<String> ocrDataValidationWarnings
     ) {
         this.id = id;
         this.caseRef = caseRef;
@@ -50,6 +50,6 @@ public class Envelope {
         this.classification = classification;
         this.documents = documents;
         this.ocrData = ocrData;
-        this.ocrValidationWarnings = ocrValidationWarnings;
+        this.ocrDataValidationWarnings = ocrDataValidationWarnings;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/EnvelopeParserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/EnvelopeParserTest.java
@@ -99,7 +99,7 @@ class EnvelopeParserTest {
                     .put(toJson(envelope.documents.get(1)))
                 )
                 .put("ocr_data", toOcrJson(envelope.ocrData))
-                .put("ocr_validation_warnings", new JSONArray(envelope.ocrValidationWarnings))
+                .put("ocr_data_validation_warnings", new JSONArray(envelope.ocrDataValidationWarnings))
                 .toString();
 
         // when
@@ -162,7 +162,7 @@ class EnvelopeParserTest {
                 )
                 .put("some_extra_ignored_field", "some_ignored_value")
                 .put("ocr_data", toOcrJson(envelope.ocrData))
-                .put("ocr_validation_warnings", new JSONArray(envelope.ocrValidationWarnings))
+                .put("ocr_data_validation_warnings", new JSONArray(envelope.ocrDataValidationWarnings))
                 .toString();
 
         // when


### PR DESCRIPTION
### Change description ###

Do not merge before https://github.com/hmcts/bulk-scan-processor/pull/805

Rename queue message field (`ocr_validation_warnings` -> `ocr_data_validation_warnings`) and corresponding class field (`ocrValidationWarnings` -> `ocrDataValidationWarnings`), in order to follow the existing convention of naming OCR data.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
