### PR TITLE
Fix issue parsing datetime object for scanned docs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -34,7 +34,8 @@ public final class CallbackValidations {
 
     private static final Logger log = LoggerFactory.getLogger(CallbackValidations.class);
 
-    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+    // todo review usage
+    public static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
         // date/time
         .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
         // optional offset

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.FORMATTER;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.getOcrData;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasCaseTypeId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasDateField;
@@ -158,8 +159,8 @@ public class CreateCaseValidator {
             ((Map<String, String>) document.get("url")).get("document_url"),
             (String) document.get("controlNumber"),
             (String) document.get("fileName"),
-            Instant.parse((String) document.get("scannedDate")),
-            Instant.parse((String) document.get("deliveryDate"))
+            Instant.from(FORMATTER.parse((String) document.get("scannedDate"))),
+            Instant.from(FORMATTER.parse((String) document.get("deliveryDate")))
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -396,6 +396,20 @@ class CreateCaseCallbackServiceTest {
         // given
         setUpTransformationUrl();
 
+        // modify scannedDocs to proof datetime field is bulletproof
+        Map<String, Object> doc = new HashMap<>();
+
+        doc.put("type", "Other");
+        doc.put("url", ImmutableMap.of(
+            "document_url", "https://some-url",
+            "document_binary_url", "https://some-bin-url",
+            "document_filename", "some-name"
+        ));
+        doc.put("controlNumber", "1234");
+        doc.put("fileName", "file");
+        doc.put("scannedDate", "2019-09-06T15:40:00Z");
+        doc.put("deliveryDate", "2019-09-06T15:40:00");
+
         Map<String, Object> data = new HashMap<>();
 
         data.put("poBox", "12345");
@@ -403,7 +417,7 @@ class CreateCaseCallbackServiceTest {
         data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
-        data.put("scannedDocuments", TestCaseBuilder.document("https://url", "name"));
+        data.put("scannedDocuments", ImmutableList.of(ImmutableMap.of("value", doc)));
         data.put("scanOCRData", ImmutableList.of(ImmutableMap.of("value", ImmutableMap.of(
             "key", "k",
             "value", 1


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create case: add endpoint to orchestrator](https://tools.hmcts.net/jira/browse/BPS-741)

### Change description ###

Previously #611 was looking in the wrong place assuming case details date was wrong. I think it was in the first place but then forgot/skipped scanned docs too - couple date fields are there as well with the same issue - not having millis not `Z`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
