### PR TITLE
Add `CreateCaseCallbackService` with event validation step

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import io.vavr.control.Either;
+import io.vavr.control.Validation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.isCreateCaseEvent;
+
+public class CreateCaseCallbackService {
+
+    private static final Logger log = LoggerFactory.getLogger(CreateCaseCallbackService.class);
+
+    public CreateCaseCallbackService() {
+        // currently empty constructor
+    }
+
+    /**
+     * Create case record from exception case record.
+     *
+     * @return Either TBD - not yet implemented
+     */
+    public Either<List<String>, Object> process(CaseDetails caseDetails, String eventId) {
+        Validation<String, Void> eventIdValidation = isCreateCaseEvent(eventId);
+
+        if (eventIdValidation.isInvalid()) {
+            String eventIdValidationError = eventIdValidation.getError();
+            log.warn("Validation error {}", eventIdValidationError);
+
+            return Either.left(singletonList(eventIdValidationError));
+        }
+
+        return Either.left(singletonList("Not yet implemented"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import io.vavr.control.Either;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreateCaseCallbackServiceTest {
+
+    private static final String EVENT_ID = "createCase";
+    private static final CreateCaseCallbackService SERVICE = new CreateCaseCallbackService();
+
+    @Test
+    void should_not_allow_to_process_callback_in_case_wrong_event_id_is_received() {
+        Either<List<String>, Object> output = SERVICE.process(null, "some event");
+
+        assertThat(output.isLeft()).isTrue();
+        assertThat(output.getLeft()).containsOnly("The some event event is not supported. Please contact service team");
+    }
+
+    @Test
+    void should_proceed_with_not_implemented_error() {
+        Either<List<String>, Object> output = SERVICE.process(null, EVENT_ID);
+
+        assertThat(output.isLeft()).isTrue();
+        assertThat(output.getLeft()).containsOnly("Not yet implemented");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create Case: pre-validation of callback request](https://tools.hmcts.net/jira/browse/BPS-738)

### Change description ###

Adding new callback service specifically dedicated for case creation event. Follows similar pattern as attach scanned docs callback service.

Next PR: checking `CaseDetails` and creating `ExceptionRecord` request object for transformation client

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No - service not used
```
