### PR TITLE
Include envelope ID in exception records

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -81,7 +81,7 @@ locals {
     TRANSFORMATION_URL_BULKSCAN = "${var.transformation_url_bulkscan}"
     // endregion
 
-    TMP_DUMMY_VAR = "remove me"
+    JURISDICTIONS_WITH_DUPLICATE_ER_PREVENTION = join(",", var.jurisdictions_with_duplicate_er_prevention)
   }
 }
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -74,3 +74,10 @@ variable "delete_envelopes_dlq_messages_ttl" {
 variable "transformation_url_bulkscan" {
   default = "http://bulk-scan-sample-app-aat.service.core-compute-aat.internal"
 }
+
+// TODO: remove when all jurisdictions support the prevention in all environments
+variable "jurisdictions_with_duplicate_er_prevention" {
+  type = "list"
+  description = "Jurisdictions that support the prevention of duplicate exception records"
+  default = ["BULKSCAN"]
+}

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
@@ -102,6 +102,7 @@ class ExceptionRecordCreationTest {
         List<String> expectedOcrDataWarnings = Arrays.asList("warning 1", "warning 2");
         assertThat(getOcrDataValidationWarnings(caseDetails)).isEqualTo(expectedOcrDataWarnings);
 
+        // envelope ID from the JSON resource representing the test message
         String messageEnvelopeId = "743aeac9-1791-463a-b929-9526e285fe2e";
         assertThat(caseDetails.getData().get("envelopeId")).isEqualTo(messageEnvelopeId);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
@@ -101,6 +101,9 @@ class ExceptionRecordCreationTest {
 
         List<String> expectedOcrDataWarnings = Arrays.asList("warning 1", "warning 2");
         assertThat(getOcrDataValidationWarnings(caseDetails)).isEqualTo(expectedOcrDataWarnings);
+
+        String messageEnvelopeId = "743aeac9-1791-463a-b929-9526e285fe2e";
+        assertThat(caseDetails.getData().get("envelopeId")).isEqualTo(messageEnvelopeId);
     }
 
     @DisplayName("Should create ExceptionRecord when provided/requested case reference is invalid")

--- a/src/functionalTest/resources/envelopes/new-envelope-with-evidence.json
+++ b/src/functionalTest/resources/envelopes/new-envelope-with-evidence.json
@@ -1,5 +1,5 @@
 {
-  "id": "0191",
+  "id": "743aeac9-1791-463a-b929-9526e285fe2e",
   "case_ref": "",
   "po_box": "BULKSCAN PO BOX",
   "jurisdiction": "BULKSCAN",

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -56,3 +56,5 @@ service-config:
       jurisdiction: BULKSCAN
       case-type-ids:
         - Bulk_Scanned
+
+jurisdictions-with-duplicate-er-prevention: BULKSCAN

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
@@ -1,9 +1,12 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 
 public class ExceptionRecord implements CaseData {
 
@@ -26,6 +29,11 @@ public class ExceptionRecord implements CaseData {
 
     public final List<CcdCollectionElement<String>> ocrDataValidationWarnings;
 
+    // TODO: remove @JsonInclude when envelopeId is present in exception record definitions
+    // for all services in all environments
+    @JsonInclude(NON_EMPTY)
+    public final String envelopeId;
+
     // Yes/No field indicating if there are warnings to show
     public final String displayWarnings;
 
@@ -38,7 +46,8 @@ public class ExceptionRecord implements CaseData {
         List<CcdCollectionElement<ScannedDocument>> scannedDocuments,
         List<CcdCollectionElement<CcdKeyValue>> ocrData,
         List<CcdCollectionElement<String>> ocrDataValidationWarnings,
-        String displayWarnings
+        String displayWarnings,
+        String envelopeId
     ) {
         this.classification = classification;
         this.poBox = poBox;
@@ -49,5 +58,6 @@ public class ExceptionRecord implements CaseData {
         this.ocrData = ocrData;
         this.ocrDataValidationWarnings = ocrDataValidationWarnings;
         this.displayWarnings = displayWarnings;
+        this.envelopeId = envelopeId;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.OcrDa
 
 import java.util.List;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.DocumentMapper.getLocalDateTime;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.DocumentMapper.mapDocuments;
@@ -23,16 +22,13 @@ public class ExceptionRecordMapper {
     private final List<String> jurisdictionsWithDuplicatePrevention;
 
     public ExceptionRecordMapper(
-        @Value("${document_management.url}")
-        final String documentManagementUrl,
-        @Value("${document_management.context-path}")
-        final String contextPath,
-        @Value("${jurisdictions-with-duplicate-er-prevention}")
-        final String[] jurisdictionsWithDuplicatePrevention
+        @Value("${document_management.url}") final String documentManagementUrl,
+        @Value("${document_management.context-path}") final String contextPath,
+        @Value("${jurisdictions-with-duplicate-er-prevention}") final List<String> jurisdictionsWithDuplicatePrevention
     ) {
         this.documentManagementUrl = documentManagementUrl;
         this.contextPath = contextPath;
-        this.jurisdictionsWithDuplicatePrevention = newArrayList(jurisdictionsWithDuplicatePrevention);
+        this.jurisdictionsWithDuplicatePrevention = jurisdictionsWithDuplicatePrevention;
     }
 
     public ExceptionRecord mapEnvelope(Envelope envelope) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.OcrDa
 
 import java.util.List;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.DocumentMapper.getLocalDateTime;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.DocumentMapper.mapDocuments;
@@ -19,13 +20,19 @@ public class ExceptionRecordMapper {
 
     private final String documentManagementUrl;
     private final String contextPath;
+    private final List<String> jurisdictionsWithDuplicatePrevention;
 
     public ExceptionRecordMapper(
-        @Value("${document_management.url}") final String documentManagementUrl,
-        @Value("${document_management.context-path}") final String contextPath
+        @Value("${document_management.url}")
+        final String documentManagementUrl,
+        @Value("${document_management.context-path}")
+        final String contextPath,
+        @Value("${jurisdictions-with-duplicate-er-prevention}")
+        final String[] jurisdictionsWithDuplicatePrevention
     ) {
         this.documentManagementUrl = documentManagementUrl;
         this.contextPath = contextPath;
+        this.jurisdictionsWithDuplicatePrevention = newArrayList(jurisdictionsWithDuplicatePrevention);
     }
 
     public ExceptionRecord mapEnvelope(Envelope envelope) {
@@ -38,7 +45,8 @@ public class ExceptionRecordMapper {
             mapDocuments(envelope.documents, documentManagementUrl, contextPath, envelope.deliveryDate),
             mapOcrData(envelope.ocrData),
             mapOcrDataWarnings(envelope.ocrDataValidationWarnings),
-            envelope.ocrDataValidationWarnings.isEmpty() ? "No" : "Yes"
+            envelope.ocrDataValidationWarnings.isEmpty() ? "No" : "Yes",
+            jurisdictionsWithDuplicatePrevention.contains(envelope.jurisdiction) ? envelope.id : null
         );
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,6 +82,11 @@ service-config:
       case-type-ids:
         - MoneyClaimCase
 
+# comma-separated list of jurisdictions that support duplicate exception record prevention
+# TODO: remove this setting when all jurisdictions support ER prevention in all environments
+jurisdictions-with-duplicate-er-prevention: ${JURISDICTIONS_WITH_DUPLICATE_ER_PREVENTION}
+
+
 scheduling:
   task:
     delete-envelopes-dlq-messages:

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -161,10 +161,10 @@ public class SampleData {
     public static Envelope envelope(Classification classification, String jurisdiction, String caseRef) {
         return new Envelope(
             ENVELOPE_ID,
-            CASE_REF,
+            caseRef,
             CASE_LEGACY_ID,
             PO_BOX,
-            JURSIDICTION,
+            jurisdiction,
             CONTAINER,
             "zip-file-test.zip",
             Instant.now(),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/feature/OcrDataOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/feature/OcrDataOrderTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.OcrDa
 import java.util.ArrayList;
 import java.util.ListIterator;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class OcrDataOrderTest {
@@ -33,7 +34,7 @@ public class OcrDataOrderTest {
         ExceptionRecordMapper mapper = new ExceptionRecordMapper(
             "http://localhost",
             "files",
-            new String[] {"BULKSCAN"}
+            newArrayList("BULKSCAN")
         );
 
         ExceptionRecord record = mapper.mapEnvelope(envelope);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/feature/OcrDataOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/feature/OcrDataOrderTest.java
@@ -30,7 +30,12 @@ public class OcrDataOrderTest {
         assertThat(envelope.ocrData).isInstanceOf(ArrayList.class);
 
         // and
-        ExceptionRecordMapper mapper = new ExceptionRecordMapper("http://localhost", "files");
+        ExceptionRecordMapper mapper = new ExceptionRecordMapper(
+            "http://localhost",
+            "files",
+            new String[] {"BULKSCAN"}
+        );
+
         ExceptionRecord record = mapper.mapEnvelope(envelope);
         assertThat(record.ocrData).isInstanceOf(ArrayList.class);
         assertThat(record.ocrData.size()).isEqualTo(envelope.ocrData.size());

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdKeyValue;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Document;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Envelope;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.OcrDataField;
@@ -23,7 +24,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelope;
 
 class ExceptionRecordMapperTest {
 
-    private final ExceptionRecordMapper mapper = new ExceptionRecordMapper("https://example.gov.uk", "files");
+    private final ExceptionRecordMapper mapper = exceptionRecordMapper("BULKSCAN");
 
     @Test
     public void mapEnvelope_maps_all_fields_correctly() {
@@ -59,6 +60,8 @@ class ExceptionRecordMapperTest {
         assertThat(toEnvelopeOcrDataWarnings(exceptionRecord.ocrDataValidationWarnings))
             .usingFieldByFieldElementComparator()
             .containsExactlyElementsOf(envelope.ocrDataValidationWarnings);
+
+        assertThat(exceptionRecord.envelopeId).isEqualTo(envelope.id);
     }
 
     @Test
@@ -97,6 +100,39 @@ class ExceptionRecordMapperTest {
         assertThat(mapper.mapEnvelope(envelopeWithoutWarning).displayWarnings).isEqualTo("No");
     }
 
+    @Test
+    public void mapEnvelope_copies_envelope_id_when_jurisdiction_supports_duplicate_prevention() {
+        // given
+        String supportedJurisdiction = "supported-jurisdiction1";
+        ExceptionRecordMapper exceptionRecordMapper = exceptionRecordMapper(supportedJurisdiction, "jurisdiction2");
+
+        // when
+        Envelope envelope = envelopeWithJurisdiction(supportedJurisdiction);
+
+        // then
+        ExceptionRecord exceptionRecord = exceptionRecordMapper.mapEnvelope(envelope);
+
+        assertThat(exceptionRecord.envelopeId).isEqualTo(envelope.id);
+    }
+
+    @Test
+    public void mapEnvelope_sets_envelope_id_to_null_when_jurisdiction_does_not_support_duplicate_prevention() {
+        // given
+        ExceptionRecordMapper exceptionRecordMapper = exceptionRecordMapper("jurisdiction1", "jurisdiction2");
+
+        // when
+        Envelope envelope = envelopeWithJurisdiction("unsupported-jurisdiction1");
+
+        // then
+        ExceptionRecord exceptionRecord = exceptionRecordMapper.mapEnvelope(envelope);
+
+        assertThat(exceptionRecord.envelopeId).isNull();
+    }
+
+    private Envelope envelopeWithJurisdiction(String jurisdiction) {
+        return envelope(Classification.NEW_APPLICATION, jurisdiction, "1231231232312765");
+    }
+
     private List<OcrDataField> ocrDataAsList(List<CcdCollectionElement<CcdKeyValue>> ocrData) {
         return ocrData
             .stream()
@@ -126,5 +162,13 @@ class ExceptionRecordMapperTest {
                     scannedDocument.deliveryDate.atZone(ZoneId.systemDefault()).toInstant()
                 )
             ).collect(toList());
+    }
+
+    private ExceptionRecordMapper exceptionRecordMapper(String... jurisdictionsWithDuplicatePrevention) {
+        return new ExceptionRecordMapper(
+            "https://example.gov.uk",
+            "files",
+            jurisdictionsWithDuplicatePrevention
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -168,7 +168,7 @@ class ExceptionRecordMapperTest {
         return new ExceptionRecordMapper(
             "https://example.gov.uk",
             "files",
-            jurisdictionsWithDuplicatePrevention
+            newArrayList(jurisdictionsWithDuplicatePrevention)
         );
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-490

### Change description ###

Include envelope ID in exception records, but only if the envelope's jurisdiction supports duplicate exception record prevention (i.e. is listed as such in the config)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
