### PR TITLE
BPS-819 add form type to ExceptionRecord model used in Transformation API

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClientTest.java
@@ -194,6 +194,7 @@ public class TransformationClientTest {
             "poBox",
             "BULKSCAN",
             Classification.NEW_APPLICATION,
+            "D8",
             Instant.now(),
             Instant.now(),
             singletonList(new ScannedDocument(
@@ -217,7 +218,12 @@ public class TransformationClientTest {
             .put("case_creation_details", new JSONObject()
                 .put("case_type_id", "some_case_type")
                 .put("event_id", "createCase")
-                .put("case_data", new JSONObject().put("case_field", "some value")))
+                .put(
+                    "case_data",
+                    new JSONObject()
+                        .put("case_field", "some value")
+                        .put("form_type", "d8")
+                ))
             .put("warnings", new JSONArray());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/request/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/request/ExceptionRecord.java
@@ -20,6 +20,9 @@ public class ExceptionRecord {
     @JsonProperty("journey_classification")
     public final Classification journeyClassification;
 
+    @JsonProperty("form_type")
+    public final String formType;
+
     @JsonProperty("delivery_date")
     public final Instant deliveryDate;
 
@@ -37,6 +40,7 @@ public class ExceptionRecord {
         String poBox,
         String poBoxJurisdiction,
         Classification journeyClassification,
+        String formType,
         Instant deliveryDate,
         Instant openingDate,
         List<ScannedDocument> scannedDocuments,
@@ -46,6 +50,7 @@ public class ExceptionRecord {
         this.poBox = poBox;
         this.poBoxJurisdiction = poBoxJurisdiction;
         this.journeyClassification = journeyClassification;
+        this.formType = formType;
         this.deliveryDate = deliveryDate;
         this.openingDate = openingDate;
         this.scannedDocuments = scannedDocuments;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -58,6 +58,15 @@ public final class CallbackValidations {
     }
 
     @Nonnull
+    public static Validation<String, String> hasFormType(CaseDetails theCase) {
+        return Optional.ofNullable(theCase)
+            .map(CaseDetails::getData)
+            .map(data -> (String) data.get("formType"))
+            .map(Validation::<String, String>valid)
+            .orElse(invalid("Missing Form Type"));
+    }
+
+    @Nonnull
     public static Validation<String, String> hasJurisdiction(CaseDetails theCase) {
         String jurisdiction = null;
         return theCase != null

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
@@ -81,7 +81,7 @@ public class CreateCaseValidator {
         Validation<String, List<ScannedDocument>> hasScannedDocuments = getScannedDocuments(caseDetails);
         Validation<String, List<OcrDataField>> hasOcrDataFields = getOcrDataFields(caseDetails);
 
-        Array<Validation<String, ?>> validations = Array.of(
+        Seq<Validation<String, ?>> validations = Array.of(
             hasCaseTypeId,
             hasPoBox,
             hasJurisdiction,
@@ -93,7 +93,7 @@ public class CreateCaseValidator {
             hasOcrDataFields
         );
 
-        Array<String> errors = getValidationErrors(validations);
+        Seq<String> errors = getValidationErrors(validations);
         if (errors.isEmpty()) {
             return Validation.valid(new ExceptionRecord(
                 hasCaseTypeId.get(),
@@ -110,7 +110,7 @@ public class CreateCaseValidator {
         return Validation.invalid(errors);
     }
 
-    private Array<String> getValidationErrors(Array<Validation<String, ?>> validations) {
+    private Seq<String> getValidationErrors(Seq<Validation<String, ?>> validations) {
         return validations
             .filter(Validation::isInvalid)
             .map(Validation::getError);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
@@ -71,40 +71,40 @@ public class CreateCaseValidator {
 
     public Validation<Seq<String>, ExceptionRecord> getValidation(CaseDetails caseDetails) {
 
-        Validation<String, String> hasCaseTypeId = hasCaseTypeId(caseDetails);
-        Validation<String, String> hasPoBox = hasPoBox(caseDetails);
-        Validation<String, String> hasJurisdiction = hasJurisdiction(caseDetails);
-        Validation<String, String> hasFormType = hasFormType(caseDetails);
-        Validation<String, Classification> hasJourneyClassification = hasJourneyClassification(caseDetails);
-        Validation<String, Instant> hasDeliveryDate = hasDateField(caseDetails, "deliveryDate");
-        Validation<String, Instant> hasOpeningDate = hasDateField(caseDetails, "openingDate");
-        Validation<String, List<ScannedDocument>> hasScannedDocuments = getScannedDocuments(caseDetails);
-        Validation<String, List<OcrDataField>> hasOcrDataFields = getOcrDataFields(caseDetails);
+        Validation<String, String> caseTypeIdValidation = hasCaseTypeId(caseDetails);
+        Validation<String, String> poBoxValidation = hasPoBox(caseDetails);
+        Validation<String, String> jurisdictionValidation = hasJurisdiction(caseDetails);
+        Validation<String, String> formTypeValidation = hasFormType(caseDetails);
+        Validation<String, Classification> journeyClassificationValidation = hasJourneyClassification(caseDetails);
+        Validation<String, Instant> deliveryDateValidation = hasDateField(caseDetails, "deliveryDate");
+        Validation<String, Instant> openingDateValidation = hasDateField(caseDetails, "openingDate");
+        Validation<String, List<ScannedDocument>> scannedDocumentsValidation = getScannedDocuments(caseDetails);
+        Validation<String, List<OcrDataField>> ocrDataFieldsValidation = getOcrDataFields(caseDetails);
 
         Seq<Validation<String, ?>> validations = Array.of(
-            hasCaseTypeId,
-            hasPoBox,
-            hasJurisdiction,
-            hasFormType,
-            hasJourneyClassification,
-            hasDeliveryDate,
-            hasOpeningDate,
-            hasScannedDocuments,
-            hasOcrDataFields
+            caseTypeIdValidation,
+            poBoxValidation,
+            jurisdictionValidation,
+            formTypeValidation,
+            journeyClassificationValidation,
+            deliveryDateValidation,
+            openingDateValidation,
+            scannedDocumentsValidation,
+            ocrDataFieldsValidation
         );
 
         Seq<String> errors = getValidationErrors(validations);
         if (errors.isEmpty()) {
             return Validation.valid(new ExceptionRecord(
-                hasCaseTypeId.get(),
-                hasPoBox.get(),
-                hasJurisdiction.get(),
-                hasJourneyClassification.get(),
-                hasFormType.get(),
-                hasDeliveryDate.get(),
-                hasOpeningDate.get(),
-                hasScannedDocuments.get(),
-                hasOcrDataFields.get()
+                caseTypeIdValidation.get(),
+                poBoxValidation.get(),
+                jurisdictionValidation.get(),
+                journeyClassificationValidation.get(),
+                formTypeValidation.get(),
+                deliveryDateValidation.get(),
+                openingDateValidation.get(),
+                scannedDocumentsValidation.get(),
+                ocrDataFieldsValidation.get()
             ));
         }
         return Validation.invalid(errors);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.req
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.OcrDataField;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.util.HmctsValidation;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.time.Instant;
@@ -26,6 +27,7 @@ import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.getOcrData;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasCaseTypeId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasDateField;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasFormType;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasJourneyClassification;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasJurisdiction;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasPoBox;
@@ -42,6 +44,7 @@ public class CreateCaseValidator {
     /**
      * Any prerequisites to execute prior further action. Failing fast.
      * Easy extension for more mandatory prerequisites - just flatmap next Validation.
+     *
      * @param prerequisites Top level requirements failing fast
      * @return Either singleton list of errors or green pass to proceed further
      */
@@ -66,12 +69,13 @@ public class CreateCaseValidator {
     }
 
     public Validation<Seq<String>, ExceptionRecord> getValidation(CaseDetails caseDetails) {
-        return Validation
+        return HmctsValidation
             .combine(
                 hasCaseTypeId(caseDetails),
                 hasPoBox(caseDetails),
                 hasJurisdiction(caseDetails),
                 hasJourneyClassification(caseDetails),
+                hasFormType(caseDetails),
                 hasDateField(caseDetails, "deliveryDate"),
                 hasDateField(caseDetails, "openingDate"),
                 getScannedDocuments(caseDetails),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
@@ -232,6 +232,17 @@ class CallbackValidationsTest {
     }
 
     @Test
+    void noFormTypeTest() {
+        checkValidation(
+            createCaseWith(b -> b.data(null)),
+            false,
+            null,
+            CallbackValidations::hasFormType,
+            "Missing Form Type"
+        );
+    }
+
+    @Test
     void noCaseIdTest() {
         checkValidation(
             createCaseWith(b -> b.id(null)),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -168,6 +168,7 @@ class CreateCaseCallbackServiceTest {
         // putting 6 via `ImmutableMap` is available from Java 9
         data.put("poBox", "12345");
         data.put("journeyClassification", NEW_APPLICATION.name());
+        data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
@@ -197,6 +198,7 @@ class CreateCaseCallbackServiceTest {
         // putting 6 via `ImmutableMap` is available from Java 9
         data.put("poBox", "12345");
         data.put("journeyClassification", NEW_APPLICATION.name());
+        data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
@@ -260,6 +262,7 @@ class CreateCaseCallbackServiceTest {
         // putting 6 via `ImmutableMap` is available from Java 9
         data.put("poBox", "12345");
         data.put("journeyClassification", SUPPLEMENTARY_EVIDENCE.name());
+        data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
@@ -291,6 +294,7 @@ class CreateCaseCallbackServiceTest {
         // putting 6 via `ImmutableMap` is available from Java 9
         data.put("poBox", "12345");
         data.put("journeyClassification", EXCEPTION.name());
+        data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -153,6 +153,7 @@ class CreateCaseCallbackServiceTest {
             "Missing poBox",
             "Internal Error: invalid jurisdiction supplied: null",
             "Missing journeyClassification",
+            "Missing Form Type",
             "Missing deliveryDate",
             "Missing openingDate"
         );
@@ -226,6 +227,7 @@ class CreateCaseCallbackServiceTest {
         // putting 6 via `ImmutableMap` is available from Java 9
         data.put("poBox", "12345");
         data.put("journeyClassification", EXCEPTION.name());
+        data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
@@ -328,6 +330,7 @@ class CreateCaseCallbackServiceTest {
         // putting 6 via `ImmutableMap` is available from Java 9
         data.put("poBox", "12345");
         data.put("journeyClassification", EXCEPTION.name());
+        data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
@@ -373,6 +376,7 @@ class CreateCaseCallbackServiceTest {
         // putting 6 via `ImmutableMap` is available from Java 9
         data.put("poBox", "12345");
         data.put("journeyClassification", EXCEPTION.name());
+        data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
@@ -397,16 +401,19 @@ class CreateCaseCallbackServiceTest {
         // given
         setUpTransformationUrl();
 
+        Map<String, Object> data = new HashMap<>();
+        // putting 6 via `ImmutableMap` is available from Java 9
+        data.put("poBox", "12345");
+        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
+        data.put("formType", "Form1");
+        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
+        data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
+
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
-            .data(ImmutableMap.of(
-                "poBox", "12345",
-                "deliveryDate", "2019-09-06T15:30:03.000Z",
-                "openingDate", "2019-09-06T15:30:04.000Z",
-                "scannedDocuments", TestCaseBuilder.document("https://url", "some doc"),
-                "scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value")
-            ))
+            .data(data)
         );
 
         // when
@@ -426,6 +433,7 @@ class CreateCaseCallbackServiceTest {
 
         data.put("poBox", "12345");
         data.put("journeyClassification", "EXCEPTIONS");
+        data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "filename"));
@@ -466,6 +474,7 @@ class CreateCaseCallbackServiceTest {
 
         data.put("poBox", "12345");
         data.put("journeyClassification", "EXCEPTION");
+        data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
         data.put("scannedDocuments", ImmutableList.of(ImmutableMap.of("value", doc)));
@@ -494,6 +503,7 @@ class CreateCaseCallbackServiceTest {
 
         data.put("poBox", "12345");
         data.put("journeyClassification", "EXCEPTION");
+        data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "name"));
@@ -513,6 +523,38 @@ class CreateCaseCallbackServiceTest {
 
         String match =
             "Invalid OCR data format. Error: (class )?java.lang.Integer cannot be cast to (class )?java.lang.String.*";
+        assertThat(output.getLeft())
+            .hasSize(1)
+            .element(0)
+            .asString()
+            .matches(match);
+    }
+
+    @Test
+    void should_report_errors_when_form_type_is_null() {
+        // given
+        setUpTransformationUrl();
+
+        Map<String, Object> data = new HashMap<>();
+
+        data.put("poBox", "12345");
+        data.put("journeyClassification", "EXCEPTION");
+        data.put("formType", null);
+        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
+        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("scannedDocuments", TestCaseBuilder.document("https://url", "name"));
+        data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("key", "value"));
+
+        CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .caseTypeId(CASE_TYPE_ID)
+            .jurisdiction("some jurisdiction")
+            .data(data)
+        );
+
+        // when
+        Either<List<String>, Map<String, Object>> output = service.process(caseDetails, EVENT_ID);
+
+        String match = "Missing Form Type";
         assertThat(output.getLeft())
             .hasSize(1)
             .element(0)

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
@@ -52,12 +52,6 @@ class TestCaseBuilder {
         return createCaseWith(b -> b.data(data));
     }
 
-    /*static CaseDetails caseWithFormType(List<Map<String, Object>> formType) {
-        Map<String, Object> data = new HashMap<>();
-        data.put("formType", formType);
-        return createCaseWith(b -> b.data(data));
-    }*/
-
     static List<Map<String, Object>> document(String url, String name) {
         Map<String, Object> doc = new HashMap<>();
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 class TestCaseBuilder {
-    private TestCaseBuilder(){
+    private TestCaseBuilder() {
     }
 
     static CaseDetails createCaseWith(Function<CaseDetailsBuilder, CaseDetailsBuilder> builder) {
@@ -51,6 +51,12 @@ class TestCaseBuilder {
         data.put("scannedDocuments", caseReference);
         return createCaseWith(b -> b.data(data));
     }
+
+    /*static CaseDetails caseWithFormType(List<Map<String, Object>> formType) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("formType", formType);
+        return createCaseWith(b -> b.data(data));
+    }*/
 
     static List<Map<String, Object>> document(String url, String name) {
         Map<String, Object> doc = new HashMap<>();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-819

### Change description ###
- Add formType field to Exception Record model (used in Transformation request)
- Add formType validation
- Replace existing validations with `List` of validations as Vavr `Validation.combine` and `Validation.ap` methods support only up to 8 arguments.  (see comments in #590 for more details)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
