### PR TITLE
Include `scannedDocuments` and `ocrData` population for transformation request object

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Class
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -207,7 +206,7 @@ final class CallbackValidations {
     /**
      * Used in createCase callback only. Can be reviewed later and with BPS-746 - revised the usage.
      * @param theCase from CCD.
-     * @return Validation of it which is always valid
+     * @return Validation of it
      */
     @SuppressWarnings("unchecked")
     static Validation<Object, List<Map<String, Object>>> getOcrData(CaseDetails theCase) {
@@ -215,6 +214,6 @@ final class CallbackValidations {
             .map(CaseDetails::getData)
             .map(data -> (List<Map<String, Object>>) data.get("scanOCRData"))
             .map(Validation::valid)
-            .orElse(Validation.valid(Collections.emptyList()));
+            .orElse(invalid("Missing OCR data"));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Class
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -201,5 +202,19 @@ final class CallbackValidations {
             .map(data -> data.get(dateField))
             .map(o -> Validation.<String, Instant>valid(Instant.parse((String) o)))
             .orElse(invalid("Missing " + dateField));
+    }
+
+    /**
+     * Used in createCase callback only. Can be reviewed later and with BPS-746 - revised the usage.
+     * @param theCase from CCD.
+     * @return Validation of it which is always valid
+     */
+    @SuppressWarnings("unchecked")
+    static Validation<Object, List<Map<String, Object>>> getOcrData(CaseDetails theCase) {
+        return Optional.ofNullable(theCase)
+            .map(CaseDetails::getData)
+            .map(data -> (List<Map<String, Object>>) data.get("scanOCRData"))
+            .map(Validation::valid)
+            .orElse(Validation.valid(Collections.emptyList()));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -81,15 +81,7 @@ public class CreateCaseCallbackService {
                 .map(items -> items.get("value"))
                 .filter(item -> item instanceof Map)
                 .map(item -> (Map<String, Object>) item)
-                .map(document -> new ScannedDocument(
-                    DocumentType.valueOf(((String) document.get("type")).toUpperCase()),
-                    (String) document.get("subType"),
-                    ((Map<String, String>) document.get("url")).get("document_url"),
-                    (String) document.get("controlNumber"),
-                    (String) document.get("fileName"),
-                    Instant.parse((String) document.get("scannedDate")),
-                    Instant.parse((String) document.get("deliveryDate"))
-                ))
+                .map(this::mapScannedDocument)
                 .collect(toList())
         ).toValidation().mapError(throwable -> "Invalid scannedDocuments format. Error: " + throwable.getMessage());
     }
@@ -113,5 +105,18 @@ public class CreateCaseCallbackService {
                     .collect(toList())
                 ).toValidation().mapError(throwable -> "Invalid OCR data format. Error: " + throwable.getMessage())
             );
+    }
+
+    @SuppressWarnings("unchecked")
+    private ScannedDocument mapScannedDocument(Map<String, Object> document) {
+        return new ScannedDocument(
+            DocumentType.valueOf(((String) document.get("type")).toUpperCase()),
+            (String) document.get("subType"),
+            ((Map<String, String>) document.get("url")).get("document_url"),
+            (String) document.get("controlNumber"),
+            (String) document.get("fileName"),
+            Instant.parse((String) document.get("scannedDate")),
+            Instant.parse((String) document.get("deliveryDate"))
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -2,18 +2,25 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
 import io.vavr.collection.Seq;
 import io.vavr.control.Either;
+import io.vavr.control.Try;
 import io.vavr.control.Validation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.DocumentType;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.OcrDataField;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ScannedDocument;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.getOcrData;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasCaseTypeId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasDateField;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasJourneyClassification;
@@ -58,17 +65,53 @@ public class CreateCaseCallbackService {
                 hasJourneyClassification(caseDetails),
                 hasDateField(caseDetails, "deliveryDate"),
                 hasDateField(caseDetails, "openingDate"),
-                getScannedDocuments(),
-                getOcrDataFields()
+                getScannedDocuments(caseDetails),
+                getOcrDataFields(caseDetails)
             )
             .ap(ExceptionRecord::new);
     }
 
-    private Validation<String, List<ScannedDocument>> getScannedDocuments() {
-        return Validation.valid(emptyList());
+    @SuppressWarnings("unchecked")
+    private Validation<String, List<ScannedDocument>> getScannedDocuments(CaseDetails caseDetails) {
+        return Try.of(() ->
+            Optional.ofNullable(caseDetails)
+                .map(Documents::getScannedDocuments)
+                .orElse(emptyList())
+                .stream()
+                .map(items -> items.get("value"))
+                .filter(item -> item instanceof Map)
+                .map(item -> (Map<String, Object>) item)
+                .map(document -> new ScannedDocument(
+                    DocumentType.valueOf(((String) document.get("type")).toUpperCase()),
+                    (String) document.get("subType"),
+                    ((Map<String, String>) document.get("url")).get("document_url"),
+                    (String) document.get("controlNumber"),
+                    (String) document.get("fileName"),
+                    Instant.parse((String) document.get("scannedDate")),
+                    Instant.parse((String) document.get("deliveryDate"))
+                ))
+                .collect(toList())
+        ).toValidation().mapError(throwable -> "Invalid scannedDocuments format. Error: " + throwable.getMessage());
     }
 
-    private Validation<String, List<OcrDataField>> getOcrDataFields() {
-        return Validation.valid(emptyList());
+    @SuppressWarnings("unchecked")
+    private Validation<String, List<OcrDataField>> getOcrDataFields(CaseDetails caseDetails) {
+        return getOcrData(caseDetails)
+            // following mapError should never happen as getting should be non-breaking
+            // left side must be String
+            .mapError(Object::toString)
+            .flatMap(fields ->
+                Try.of(() -> fields
+                    .stream()
+                    .map(items -> items.get("value"))
+                    .filter(item -> item instanceof Map)
+                    .map(item -> (Map<String, String>) item)
+                    .map(ocrData -> new OcrDataField(
+                        ocrData.get("key"),
+                        ocrData.get("value")
+                    ))
+                    .collect(toList())
+                ).toValidation().mapError(throwable -> "Invalid OCR data format. Error: " + throwable.getMessage())
+            );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -137,13 +137,13 @@ class CreateCaseCallbackServiceTest {
                     + Classification.class.getName() + ".EXCEPTIONS",
                 "Invalid scannedDocuments format. Error: No enum constant " + DocumentType.class.getName() + ".OTHERS"
             );
+        String match =
+            "Invalid OCR data format. Error: (class )?java.lang.Integer cannot be cast to (class )?java.lang.String.*";
         assertThat(output.getLeft())
             .filteredOn(string -> string.startsWith("Invalid OCR data format."))
             .hasSize(1)
             .element(0)
             .asString()
-            .matches(
-                "Invalid OCR data format. Error: class java.lang.Integer cannot be cast to class java.lang.String.*"
-            );
+            .matches(match);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -1,9 +1,12 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.vavr.control.Either;
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.DocumentType;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.HashMap;
@@ -64,8 +67,8 @@ class CreateCaseCallbackServiceTest {
 
         // then
         assertThat(output.isRight()).isTrue();
-        assertThat(output.get().scannedDocuments).hasSize(0);
-        assertThat(output.get().ocrDataFields).hasSize(0);
+        assertThat(output.get().scannedDocuments).hasSize(1);
+        assertThat(output.get().ocrDataFields).hasSize(1);
     }
 
     @Test
@@ -89,5 +92,58 @@ class CreateCaseCallbackServiceTest {
         // then
         assertThat(output.isLeft()).isTrue();
         assertThat(output.getLeft()).containsOnly("Missing journeyClassification");
+    }
+
+    @Test
+    void should_report_errors_when_data_is_in_invalid_form() {
+        // given
+        Map<String, Object> doc = new HashMap<>();
+
+        // putting 6 via `ImmutableMap` is available from Java 9
+        doc.put("type", "Others");
+        doc.put("url", ImmutableMap.of(
+            "document_filename", "name"
+        ));
+        doc.put("controlNumber", "1234");
+        doc.put("fileName", "file");
+        doc.put("scannedDate", "2019-09-06T15:40:00.000Z");
+        doc.put("deliveryDate", "2019-09-06T15:40:00.001Z");
+
+        Map<String, Object> data = new HashMap<>();
+
+        data.put("poBox", "12345");
+        data.put("journeyClassification", "EXCEPTIONS");
+        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
+        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("scannedDocuments", ImmutableList.of(ImmutableMap.of("value", doc)));
+        data.put("scanOCRData", ImmutableList.of(ImmutableMap.of("value", ImmutableMap.of(
+            "key", "k",
+            "value", 1
+        ))));
+
+        CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .caseTypeId("some case type")
+            .jurisdiction("some jurisdiction")
+            .data(data)
+        );
+
+        // when
+        Either<List<String>, ExceptionRecord> output = SERVICE.process(caseDetails, EVENT_ID);
+
+        assertThat(output.getLeft())
+            .hasSize(3)
+            .contains(
+                "Invalid journeyClassification. Error: No enum constant "
+                    + Classification.class.getName() + ".EXCEPTIONS",
+                "Invalid scannedDocuments format. Error: No enum constant " + DocumentType.class.getName() + ".OTHERS"
+            );
+        assertThat(output.getLeft())
+            .filteredOn(string -> string.startsWith("Invalid OCR data format."))
+            .hasSize(1)
+            .element(0)
+            .asString()
+            .matches(
+                "Invalid OCR data format. Error: class java.lang.Integer cannot be cast to class java.lang.String.*"
+            );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -40,7 +40,8 @@ class CreateCaseCallbackServiceTest {
             "Internal Error: invalid jurisdiction supplied: null",
             "Missing journeyClassification",
             "Missing deliveryDate",
-            "Missing openingDate"
+            "Missing openingDate",
+            "Missing OCR data"
         );
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create Case: pre-validation of callback request](https://tools.hmcts.net/jira/browse/BPS-738)

### Change description ###

Final step in validating / converting `CaseDetails` object to `ExceptionRecord` so it can be pushed to transformation API. Please follow the documentation links provided in #560 description.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
