### PR TITLE
Add transformation client to `createCase` callback service

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -10,6 +10,7 @@ import io.vavr.control.Validation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.InvalidCaseDataException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.TransformationClient;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
@@ -102,6 +103,9 @@ public class CreateCaseCallbackService {
             );
 
             return Validation.valid(ImmutableMap.of("caseReference", UUID.randomUUID()));
+        } catch (InvalidCaseDataException exception) {
+            // let controller deal with this. it is 422 or 400
+            throw exception;
         } catch (Exception exception) {
             log.error(
                 "Failed to create exception for service {} and exception record {}",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -54,7 +54,7 @@ public class CreateCaseCallbackService {
             .flatMap(theVoid -> validator
                 .getValidation(caseDetails)
                 .combine(getServiceConfig(caseDetails).mapError(Array::of))
-                .ap((exceptionRecord, configItem) -> createExceptionRecord(
+                .ap((exceptionRecord, configItem) -> createNewCase(
                     exceptionRecord,
                     configItem,
                     caseDetails.getId()
@@ -83,7 +83,7 @@ public class CreateCaseCallbackService {
             .getOrElse(Validation.invalid("Transformation URL is not configured"));
     }
 
-    private Validation<Seq<String>, Map<String, Object>> createExceptionRecord(
+    private Validation<Seq<String>, Map<String, Object>> createNewCase(
         ExceptionRecord exceptionRecord,
         ServiceConfigItem configItem,
         long caseId

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -7,6 +7,8 @@ import io.vavr.collection.Seq;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
 import io.vavr.control.Validation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.TransformationClient;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
@@ -25,6 +27,8 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdVali
 
 @Service
 public class CreateCaseCallbackService {
+
+    private static final Logger log = LoggerFactory.getLogger(CreateCaseCallbackService.class);
 
     private final CreateCaseValidator validator;
     private final ServiceConfigProvider serviceConfigProvider;
@@ -80,7 +84,8 @@ public class CreateCaseCallbackService {
         ServiceConfigItem configItem
     ) {
         try {
-            // log
+            log.info("Start creating exception record for {}", configItem.getService());
+
             transformationClient.transformExceptionRecord(
                 configItem.getTransformationUrl(),
                 exceptionRecord,
@@ -89,7 +94,8 @@ public class CreateCaseCallbackService {
 
             return Validation.valid(ImmutableMap.of("caseReference", UUID.randomUUID()));
         } catch (Exception exception) {
-            // log
+            log.error("Failed to create exception for {}", configItem.getService(), exception);
+
             return Validation.invalid(Array.of("Internal error. " + exception.getMessage()));
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -89,7 +89,11 @@ public class CreateCaseCallbackService {
         long caseId
     ) {
         try {
-            log.info("Start creating exception record for {} {}", configItem.getService(), caseId);
+            log.info(
+                "Start creating exception record for service {} and exception record {}",
+                configItem.getService(),
+                caseId
+            );
 
             transformationClient.transformExceptionRecord(
                 configItem.getTransformationUrl(),
@@ -99,7 +103,12 @@ public class CreateCaseCallbackService {
 
             return Validation.valid(ImmutableMap.of("caseReference", UUID.randomUUID()));
         } catch (Exception exception) {
-            log.error("Failed to create exception for {} {}", configItem.getService(), caseId, exception);
+            log.error(
+                "Failed to create exception for service {} and exception record {}",
+                configItem.getService(),
+                caseId,
+                exception
+            );
 
             return Validation.invalid(Array.of("Internal error. " + exception.getMessage()));
         }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.CaseTransformationException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.TransformationClient;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.DocumentType;
@@ -170,6 +172,47 @@ class CreateCaseCallbackServiceTest {
         // then
         assertThat(output.isRight()).isTrue();
         assertThat(output.get().keySet()).containsOnly("caseReference");
+
+        // and verify all calls were made
+        verify(transformationClient).transformExceptionRecord(anyString(), any(ExceptionRecord.class), anyString());
+    }
+
+    @Test
+    void should_report_with_internal_error_message_when_transformation_client_throws_exception()
+        throws IOException, CaseTransformationException {
+        // given
+        setUpTransformationUrl();
+        CaseTransformationException exception = new CaseTransformationException(
+            new HttpClientErrorException(HttpStatus.CONFLICT),
+            "oh no"
+        );
+        doThrow(exception)
+            .when(transformationClient)
+            .transformExceptionRecord(anyString(), any(ExceptionRecord.class), anyString());
+
+        Map<String, Object> data = new HashMap<>();
+        // putting 6 via `ImmutableMap` is available from Java 9
+        data.put("poBox", "12345");
+        data.put("journeyClassification", EXCEPTION.name());
+        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
+        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
+        data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
+
+        CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .caseTypeId(CASE_TYPE_ID)
+            .jurisdiction("some jurisdiction")
+            .data(data)
+        );
+
+        // when
+        Either<List<String>, Map<String, Object>> output = service.process(caseDetails, EVENT_ID);
+
+        // then
+        assertThat(output.isLeft()).isTrue();
+        assertThat(output.getLeft())
+            .hasSize(1)
+            .containsOnly("Internal error. " + exception.getMessage());
 
         // and verify all calls were made
         verify(transformationClient).transformExceptionRecord(anyString(), any(ExceptionRecord.class), anyString());

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -161,6 +161,7 @@ class CreateCaseCallbackServiceTest {
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .id(1L)
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)
@@ -200,6 +201,7 @@ class CreateCaseCallbackServiceTest {
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .id(1L)
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.DocumentType;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CreateCaseValidator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.config.ServiceConfigProvider;
@@ -52,7 +51,7 @@ class CreateCaseCallbackServiceTest {
 
     @Test
     void should_not_allow_to_process_callback_in_case_wrong_event_id_is_received() {
-        Either<List<String>, ExceptionRecord> output = service.process(null, "some event");
+        Either<List<String>, Map<String, Object>> output = service.process(null, "some event");
 
         assertThat(output.isLeft()).isTrue();
         assertThat(output.getLeft()).containsOnly("The some event event is not supported. Please contact service team");
@@ -65,7 +64,7 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.id(1L));
 
         // when
-        Either<List<String>, ExceptionRecord> output = service.process(caseDetails, EVENT_ID);
+        Either<List<String>, Map<String, Object>> output = service.process(caseDetails, EVENT_ID);
 
         assertThat(output.isLeft()).isTrue();
         assertThat(output.getLeft()).containsOnly("No case type ID supplied");
@@ -78,7 +77,7 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.caseTypeId(""));
 
         // when
-        Either<List<String>, ExceptionRecord> output = service.process(caseDetails, EVENT_ID);
+        Either<List<String>, Map<String, Object>> output = service.process(caseDetails, EVENT_ID);
 
         // then
         assertThat(output.isLeft()).isTrue();
@@ -93,7 +92,7 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.caseTypeId(CASE_TYPE_ID));
 
         // when
-        Either<List<String>, ExceptionRecord> output = service.process(caseDetails, EVENT_ID);
+        Either<List<String>, Map<String, Object>> output = service.process(caseDetails, EVENT_ID);
 
         // then
         assertThat(output.isLeft()).isTrue();
@@ -107,7 +106,7 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.caseTypeId(CASE_TYPE_ID));
 
         // when
-        Either<List<String>, ExceptionRecord> output = service.process(caseDetails, EVENT_ID);
+        Either<List<String>, Map<String, Object>> output = service.process(caseDetails, EVENT_ID);
 
         // then
         assertThat(output.isLeft()).isTrue();
@@ -122,7 +121,7 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.caseTypeId(CASE_TYPE_ID));
 
         // when
-        Either<List<String>, ExceptionRecord> output = service.process(caseDetails, EVENT_ID);
+        Either<List<String>, Map<String, Object>> output = service.process(caseDetails, EVENT_ID);
 
         assertThat(output.isLeft()).isTrue();
         assertThat(output.getLeft()).containsOnly(
@@ -156,12 +155,11 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ExceptionRecord> output = service.process(caseDetails, EVENT_ID);
+        Either<List<String>, Map<String, Object>> output = service.process(caseDetails, EVENT_ID);
 
         // then
         assertThat(output.isRight()).isTrue();
-        assertThat(output.get().scannedDocuments).hasSize(1);
-        assertThat(output.get().ocrDataFields).hasSize(1);
+        assertThat(output.get().keySet()).containsOnly("caseReference");
     }
 
     @Test
@@ -182,7 +180,7 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ExceptionRecord> output = service.process(caseDetails, EVENT_ID);
+        Either<List<String>, Map<String, Object>> output = service.process(caseDetails, EVENT_ID);
 
         // then
         assertThat(output.isLeft()).isTrue();
@@ -210,7 +208,7 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ExceptionRecord> output = service.process(caseDetails, EVENT_ID);
+        Either<List<String>, Map<String, Object>> output = service.process(caseDetails, EVENT_ID);
 
         assertThat(output.getLeft()).containsOnly(
             "Invalid journeyClassification. Error: No enum constant " + Classification.class.getName() + ".EXCEPTIONS"
@@ -250,7 +248,7 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ExceptionRecord> output = service.process(caseDetails, EVENT_ID);
+        Either<List<String>, Map<String, Object>> output = service.process(caseDetails, EVENT_ID);
 
         assertThat(output.getLeft()).containsOnly(
             "Invalid scannedDocuments format. Error: No enum constant " + DocumentType.class.getName() + ".OTHERS"
@@ -281,7 +279,7 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ExceptionRecord> output = service.process(caseDetails, EVENT_ID);
+        Either<List<String>, Map<String, Object>> output = service.process(caseDetails, EVENT_ID);
 
         String match =
             "Invalid OCR data format. Error: (class )?java.lang.Integer cannot be cast to (class )?java.lang.String.*";


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create case: add endpoint to orchestrator](https://tools.hmcts.net/jira/browse/BPS-741)

### Change description ###

Just a placement to call transformation client. This PR solves one TBD - returns a real object to caller which does not exists at the moment.

Next: add s2s

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
