### PR TITLE
Require transformation URL to be configured

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -1,25 +1,34 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
+import com.google.common.base.Strings;
 import io.vavr.collection.Seq;
 import io.vavr.control.Either;
+import io.vavr.control.Try;
+import io.vavr.control.Validation;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CreateCaseValidator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.config.ServiceConfigProvider;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.List;
 
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasServiceNameInCaseTypeId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.isCreateCaseEvent;
 
 @Service
 public class CreateCaseCallbackService {
 
     private final CreateCaseValidator validator;
+    private final ServiceConfigProvider serviceConfigProvider;
 
     public CreateCaseCallbackService(
-        CreateCaseValidator validator
+        CreateCaseValidator validator,
+        ServiceConfigProvider serviceConfigProvider
     ) {
         this.validator = validator;
+        this.serviceConfigProvider = serviceConfigProvider;
     }
 
     /**
@@ -28,12 +37,28 @@ public class CreateCaseCallbackService {
      * @return Either TBD - not yet implemented
      */
     public Either<List<String>, ExceptionRecord> process(CaseDetails caseDetails, String eventId) {
-        return validator
-            .mandatoryPrerequisites(() -> isCreateCaseEvent(eventId))
+        return assertAllowToAccess(caseDetails, eventId)
             .flatMap(theVoid -> validator
                 .getValidation(caseDetails)
                 .toEither()
                 .mapLeft(Seq::asJava)
             );
+    }
+
+    private Either<List<String>, Void> assertAllowToAccess(CaseDetails caseDetails, String eventId) {
+        return validator.mandatoryPrerequisites(
+            () -> isCreateCaseEvent(eventId),
+            () -> getServiceConfig(caseDetails).map(item -> null)
+        );
+    }
+
+    private Validation<String, ServiceConfigItem> getServiceConfig(CaseDetails caseDetails) {
+        return hasServiceNameInCaseTypeId(caseDetails).flatMap(service -> Try
+            .of(() -> serviceConfigProvider.getConfig(service))
+            .toValidation()
+            .mapError(Throwable::getMessage)
+        )
+            .filter(item -> !Strings.isNullOrEmpty(item.getTransformationUrl()))
+            .getOrElse(Validation.invalid("Transformation URL is not configured"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -60,7 +60,7 @@ class CreateCaseCallbackServiceTest {
     }
 
     @Test
-    void should_not_allow_to_process_callback_in_case_wrong_case_type_id_is_missing() {
+    void should_not_allow_to_process_callback_when_case_type_id_is_missing() {
         // given
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.id(1L));
 
@@ -73,7 +73,7 @@ class CreateCaseCallbackServiceTest {
     }
 
     @Test
-    void should_not_allow_to_process_callback_in_case_wrong_case_type_id_is_empty() {
+    void should_not_allow_to_process_callback_when_case_type_id_is_empty() {
         // given
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.caseTypeId(""));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create case: add endpoint to orchestrator](https://tools.hmcts.net/jira/browse/BPS-741)

### Change description ###

Require transformation URL to be configured prior doing any `CaseDetails` validation. This is fail fast operation and expanding previously (#572) extracted component to accept any number of "fail fast" operations. Not using stream api as it might as well evaluate all suppliers.

Such expansion as well proves the mentioning of it in previous PR - and there are more to come.

Lot of branches introduced hence so many changes here. Main goal: introduce mandatory requirement of callback: service in question has to be configured with transformation url in orchestrator

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
