### PR TITLE
Use `createNewCase` as event id

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
@@ -53,7 +53,7 @@ class CreateCaseCallbackTest {
     void should_not_create_case_if_classification_new_application_without_ocr_data() {
         postWithBody(getRequestBody("invalid-new-application-without-ocr.json"))
             .statusCode(OK.value())
-            .body("errors", contains("Event createCase not allowed "
+            .body("errors", contains("Event createNewCase not allowed "
                 + "for the current journey classification NEW_APPLICATION without OCR"))
             .body("warnings", nullValue())
             .body("data", nullValue());
@@ -63,7 +63,7 @@ class CreateCaseCallbackTest {
     void should_not_create_case_if_classification_exception_without_ocr_data() {
         postWithBody(getRequestBody("invalid-exception-without-ocr.json"))
             .statusCode(OK.value())
-            .body("errors", contains("Event createCase not allowed "
+            .body("errors", contains("Event createNewCase not allowed "
                 + "for the current journey classification EXCEPTION without OCR"))
             .body("warnings", nullValue())
             .body("data", nullValue());
@@ -125,7 +125,7 @@ class CreateCaseCallbackTest {
         givenThat(
             get(
                 // values from config + initial request body
-                "/caseworkers/" + USER_ID + "/jurisdictions/BULKSCAN/case-types/123/event-triggers/createCase/token"
+                "/caseworkers/" + USER_ID + "/jurisdictions/BULKSCAN/case-types/123/event-triggers/createNewCase/token"
             )
             .withHeader("ServiceAuthorization", containing("Bearer"))
             .willReturn(okJson(startResponseBody))
@@ -167,7 +167,7 @@ class CreateCaseCallbackTest {
             .header(HttpHeaders.AUTHORIZATION, IDAM_TOKEN)
             .header(CcdCallbackController.USER_ID, USER_ID)
             .body(body)
-            .post("http://localhost:" + serverPort + "/callback/create-case")
+            .post("http://localhost:" + serverPort + "/callback/create-new-case")
             .then();
     }
 }

--- a/src/integrationTest/resources/ccd/callback/create-case/request/invalid-empty-case-data.json
+++ b/src/integrationTest/resources/ccd/callback/create-case/request/invalid-empty-case-data.json
@@ -12,6 +12,6 @@
     "security_classification": "PUBLIC",
     "callback_response_status": ""
   },
-  "event_id": "createCase",
+  "event_id": "createNewCase",
   "ignore_warning": false
 }

--- a/src/integrationTest/resources/ccd/callback/create-case/request/invalid-exception-without-ocr.json
+++ b/src/integrationTest/resources/ccd/callback/create-case/request/invalid-exception-without-ocr.json
@@ -18,6 +18,6 @@
     "security_classification": "PUBLIC",
     "callback_response_status": ""
   },
-  "event_id": "createCase",
+  "event_id": "createNewCase",
   "ignore_warning": false
 }

--- a/src/integrationTest/resources/ccd/callback/create-case/request/invalid-new-application-without-ocr.json
+++ b/src/integrationTest/resources/ccd/callback/create-case/request/invalid-new-application-without-ocr.json
@@ -18,6 +18,6 @@
     "security_classification": "PUBLIC",
     "callback_response_status": ""
   },
-  "event_id": "createCase",
+  "event_id": "createNewCase",
   "ignore_warning": false
 }

--- a/src/integrationTest/resources/ccd/callback/create-case/request/valid-exception-warnings-flag-on.json
+++ b/src/integrationTest/resources/ccd/callback/create-case/request/valid-exception-warnings-flag-on.json
@@ -32,6 +32,6 @@
     "security_classification": "PUBLIC",
     "callback_response_status": ""
   },
-  "event_id": "createCase",
+  "event_id": "createNewCase",
   "ignore_warning": false
 }

--- a/src/integrationTest/resources/ccd/callback/create-case/request/valid-exception.json
+++ b/src/integrationTest/resources/ccd/callback/create-case/request/valid-exception.json
@@ -32,6 +32,6 @@
     "security_classification": "PUBLIC",
     "callback_response_status": ""
   },
-  "event_id": "createCase",
+  "event_id": "createNewCase",
   "ignore_warning": false
 }

--- a/src/integrationTest/resources/ccd/callback/create-case/request/valid-new-application-with-ocr.json
+++ b/src/integrationTest/resources/ccd/callback/create-case/request/valid-new-application-with-ocr.json
@@ -32,6 +32,6 @@
     "security_classification": "PUBLIC",
     "callback_response_status": ""
   },
-  "event_id": "createCase",
+  "event_id": "createNewCase",
   "ignore_warning": false
 }

