### PR TITLE
Prepare validation for create case callback request

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -22,7 +22,6 @@ final class CallbackValidations {
 
     private static final String CLASSIFICATION_SUPPLEMENTARY_EVIDENCE = "SUPPLEMENTARY_EVIDENCE";
     private static final String CLASSIFICATION_EXCEPTION = "EXCEPTION";
-    private static final String EVENT_ID_ATTACH_TO_CASE = "attachToExistingCase";
 
     private static final Logger log = LoggerFactory.getLogger(CallbackValidations.class);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -144,12 +144,6 @@ final class CallbackValidations {
             : invalid("Callback has no user id received in the header");
     }
 
-    @Nonnull
-    static Validation<String, Void> hasValidEventId(String eventId) {
-        return EVENT_ID_ATTACH_TO_CASE.equalsIgnoreCase(eventId)
-            ? valid(null) : invalid(format("The %s event is not supported. Please contact service team", eventId));
-    }
-
     private static Optional<String> getJourneyClassification(CaseDetails theCase) {
         return Optional.ofNullable(theCase)
             .map(CaseDetails::getData)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -25,6 +25,7 @@ public class CreateCaseCallbackService {
      *
      * @return Either TBD - not yet implemented
      */
+    @SuppressWarnings("squid:S1172") // tmp. suppress unused `caseDetails` parameter
     public Either<List<String>, ExceptionRecord> process(CaseDetails caseDetails, String eventId) {
         Validation<String, Void> eventIdValidation = isCreateCaseEvent(eventId);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -4,6 +4,7 @@ import io.vavr.control.Either;
 import io.vavr.control.Validation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.List;
@@ -24,7 +25,7 @@ public class CreateCaseCallbackService {
      *
      * @return Either TBD - not yet implemented
      */
-    public Either<List<String>, Object> process(CaseDetails caseDetails, String eventId) {
+    public Either<List<String>, ExceptionRecord> process(CaseDetails caseDetails, String eventId) {
         Validation<String, Void> eventIdValidation = isCreateCaseEvent(eventId);
 
         if (eventIdValidation.isInvalid()) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
@@ -220,30 +220,6 @@ class CallbackValidationsTest {
         );
     }
 
-    private static Object[][] eventIdTestParams() {
-        return new Object[][]{
-            {"Invalid event id", "invalid_event_id", false, "The invalid_event_id event is not supported. Please contact service team"},
-            {"Valid event id", "attachToExistingCase", true, null},
-        };
-    }
-
-    @ParameterizedTest(name = "{0}: valid:{2} error/value:{3}")
-    @MethodSource("eventIdTestParams")
-    void eventIdTest(
-        String caseDescription,
-        String eventId,
-        boolean valid,
-        String expectedValueOrError
-    ) {
-        checkValidation(
-            eventId,
-            valid,
-            expectedValueOrError,
-            CallbackValidations::hasValidEventId,
-            expectedValueOrError
-        );
-    }
-
     @Test
     void invalidJurisdictionTest() {
         checkValidation(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
@@ -142,9 +142,9 @@ class CallbackValidationsTest {
 
     private static Object[][] scannedRecordTestParams() {
         String noDocumentError = "There were no documents in exception record";
-        CaseDetails validDoc = caseWithDocument(document("fileName.pdf"));
+        CaseDetails validDoc = caseWithDocument(document("https://url", "fileName.pdf"));
         return new Object[][]{
-            {"Correct map with document", validDoc, true, document("fileName.pdf"), null},
+            {"Correct map with document", validDoc, true, document("https://url", "fileName.pdf"), null},
             {"Null case details", null, false, null, noDocumentError},
             {"Null data supplied", createCaseWith(b -> b.data(null)), false, null, noDocumentError},
             {"Empty data supplied", createCaseWith(b -> b.data(ImmutableMap.of())), false, null, noDocumentError},

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
 import io.vavr.control.Either;
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
 
 import java.util.List;
 
@@ -14,7 +15,7 @@ class CreateCaseCallbackServiceTest {
 
     @Test
     void should_not_allow_to_process_callback_in_case_wrong_event_id_is_received() {
-        Either<List<String>, Object> output = SERVICE.process(null, "some event");
+        Either<List<String>, ExceptionRecord> output = SERVICE.process(null, "some event");
 
         assertThat(output.isLeft()).isTrue();
         assertThat(output.getLeft()).containsOnly("The some event event is not supported. Please contact service team");
@@ -22,7 +23,7 @@ class CreateCaseCallbackServiceTest {
 
     @Test
     void should_proceed_with_not_implemented_error() {
-        Either<List<String>, Object> output = SERVICE.process(null, EVENT_ID);
+        Either<List<String>, ExceptionRecord> output = SERVICE.process(null, EVENT_ID);
 
         assertThat(output.isLeft()).isTrue();
         assertThat(output.getLeft()).containsOnly("Not yet implemented");

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
@@ -52,7 +52,20 @@ class TestCaseBuilder {
         return createCaseWith(b -> b.data(data));
     }
 
-    static List<Map<String, Object>> document(String name) {
-        return ImmutableList.of(ImmutableMap.of("fileName", name));
+    static List<Map<String, Object>> document(String url, String name) {
+        Map<String, Object> doc = new HashMap<>();
+
+        doc.put("type", "Other");
+        doc.put("url", ImmutableMap.of(
+            "document_url", url,
+            "document_binary_url", url,
+            "document_filename", name
+        ));
+        doc.put("controlNumber", "1234");
+        doc.put("fileName", "file");
+        doc.put("scannedDate", "2019-09-06T15:40:00.000Z");
+        doc.put("deliveryDate", "2019-09-06T15:40:00.001Z");
+
+        return ImmutableList.of(ImmutableMap.of("value", doc));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create Case: pre-validation of callback request](https://tools.hmcts.net/jira/browse/BPS-738)

### Change description ###

Something happened while developed locally: previously (#553) removed code got in.

Other changes:

- as part of validation process it's output must be `ExceptionRecord`
- need fully developed document which lives in ccd's `CaseDetails` data object. Following [these specs](https://github.com/hmcts/ccd-data-store-api/blob/master/docs/api/case-data.md) on how to build such objects and our exception record definitions to know what actual fields are there

Next: introduce either full validation/conversion or get in partially. Predicted changes: `4 files changed, 229 insertions(+)`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
