### PR TITLE
Fix parsing of case data dates

### DIFF
--- a/src/integrationTest/resources/ccd/callback/create-case/request/invalid-exception-without-ocr.json
+++ b/src/integrationTest/resources/ccd/callback/create-case/request/invalid-exception-without-ocr.json
@@ -12,8 +12,8 @@
       "poBox": "PO 12345",
       "journeyClassification": "EXCEPTION",
       "formType": "B123",
-      "deliveryDate": "2018-01-02T12:34:56.123Z",
-      "openingDate": "2018-01-03T12:34:56.123Z"
+      "deliveryDate": "2018-01-02T12:34:56",
+      "openingDate": "2018-01-03T12:34:56"
     },
     "security_classification": "PUBLIC",
     "callback_response_status": ""

--- a/src/integrationTest/resources/ccd/callback/create-case/request/invalid-new-application-without-ocr.json
+++ b/src/integrationTest/resources/ccd/callback/create-case/request/invalid-new-application-without-ocr.json
@@ -12,8 +12,8 @@
       "poBox": "PO 12345",
       "journeyClassification": "NEW_APPLICATION",
       "formType": "B123",
-      "deliveryDate": "2018-01-02T12:34:56.123Z",
-      "openingDate": "2018-01-03T12:34:56.123Z"
+      "deliveryDate": "2018-01-02T12:34:56",
+      "openingDate": "2018-01-03T12:34:56"
     },
     "security_classification": "PUBLIC",
     "callback_response_status": ""

--- a/src/integrationTest/resources/ccd/callback/create-case/request/valid-exception-warnings-flag-on.json
+++ b/src/integrationTest/resources/ccd/callback/create-case/request/valid-exception-warnings-flag-on.json
@@ -12,8 +12,8 @@
       "poBox": "PO 12345",
       "journeyClassification": "EXCEPTION",
       "formType": "B123",
