### PR TITLE
Feature: validate case details for `createCase` callback

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -180,7 +180,7 @@ final class CallbackValidations {
             .map(CaseDetails::getData)
             .map(data -> data.get("poBox"))
             .map(o -> Validation.<String, String>valid((String) o))
-            .orElse(Validation.valid(null));
+            .orElse(invalid("Missing poBox"));
     }
 
     /**
@@ -211,6 +211,6 @@ final class CallbackValidations {
             .map(CaseDetails::getData)
             .map(data -> data.get(dateField))
             .map(o -> Validation.<String, Instant>valid(Instant.parse((String) o)))
-            .orElse(Validation.valid(null));
+            .orElse(invalid("Missing " + dateField));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -170,12 +170,17 @@ final class CallbackValidations {
             .orElse(false);
     }
 
+    /**
+     * Extracting PO BOX, optionally
+     * @param theCase from CCD
+     * @return Validation of it which is always valid
+     */
     static Validation<String, String> hasPoBox(CaseDetails theCase) {
         return Optional.ofNullable(theCase)
             .map(CaseDetails::getData)
             .map(data -> data.get("poBox"))
             .map(o -> Validation.<String, String>valid((String) o))
-            .orElse(invalid("Missing poBox"));
+            .orElse(Validation.valid(null));
     }
 
     static Validation<String, Classification> hasJourneyClassification(CaseDetails theCase) {
@@ -188,11 +193,17 @@ final class CallbackValidations {
             .orElse(invalid("Missing journeyClassification"));
     }
 
+    /**
+     * Extracting any date, optionally.
+     * @param theCase from CCD
+     * @param dateField name
+     * @return Validation of it which is always valid
+     */
     static Validation<String, Instant> hasDateField(CaseDetails theCase, String dateField) {
         return Optional.ofNullable(theCase)
             .map(CaseDetails::getData)
             .map(data -> data.get(dateField))
             .map(o -> Validation.<String, Instant>valid(Instant.parse((String) o)))
-            .orElse(invalid("Missing " + dateField));
+            .orElse(Validation.valid(null));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -184,7 +184,7 @@ final class CallbackValidations {
     }
 
     /**
-     * Used in createCase callback only. For further integration need more generic few and refactor.
+     * Used in createCase callback only.
      * @param theCase from CCD
      * @return Validation of it
      */
@@ -197,19 +197,7 @@ final class CallbackValidations {
             .map(validation -> validation
                 .mapError(throwable -> "Invalid journeyClassification. Error: " + throwable.getMessage())
             )
-            .orElse(invalid("Missing journeyClassification"))
-            .filter(classification -> {
-                switch (classification) {
-                    case EXCEPTION:
-                    case NEW_APPLICATION:
-                        return true;
-                    case SUPPLEMENTARY_EVIDENCE:
-                    default:
-                        return false;
-                }
-            })
-            .filter(classification -> hasOcr(theCase))
-            .getOrElse(Validation.invalid("Incorrect journeyClassification: " + classificationOption.orElse("null")));
+            .orElse(invalid("Missing journeyClassification"));
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -170,11 +170,6 @@ final class CallbackValidations {
             .orElse(false);
     }
 
-    /**
-     * Extracting PO BOX, optionally.
-     * @param theCase from CCD
-     * @return Validation of it which is always valid
-     */
     static Validation<String, String> hasPoBox(CaseDetails theCase) {
         return Optional.ofNullable(theCase)
             .map(CaseDetails::getData)
@@ -200,12 +195,6 @@ final class CallbackValidations {
             .orElse(invalid("Missing journeyClassification"));
     }
 
-    /**
-     * Extracting any date, optionally.
-     * @param theCase from CCD
-     * @param dateField name
-     * @return Validation of it which is always valid
-     */
     static Validation<String, Instant> hasDateField(CaseDetails theCase, String dateField) {
         return Optional.ofNullable(theCase)
             .map(CaseDetails::getData)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -171,7 +171,7 @@ final class CallbackValidations {
     }
 
     /**
-     * Extracting PO BOX, optionally
+     * Extracting PO BOX, optionally.
      * @param theCase from CCD
      * @return Validation of it which is always valid
      */
@@ -184,7 +184,7 @@ final class CallbackValidations {
     }
 
     /**
-     * Used in createCase callback only. For further integration need more generic few and refactor
+     * Used in createCase callback only. For further integration need more generic few and refactor.
      * @param theCase from CCD
      * @return Validation of it
      */

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -1,11 +1,14 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
+import io.vavr.control.Try;
 import io.vavr.control.Validation;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -42,6 +45,14 @@ final class CallbackValidations {
         log.error("{}:{}", error, arg1);
         String formatString = "Internal Error: " + error;
         return invalid(format(formatString, arg1));
+    }
+
+    @Nonnull
+    static Validation<String, String> hasCaseTypeId(CaseDetails theCase) {
+        return Optional.ofNullable(theCase)
+            .map(CaseDetails::getCaseTypeId)
+            .map(Validation::<String, String>valid)
+            .orElse(invalid("Missing caseType"));
     }
 
     @Nonnull
@@ -157,5 +168,31 @@ final class CallbackValidations {
             .map(data -> (List<Map<String, Object>>) data.get("scanOCRData"))
             .map(CollectionUtils::isNotEmpty)
             .orElse(false);
+    }
+
+    static Validation<String, String> hasPoBox(CaseDetails theCase) {
+        return Optional.ofNullable(theCase)
+            .map(CaseDetails::getData)
+            .map(data -> data.get("poBox"))
+            .map(o -> Validation.<String, String>valid((String) o))
+            .orElse(invalid("Missing poBox"));
+    }
+
+    static Validation<String, Classification> hasJourneyClassification(CaseDetails theCase) {
+        return getJourneyClassification(theCase)
+            .map(classification -> Try.of(() -> Classification.valueOf(classification)))
+            .map(Try::toValidation)
+            .map(validation -> validation
+                .mapError(throwable -> "Invalid classification. Error: " + throwable.getMessage())
+            )
+            .orElse(invalid("Missing journeyClassification"));
+    }
+
+    static Validation<String, Instant> hasDateField(CaseDetails theCase, String dateField) {
+        return Optional.ofNullable(theCase)
+            .map(CaseDetails::getData)
+            .map(data -> data.get(dateField))
+            .map(o -> Validation.<String, Instant>valid(Instant.parse((String) o)))
+            .orElse(invalid("Missing " + dateField));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -1,15 +1,24 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
+import io.vavr.collection.Seq;
 import io.vavr.control.Either;
 import io.vavr.control.Validation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.OcrDataField;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ScannedDocument;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasCaseTypeId;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasDateField;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasJourneyClassification;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasJurisdiction;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasPoBox;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.isCreateCaseEvent;
 
 public class CreateCaseCallbackService {
@@ -25,7 +34,6 @@ public class CreateCaseCallbackService {
      *
      * @return Either TBD - not yet implemented
      */
-    @SuppressWarnings("squid:S1172") // tmp. suppress unused `caseDetails` parameter
     public Either<List<String>, ExceptionRecord> process(CaseDetails caseDetails, String eventId) {
         Validation<String, Void> eventIdValidation = isCreateCaseEvent(eventId);
 
@@ -36,6 +44,34 @@ public class CreateCaseCallbackService {
             return Either.left(singletonList(eventIdValidationError));
         }
 
-        return Either.left(singletonList("Not yet implemented"));
+        return getValidation(caseDetails)
+            .toEither()
+            .mapLeft(Seq::asJava);
+    }
+
+    private Validation<Seq<String>, ExceptionRecord> getValidation(CaseDetails caseDetails) {
+        Validation<String, List<ScannedDocument>> scannedDocuments = getScannedDocuments();
+        Validation<String, List<OcrDataField>> ocrDataFields = getOcrDataFields();
+
+        return Validation
+            .combine(
+                hasCaseTypeId(caseDetails),
+                hasPoBox(caseDetails),
+                hasJurisdiction(caseDetails),
+                hasJourneyClassification(caseDetails),
+                hasDateField(caseDetails, "deliveryDate"),
+                hasDateField(caseDetails, "openingDate"),
+                scannedDocuments,
+                ocrDataFields
+            )
+            .ap(ExceptionRecord::new);
+    }
+
+    private Validation<String, List<ScannedDocument>> getScannedDocuments() {
+        return Validation.valid(emptyList());
+    }
+
+    private Validation<String, List<OcrDataField>> getOcrDataFields() {
+        return Validation.valid(emptyList());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -50,9 +50,6 @@ public class CreateCaseCallbackService {
     }
 
     private Validation<Seq<String>, ExceptionRecord> getValidation(CaseDetails caseDetails) {
-        Validation<String, List<ScannedDocument>> scannedDocuments = getScannedDocuments();
-        Validation<String, List<OcrDataField>> ocrDataFields = getOcrDataFields();
-
         return Validation
             .combine(
                 hasCaseTypeId(caseDetails),
@@ -61,8 +58,8 @@ public class CreateCaseCallbackService {
                 hasJourneyClassification(caseDetails),
                 hasDateField(caseDetails, "deliveryDate"),
                 hasDateField(caseDetails, "openingDate"),
-                scannedDocuments,
-                ocrDataFields
+                getScannedDocuments(),
+                getOcrDataFields()
             )
             .ap(ExceptionRecord::new);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -3,8 +3,11 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 import io.vavr.control.Either;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,10 +25,44 @@ class CreateCaseCallbackServiceTest {
     }
 
     @Test
-    void should_proceed_with_not_implemented_error() {
+    void should_report_all_errors_when_null_is_provided_as_case_details() {
         Either<List<String>, ExceptionRecord> output = SERVICE.process(null, EVENT_ID);
 
         assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("Not yet implemented");
+        assertThat(output.getLeft()).containsOnly(
+            "Missing caseType",
+            "Missing poBox",
+            "Internal Error: invalid jurisdiction supplied: null",
+            "Missing journeyClassification",
+            "Missing deliveryDate",
+            "Missing openingDate"
+        );
+    }
+
+    @Test
+    void should_successfully_create_exception_record_with_documents_and_ocr_data_for_transformation_client() {
+        // given
+        Map<String, Object> data = new HashMap<>();
+        // putting 6 via `ImmutableMap` is available from Java 9
+        data.put("poBox", "12345");
+        data.put("journeyClassification", "EXCEPTION");
+        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
+        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
+        data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
+
+        CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .caseTypeId("some case type")
+            .jurisdiction("some jurisdiction")
+            .data(data)
+        );
+
+        // when
+        Either<List<String>, ExceptionRecord> output = SERVICE.process(caseDetails, EVENT_ID);
+
+        // then
+        assertThat(output.isRight()).isTrue();
+        assertThat(output.get().scannedDocuments).hasSize(0);
+        assertThat(output.get().ocrDataFields).hasSize(0);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -33,7 +33,7 @@ class CreateCaseCallbackServiceTest {
         assertThat(output.getLeft()).containsOnly(
             "Missing caseType",
             "Internal Error: invalid jurisdiction supplied: null",
-            "Incorrect journeyClassification: null"
+            "Missing journeyClassification"
         );
     }
 
@@ -62,32 +62,6 @@ class CreateCaseCallbackServiceTest {
         assertThat(output.isRight()).isTrue();
         assertThat(output.get().scannedDocuments).hasSize(0);
         assertThat(output.get().ocrDataFields).hasSize(0);
-    }
-
-    @Test
-    void should_warn_about_incorrect_classification_being_used() {
-        // given
-        Map<String, Object> data = new HashMap<>();
-        // putting 6 via `ImmutableMap` is available from Java 9
-        data.put("poBox", "12345");
-        data.put("journeyClassification", "SUPPLEMENTARY_EVIDENCE");
-        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
-        data.put("openingDate", "2019-09-06T15:30:04.000Z");
-        data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
-        data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
-
-        CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
-            .caseTypeId("some case type")
-            .jurisdiction("some jurisdiction")
-            .data(data)
-        );
-
-        // when
-        Either<List<String>, ExceptionRecord> output = SERVICE.process(caseDetails, EVENT_ID);
-
-        // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("Incorrect journeyClassification: SUPPLEMENTARY_EVIDENCE");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification.EXCEPTION;
 
 class CreateCaseCallbackServiceTest {
 
@@ -43,7 +44,7 @@ class CreateCaseCallbackServiceTest {
         Map<String, Object> data = new HashMap<>();
         // putting 6 via `ImmutableMap` is available from Java 9
         data.put("poBox", "12345");
-        data.put("journeyClassification", "EXCEPTION");
+        data.put("journeyClassification", EXCEPTION.name());
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -33,8 +33,11 @@ class CreateCaseCallbackServiceTest {
         assertThat(output.isLeft()).isTrue();
         assertThat(output.getLeft()).containsOnly(
             "Missing caseType",
+            "Missing poBox",
             "Internal Error: invalid jurisdiction supplied: null",
-            "Missing journeyClassification"
+            "Missing journeyClassification",
+            "Missing deliveryDate",
+            "Missing openingDate"
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -31,11 +31,8 @@ class CreateCaseCallbackServiceTest {
         assertThat(output.isLeft()).isTrue();
         assertThat(output.getLeft()).containsOnly(
             "Missing caseType",
-            "Missing poBox",
             "Internal Error: invalid jurisdiction supplied: null",
-            "Missing journeyClassification",
-            "Missing deliveryDate",
-            "Missing openingDate"
+            "Missing journeyClassification"
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
@@ -68,4 +68,8 @@ class TestCaseBuilder {
 
         return ImmutableList.of(ImmutableMap.of("value", doc));
     }
+
+    static List<Map<String, Object>> ocrDataEntry(String key, String value) {
+        return ImmutableList.of(ImmutableMap.of("value", ImmutableMap.of("key", key, "value", value)));
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create Case: pre-validation of callback request](https://tools.hmcts.net/jira/browse/BPS-738)

### Change description ###

Follow up of #560 - links to specs etc. Here:

- Validate necessary fields are present in order to successfully create `ExceptionRecord` - request object for transformation client
- Leave out scanned documents and ocr data for following PR and only test happy path here

Last bulletpoint: reduces headache for reviewer to follow how things are done. Next PR will include all the code in `getScannedDocuments` and `getOcrDataFields` methods

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