--- a/src/integrationTest/resources/ccd/callback/transformation-client/response/ok-no-warnings.json
+++ b/src/integrationTest/resources/ccd/callback/transformation-client/response/ok-no-warnings.json
@@ -1,7 +1,7 @@
 {
   "case_creation_details": {
     "case_type_id": "123",
-    "event_id": "createCase",
+    "event_id": "createNewCase",
     "case_data": {}
   },
   "warnings": []

--- a/src/integrationTest/resources/ccd/callback/transformation-client/response/ok-with-warnings.json
+++ b/src/integrationTest/resources/ccd/callback/transformation-client/response/ok-with-warnings.json
@@ -1,7 +1,7 @@
 {
   "case_creation_details": {
     "case_type_id": "123",
-    "event_id": "createCase",
+    "event_id": "createNewCase",
     "case_data": {}
   },
   "warnings": [

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
@@ -55,7 +55,7 @@ public class CcdCallbackController {
         }
     }
 
-    @PostMapping(path = "/create-case")
+    @PostMapping(path = "/create-new-case")
     public CallbackResponse createCase(
         @RequestBody CcdCallbackRequest callbackRequest,
         @RequestHeader(value = "Authorization", required = false) String idamToken,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -211,14 +211,14 @@ public final class CallbackValidations {
     ) {
         if (SUPPLEMENTARY_EVIDENCE.equals(classification)) {
             return invalid(format(
-                "Event createCase not allowed for the current journey classification %s",
+                "Event createNewCase not allowed for the current journey classification %s",
                 classification
             ));
         }
 
         if ((EXCEPTION.equals(classification) || NEW_APPLICATION.equals(classification)) && !hasOcr(theCase)) {
             return invalid(format(
-                "Event createCase not allowed for the current journey classification %s without OCR",
+                "Event createNewCase not allowed for the current journey classification %s without OCR",
                 classification
             ));
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
 import static java.util.Collections.emptyList;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasServiceNameInCaseTypeId;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.isCreateCaseEvent;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.isCreateNewCaseEvent;
 
 @Service
 public class CreateCaseCallbackService {
@@ -91,7 +91,7 @@ public class CreateCaseCallbackService {
 
     private Either<List<String>, Void> assertAllowToAccess(CaseDetails caseDetails, String eventId) {
         return validator.mandatoryPrerequisites(
-            () -> isCreateCaseEvent(eventId),
+            () -> isCreateNewCaseEvent(eventId),
             () -> getServiceConfig(caseDetails).map(item -> null)
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidator.java
@@ -12,7 +12,7 @@ import static java.lang.String.format;
 public final class EventIdValidator {
 
     private static final String EVENT_ID_ATTACH_TO_CASE = "attachToExistingCase";
-    private static final String EVENT_ID_CREATE_CASE = "createCase";
+    private static final String EVENT_ID_CREATE_NEW_CASE = "createNewCase";
 
     private EventIdValidator() {
         // utility class constructor
@@ -24,8 +24,8 @@ public final class EventIdValidator {
     }
 
     @Nonnull
-    static Validation<String, Void> isCreateCaseEvent(String eventId) {
-        return hasValidEventId(EVENT_ID_CREATE_CASE::equals, eventId);
+    static Validation<String, Void> isCreateNewCaseEvent(String eventId) {
+        return hasValidEventId(EVENT_ID_CREATE_NEW_CASE::equals, eventId);
     }
 
     @Nonnull

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -48,7 +48,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.mode
 @ExtendWith(MockitoExtension.class)
 class CreateCaseCallbackServiceTest {
 
-    private static final String EVENT_ID = "createCase";
+    private static final String EVENT_ID = "createNewCase";
     private static final String IDAM_TOKEN = "idam-token";
     private static final String USER_ID = "user-id";
     private static final String SERVICE = "service";
@@ -196,7 +196,7 @@ class CreateCaseCallbackServiceTest {
         // then
         assertThat(output.isLeft()).isTrue();
         assertThat(output.getLeft()).containsOnly(
-            "Event createCase not allowed for the current journey classification NEW_APPLICATION without OCR"
+            "Event " + EVENT_ID + " not allowed for the current journey classification NEW_APPLICATION without OCR"
         );
     }
 
@@ -232,7 +232,7 @@ class CreateCaseCallbackServiceTest {
         // then
         assertThat(output.isLeft()).isTrue();
         assertThat(output.getLeft()).containsOnly(
-            "Event createCase not allowed for the current journey classification SUPPLEMENTARY_EVIDENCE"
+            "Event " + EVENT_ID + " not allowed for the current journey classification SUPPLEMENTARY_EVIDENCE"
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidatorTest.java
@@ -28,15 +28,15 @@ class EventIdValidatorTest {
     private static Object[][] createCaseEventIdTestParams() {
         return new Object[][]{
             {"Invalid 'Create Case' event id", "invalid_event_id", false},
-            {"Valid 'Create Case' event id", "CreateCase", false},
-            {"Valid 'Create Case' event id", "createCase", true}
+            {"Valid 'Create Case' event id", "CreateNewCase", false},
+            {"Valid 'Create Case' event id", "createNewCase", true}
         };
     }
 
     @ParameterizedTest(name = "{0}: valid:{2}")
     @MethodSource("createCaseEventIdTestParams")
     void createCaseEventIdTest(String caseDescription, String eventId, boolean expectedIsValid) {
-        Validation<String, Void> validation = EventIdValidator.isCreateCaseEvent(eventId);
+        Validation<String, Void> validation = EventIdValidator.isCreateNewCaseEvent(eventId);
 
         assertThat(validation.isValid()).isEqualTo(expectedIsValid);
         assertErrorMessage(validation, eventId);


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create case: add endpoint to orchestrator](https://tools.hmcts.net/jira/browse/BPS-741)

### Change description ###

It is non breaking change because endpoint is nowhere used. Updating event id to be `createNewCase` as per SSCS configuration - they are already Phase2 on-board. Not sure where I saw `createCase` as my preference throughout the PRs - it's been a while.

Once again, non-breaking even though enpoint is updated

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
