### PR TITLE
Make service result object more sensible

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/in/CcdCallbackRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/in/CcdCallbackRequest.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.model.in;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+public class CcdCallbackRequest {
+
+    private final String eventId;
+    private final CaseDetails caseDetails;
+    private final boolean ignoreWarnings;
+
+    public CcdCallbackRequest(
+        @JsonProperty("event_id") String eventId,
+        @JsonProperty("case_details") CaseDetails caseDetails,
+        @JsonProperty("ignore_warning") boolean ignoreWarnings
+    ) {
+        this.eventId = eventId;
+        this.caseDetails = caseDetails;
+        this.ignoreWarnings = ignoreWarnings;
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public CaseDetails getCaseDetails() {
+        return caseDetails;
+    }
+
+    public boolean isIgnoreWarnings() {
+        return ignoreWarnings;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -112,8 +112,10 @@ public class CreateCaseCallbackService {
                 transformationResponse.warnings
             ));
         } catch (InvalidCaseDataException exception) {
-            // let controller deal with this. it is 422 or 400
-            throw exception;
+            return Validation.valid(new ProcessResult(
+                exception.getResponse().warnings,
+                exception.getResponse().errors
+            ));
         } catch (Exception exception) {
             log.error(
                 "Failed to create exception for service {} and exception record {}",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
@@ -17,28 +17,16 @@ public class ProcessResult {
 
     private final List<String> errors;
 
-    private ProcessResult(
-        Map<String, Object> modifiedFields,
-        List<String> warnings,
-        List<String> errors
-    ) {
+    public ProcessResult(Map<String, Object> modifiedFields) {
         this.modifiedFields = modifiedFields;
+        this.warnings = emptyList();
+        this.errors = emptyList();
+    }
+
+    public ProcessResult(List<String> warnings, List<String> errors) {
+        this.modifiedFields = emptyMap();
         this.warnings = warnings;
         this.errors = errors;
-    }
-
-    public ProcessResult(
-        Map<String, Object> modifiedFields,
-        List<String> warnings
-    ) {
-        this(modifiedFields, warnings, emptyList());
-    }
-
-    public ProcessResult(
-        List<String> warnings,
-        List<String> errors
-    ) {
-        this(emptyMap(), warnings, errors);
     }
 
     public Map<String, Object> getModifiedFields() {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
@@ -3,6 +3,9 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+
 /**
  * Data model representing objects used in drafting a response to a callback request.
  */
@@ -12,12 +15,30 @@ public class ProcessResult {
 
     private final List<String> warnings;
 
+    private final List<String> errors;
+
+    private ProcessResult(
+        Map<String, Object> modifiedFields,
+        List<String> warnings,
+        List<String> errors
+    ) {
+        this.modifiedFields = modifiedFields;
+        this.warnings = warnings;
+        this.errors = errors;
+    }
+
     public ProcessResult(
         Map<String, Object> modifiedFields,
         List<String> warnings
     ) {
-        this.modifiedFields = modifiedFields;
-        this.warnings = warnings;
+        this(modifiedFields, warnings, emptyList());
+    }
+
+    public ProcessResult(
+        List<String> warnings,
+        List<String> errors
+    ) {
+        this(emptyMap(), warnings, errors);
     }
 
     public Map<String, Object> getModifiedFields() {
@@ -26,5 +47,9 @@ public class ProcessResult {
 
     public List<String> getWarnings() {
         return warnings;
+    }
+
+    public List<String> getErrors() {
+        return errors;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Data model representing objects used in drafting a response to a callback request.
+ */
+public class ProcessResult {
+
+    private final Map<String, Object> modifiedFields;
+
+    private final List<String> warnings;
+
+    public ProcessResult(
+        Map<String, Object> modifiedFields,
+        List<String> warnings
+    ) {
+        this.modifiedFields = modifiedFields;
+        this.warnings = warnings;
+    }
+
+    public Map<String, Object> getModifiedFields() {
+        return modifiedFields;
+    }
+
+    public List<String> getWarnings() {
+        return warnings;
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create case: add endpoint to orchestrator](https://tools.hmcts.net/jira/browse/BPS-741)

### Change description ###

It would make more sense to have a decent enough object as data class which holds relevant information useful to make a callback response - introducing one

This is potentially if not eventually last change to service's `process` method in terms of return object

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
