### PR TITLE
Extend io.vavr.control.Validation interface to flexibly apply larger sized object constructs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,8 @@ jacocoTestReport {
   afterEvaluate {
     getClassDirectories().from = getClassDirectories().files.collect {
       fileTree(dir: it, exclude: [
-        'uk/gov/hmcts/reform/bulkscan/orchestrator/config/**'
+        'uk/gov/hmcts/reform/bulkscan/orchestrator/config/**',
+        'uk/gov/hmcts/reform/bulkscan/orchestrator/util/**' // remove when used in source code
       ])
     }
   }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/util/Function9.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/util/Function9.java
@@ -14,6 +14,7 @@ public interface Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> extends Serial
 
     R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9);
 
+    @SuppressWarnings("LineLength")
     default Function1<T1, Function1<T2, Function1<T3, Function1<T4, Function1<T5, Function1<T6, Function1<T7, Function1<T8, Function1<T9, R>>>>>>>>> curried() {
         return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> t7 -> t8 -> t9 -> apply(t1, t2, t3, t4, t5, t6, t7, t8, t9);
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/util/Function9.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/util/Function9.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.util;
+
+import io.vavr.Function1;
+
+import java.io.Serializable;
+
+@FunctionalInterface
+public interface Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> extends Serializable {
+
+    /**
+     * The <a href="https://docs.oracle.com/javase/8/docs/api/index.html">serial version uid</a>.
+     */
+    long serialVersionUID = 1L;
+
+    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9);
+
+    default Function1<T1, Function1<T2, Function1<T3, Function1<T4, Function1<T5, Function1<T6, Function1<T7, Function1<T8, Function1<T9, R>>>>>>>>> curried() {
+        return t1 -> t2 -> t3 -> t4 -> t5 -> t6 -> t7 -> t8 -> t9 -> apply(t1, t2, t3, t4, t5, t6, t7, t8, t9);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/util/HmctsValidation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/util/HmctsValidation.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.util;
+
+import io.vavr.collection.Seq;
+import io.vavr.control.Validation;
+
+import java.util.Objects;
+
+public interface HmctsValidation<E, T> extends Validation<E, T> {
+
+    static <E, T1, T2, T3, T4, T5, T6, T7, T8, T9> Builder9<E, T1, T2, T3, T4, T5, T6, T7, T8, T9> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3, Validation<E, T4> validation4, Validation<E, T5> validation5, Validation<E, T6> validation6, Validation<E, T7> validation7, Validation<E, T8> validation8, Validation<E, T9> validation9) {
+        Objects.requireNonNull(validation1, "validation1 is null");
+        Objects.requireNonNull(validation2, "validation2 is null");
+        Objects.requireNonNull(validation3, "validation3 is null");
+        Objects.requireNonNull(validation4, "validation4 is null");
+        Objects.requireNonNull(validation5, "validation5 is null");
+        Objects.requireNonNull(validation6, "validation6 is null");
+        Objects.requireNonNull(validation7, "validation7 is null");
+        Objects.requireNonNull(validation8, "validation8 is null");
+        Objects.requireNonNull(validation9, "validation9 is null");
+        return new Builder9<>(validation1, validation2, validation3, validation4, validation5, validation6, validation7, validation8, validation9);
+    }
+
+    final class Builder9<E, T1, T2, T3, T4, T5, T6, T7, T8, T9> {
+
+        private Validation<E, T1> v1;
+        private Validation<E, T2> v2;
+        private Validation<E, T3> v3;
+        private Validation<E, T4> v4;
+        private Validation<E, T5> v5;
+        private Validation<E, T6> v6;
+        private Validation<E, T7> v7;
+        private Validation<E, T8> v8;
+        private Validation<E, T9> v9;
+
+        private Builder9(Validation<E, T1> v1, Validation<E, T2> v2, Validation<E, T3> v3, Validation<E, T4> v4, Validation<E, T5> v5, Validation<E, T6> v6, Validation<E, T7> v7, Validation<E, T8> v8, Validation<E, T9> v9) {
+            this.v1 = v1;
+            this.v2 = v2;
+            this.v3 = v3;
+            this.v4 = v4;
+            this.v5 = v5;
+            this.v6 = v6;
+            this.v7 = v7;
+            this.v8 = v8;
+            this.v9 = v9;
+        }
+
+        public <R> Validation<Seq<E>, R> ap(Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> f) {
+            return v9.ap(v8.ap(v7.ap(v6.ap(v5.ap(v4.ap(v3.ap(v2.ap(v1.ap(Validation.valid(f.curried()))))))))));
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/util/HmctsValidation.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/util/HmctsValidation.java
@@ -5,6 +5,7 @@ import io.vavr.control.Validation;
 
 import java.util.Objects;
 
+@SuppressWarnings("LineLength")
 public interface HmctsValidation<E, T> extends Validation<E, T> {
 
     static <E, T1, T2, T3, T4, T5, T6, T7, T8, T9> Builder9<E, T1, T2, T3, T4, T5, T6, T7, T8, T9> combine(Validation<E, T1> validation1, Validation<E, T2> validation2, Validation<E, T3> validation3, Validation<E, T4> validation4, Validation<E, T5> validation5, Validation<E, T6> validation6, Validation<E, T7> validation7, Validation<E, T8> validation8, Validation<E, T9> validation9) {


### PR DESCRIPTION
### Change description ###

`ExceptionRecord` construct requires larger size of arguments to be passed in constructor. At the moment vavr is pmd compatible and my guess it'll stay like that for indefinite time so 8 arguments is a limit. Therefore extending with custom `HmctsValidation` and providing relevant builder (which is for 9 argument constructs). In case `ExceptionRecord` or any other object will require higher number of arguments - can simply bump to further iterations or add more if this one will still be used.

This is not Jira related but problem arose during [Add form type to Exception Record](https://tools.hmcts.net/jira/browse/BPS-819)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