-      "deliveryDate": "2018-01-02T12:34:56.123Z",
-      "openingDate": "2018-01-03T12:34:56.123Z",
+      "deliveryDate": "2018-01-02T12:34:56",
+      "openingDate": "2018-01-03T12:34:56",
       "scanOCRData": [
         {
           "value": {

--- a/src/integrationTest/resources/ccd/callback/create-case/request/valid-exception.json
+++ b/src/integrationTest/resources/ccd/callback/create-case/request/valid-exception.json
@@ -12,8 +12,8 @@
       "poBox": "PO 12345",
       "journeyClassification": "EXCEPTION",
       "formType": "B123",
-      "deliveryDate": "2018-01-02T12:34:56.123Z",
-      "openingDate": "2018-01-03T12:34:56.123Z",
+      "deliveryDate": "2018-01-02T12:34:56",
+      "openingDate": "2018-01-03T12:34:56",
       "scanOCRData": [
         {
           "value": {

--- a/src/integrationTest/resources/ccd/callback/create-case/request/valid-new-application-with-ocr.json
+++ b/src/integrationTest/resources/ccd/callback/create-case/request/valid-new-application-with-ocr.json
@@ -12,8 +12,8 @@
       "poBox": "PO 12345",
       "journeyClassification": "NEW_APPLICATION",
       "formType": "B123",
-      "deliveryDate": "2018-01-02T12:34:56.123Z",
-      "openingDate": "2018-01-03T12:34:56.123Z",
+      "deliveryDate": "2018-01-02T12:34:56",
+      "openingDate": "2018-01-03T12:34:56",
       "scanOCRData": [
         {
           "value": {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -9,6 +9,9 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Class
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -30,6 +33,8 @@ public final class CallbackValidations {
     private static final String CLASSIFICATION_EXCEPTION = "EXCEPTION";
 
     private static final Logger log = LoggerFactory.getLogger(CallbackValidations.class);
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
     private static final CaseReferenceValidator caseRefValidator = new CaseReferenceValidator();
     private static final ScannedDocumentValidator scannedDocumentValidator = new ScannedDocumentValidator();
@@ -230,7 +235,9 @@ public final class CallbackValidations {
         return Optional.ofNullable(theCase)
             .map(CaseDetails::getData)
             .map(data -> data.get(dateField))
-            .map(o -> Validation.<String, Instant>valid(Instant.parse((String) o)))
+            .map(o -> Validation.<String, Instant>valid(
+                LocalDateTime.parse((String) o, FORMATTER).atZone(ZoneId.of("Europe/London")).toInstant()
+            ))
             .orElse(invalid("Missing " + dateField));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -175,8 +175,8 @@ class CreateCaseCallbackServiceTest {
         data.put("poBox", "12345");
         data.put("journeyClassification", NEW_APPLICATION.name());
         data.put("formType", "Form1");
-        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
-        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("deliveryDate", "2019-09-06T15:30:03");
+        data.put("openingDate", "2019-09-06T15:30:04");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
@@ -210,8 +210,8 @@ class CreateCaseCallbackServiceTest {
         data.put("poBox", "12345");
         data.put("journeyClassification", SUPPLEMENTARY_EVIDENCE.name());
         data.put("formType", "Form1");
-        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
-        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("deliveryDate", "2019-09-06T15:30:03");
+        data.put("openingDate", "2019-09-06T15:30:04");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
 
@@ -255,8 +255,8 @@ class CreateCaseCallbackServiceTest {
         data.put("poBox", "12345");
         data.put("journeyClassification", EXCEPTION.name());
         data.put("formType", "Form1");
-        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
-        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("deliveryDate", "2019-09-06T15:30:03");
+        data.put("openingDate", "2019-09-06T15:30:04");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
 
@@ -289,9 +289,9 @@ class CreateCaseCallbackServiceTest {
         Map<String, Object> data = new HashMap<>();
         // putting 6 via `ImmutableMap` is available from Java 9
         data.put("poBox", "12345");
-        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
+        data.put("deliveryDate", "2019-09-06T15:30:03");
         data.put("formType", "Form1");
-        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("openingDate", "2019-09-06T15:30:04");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
 
@@ -323,8 +323,8 @@ class CreateCaseCallbackServiceTest {
         data.put("poBox", "12345");
         data.put("journeyClassification", "EXCEPTIONS");
         data.put("formType", "Form1");
-        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
-        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("deliveryDate", "2019-09-06T15:30:03");
+        data.put("openingDate", "2019-09-06T15:30:04");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "filename"));
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("key", "value"));
 
@@ -360,7 +360,7 @@ class CreateCaseCallbackServiceTest {
         ));
         doc.put("controlNumber", "1234");
         doc.put("fileName", "file");
-        doc.put("scannedDate", "2019-09-06T15:40:00.000Z");
+        doc.put("scannedDate", "2019-09-06T15:40:00");
         doc.put("deliveryDate", "2019-09-06T15:40:00.001Z");
 
         Map<String, Object> data = new HashMap<>();
@@ -368,8 +368,8 @@ class CreateCaseCallbackServiceTest {
         data.put("poBox", "12345");
         data.put("journeyClassification", "EXCEPTION");
         data.put("formType", "Form1");
-        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
-        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("deliveryDate", "2019-09-06T15:30:03");
+        data.put("openingDate", "2019-09-06T15:30:04");
         data.put("scannedDocuments", ImmutableList.of(ImmutableMap.of("value", doc)));
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("key", "value"));
 
@@ -401,8 +401,8 @@ class CreateCaseCallbackServiceTest {
         data.put("poBox", "12345");
         data.put("journeyClassification", "EXCEPTION");
         data.put("formType", "Form1");
-        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
-        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("deliveryDate", "2019-09-06T15:30:03");
+        data.put("openingDate", "2019-09-06T15:30:04");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "name"));
         data.put("scanOCRData", ImmutableList.of(ImmutableMap.of("value", ImmutableMap.of(
             "key", "k",
@@ -441,8 +441,8 @@ class CreateCaseCallbackServiceTest {
         data.put("poBox", "12345");
         data.put("journeyClassification", "EXCEPTION");
         data.put("formType", null);
-        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
-        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("deliveryDate", "2019-09-06T15:30:03");
+        data.put("openingDate", "2019-09-06T15:30:04");
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "name"));
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("key", "value"));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create case: add endpoint to orchestrator](https://tools.hmcts.net/jira/browse/BPS-741)

### Change description ###

Apparently top level dates come in normally parsed as `LocalDataTime` but case data only has strings which we assumed having millis in but they are not. Manually defining formatter and converting to instant (object is used in transformation request.

Error from CCD:

> Request processing failed; nested exception is java.time.format.DateTimeParseException: Text '2018-06-23T00:00:00' could not be parsed at index 19 Text '2018-06-23T00:00:00' could not be parsed at index 19 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
