### PR TITLE
Always prevent creation of duplicate exception records

### DIFF
--- a/charts/bulk-scan-orchestrator/values.yaml
+++ b/charts/bulk-scan-orchestrator/values.yaml
@@ -7,7 +7,6 @@ java:
     IDAM_CLIENT_REDIRECT_URI: "https://bulk-scan-orchestrator-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/oauth2/callback"
     CORE_CASE_DATA_API_URL: "http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     DOCUMENT_MANAGEMENT_URL: "http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
-    JURISDICTIONS_WITH_DUPLICATE_ER_PREVENTION: "BULKSCAN,CMC,DIVORCE,PROBATE,SSCS"
     TRANSFORMATION_URL_PROBATE: "http://probate-back-office-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
   keyVaults:
     bulk-scan:

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -83,8 +83,6 @@ locals {
     TRANSFORMATION_URL_BULKSCAN = "${var.transformation_url_bulkscan}"
     TRANSFORMATION_URL_PROBATE  = "${var.transformation_url_probate}"
     // endregion
-
-    JURISDICTIONS_WITH_DUPLICATE_ER_PREVENTION = "${join(",", var.jurisdictions_with_duplicate_er_prevention)}"
   }
 }
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -78,10 +78,3 @@ variable "transformation_url_bulkscan" {
 variable "transformation_url_probate" {
   default = ""
 }
-
-// TODO: remove when all jurisdictions support the prevention in all environments
-variable "jurisdictions_with_duplicate_er_prevention" {
-  type = "list"
-  description = "Jurisdictions that support the prevention of duplicate exception records"
-  default = ["BULKSCAN", "CMC", "DIVORCE", "PROBATE", "SSCS"]
-}

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -61,6 +61,3 @@ service-config:
       jurisdiction: BULKSCAN
       case-type-ids:
         - Bulk_Scanned
-
-# TODO: remove this setting when all jurisdictions support ER prevention in all environments
-jurisdictions-with-duplicate-er-prevention: "BULKSCAN"

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -57,5 +57,3 @@ service-config:
       transformation-url: *wiremock
       case-type-ids:
         - Bulk_Scanned
-
-jurisdictions-with-duplicate-er-prevention: BULKSCAN

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -21,16 +21,13 @@ public class ExceptionRecordMapper {
 
     private final String documentManagementUrl;
     private final String contextPath;
-    private final List<String> jurisdictionsWithDuplicatePrevention;
 
     public ExceptionRecordMapper(
         @Value("${document_management.url}") final String documentManagementUrl,
-        @Value("${document_management.context-path}") final String contextPath,
-        @Value("${jurisdictions-with-duplicate-er-prevention}") final List<String> jurisdictionsWithDuplicatePrevention
+        @Value("${document_management.context-path}") final String contextPath
     ) {
         this.documentManagementUrl = documentManagementUrl;
         this.contextPath = contextPath;
-        this.jurisdictionsWithDuplicatePrevention = jurisdictionsWithDuplicatePrevention;
     }
 
     public ExceptionRecord mapEnvelope(Envelope envelope) {
@@ -45,7 +42,7 @@ public class ExceptionRecordMapper {
             mapOcrData(envelope.ocrData),
             mapOcrDataWarnings(envelope.ocrDataValidationWarnings),
             envelope.ocrDataValidationWarnings.isEmpty() ? NO : YES,
-            jurisdictionsWithDuplicatePrevention.contains(envelope.jurisdiction) ? envelope.id : null
+            envelope.id
         );
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -86,11 +86,6 @@ service-config:
       case-type-ids:
         - MoneyClaimCase
 
-# comma-separated list of jurisdictions that support duplicate exception record prevention
-# TODO: remove this setting when all jurisdictions support ER prevention in all environments
-jurisdictions-with-duplicate-er-prevention: ${JURISDICTIONS_WITH_DUPLICATE_ER_PREVENTION}
-
-
 scheduling:
   task:
     delete-envelopes-dlq-messages:

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/feature/OcrDataOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/feature/OcrDataOrderTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.OcrDa
 import java.util.ArrayList;
 import java.util.ListIterator;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class OcrDataOrderTest {
@@ -33,8 +32,7 @@ public class OcrDataOrderTest {
         // and
         ExceptionRecordMapper mapper = new ExceptionRecordMapper(
             "http://localhost",
-            "files",
-            newArrayList("BULKSCAN")
+            "files"
         );
 
         ExceptionRecord record = mapper.mapEnvelope(envelope);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -24,7 +24,10 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelope;
 
 class ExceptionRecordMapperTest {
 
-    private final ExceptionRecordMapper mapper = exceptionRecordMapper("BULKSCAN");
+    private final ExceptionRecordMapper mapper = new ExceptionRecordMapper(
+        "https://example.gov.uk",
+        "files"
+    );
 
     @Test
     public void mapEnvelope_maps_all_fields_correctly() {
@@ -101,32 +104,17 @@ class ExceptionRecordMapperTest {
     }
 
     @Test
-    public void mapEnvelope_copies_envelope_id_when_jurisdiction_supports_duplicate_prevention() {
+    public void mapEnvelope_copies_envelope_id_to_exception_record() {
         // given
         String supportedJurisdiction = "supported-jurisdiction1";
-        ExceptionRecordMapper exceptionRecordMapper = exceptionRecordMapper(supportedJurisdiction, "jurisdiction2");
 
         // when
         Envelope envelope = envelopeWithJurisdiction(supportedJurisdiction);
 
         // then
-        ExceptionRecord exceptionRecord = exceptionRecordMapper.mapEnvelope(envelope);
+        ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
 
         assertThat(exceptionRecord.envelopeId).isEqualTo(envelope.id);
-    }
-
-    @Test
-    public void mapEnvelope_sets_envelope_id_to_null_when_jurisdiction_does_not_support_duplicate_prevention() {
-        // given
-        ExceptionRecordMapper exceptionRecordMapper = exceptionRecordMapper("jurisdiction1", "jurisdiction2");
-
-        // when
-        Envelope envelope = envelopeWithJurisdiction("unsupported-jurisdiction1");
-
-        // then
-        ExceptionRecord exceptionRecord = exceptionRecordMapper.mapEnvelope(envelope);
-
-        assertThat(exceptionRecord.envelopeId).isNull();
     }
 
     private Envelope envelopeWithJurisdiction(String jurisdiction) {
@@ -162,13 +150,5 @@ class ExceptionRecordMapperTest {
                     scannedDocument.deliveryDate.atZone(ZoneId.systemDefault()).toInstant()
                 )
             ).collect(toList());
-    }
-
-    private ExceptionRecordMapper exceptionRecordMapper(String... jurisdictionsWithDuplicatePrevention) {
-        return new ExceptionRecordMapper(
-            "https://example.gov.uk",
-            "files",
-            newArrayList(jurisdictionsWithDuplicatePrevention)
-        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/ExceptionRecordCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/ExceptionRecordCreatorTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -20,7 +21,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelope;
@@ -36,25 +36,14 @@ public class ExceptionRecordCreatorTest {
 
     private static final Long CASE_DETAILS_ID = 234L;
 
-    @Test
-    public void should_create_exception_record_when_duplicate_prevention_not_supported() {
-        // given
-        setupCcdApi();
+    private CreateExceptionRecord exceptionRecordCreator;
 
-        Envelope envelope = envelope(1);
-        ExceptionRecord expectedExceptionRecord = mock(ExceptionRecord.class);
-        given(exceptionRecordMapper.mapEnvelope(envelope)).willReturn(expectedExceptionRecord);
-
-        // when
-        Long ccdRef = exceptionRecordCreator("other-jurisdiction1").tryCreateFrom(envelope);
-
-        // then
-        assertThat(ccdRef).isSameAs(CASE_DETAILS_ID);
-        assertExceptionRecordCreated(expectedExceptionRecord, envelope);
-
-        // no duplicate search is performed
-        verify(ccdApi, never()).getExceptionRecordRefsByEnvelopeId(any(), any());
-        verify(exceptionRecordMapper).mapEnvelope(envelope);
+    @BeforeEach
+    public void setUp() {
+        exceptionRecordCreator = new CreateExceptionRecord(
+            exceptionRecordMapper,
+            ccdApi
+        );
     }
 
     @Test
@@ -68,7 +57,7 @@ public class ExceptionRecordCreatorTest {
         given(exceptionRecordMapper.mapEnvelope(envelope)).willReturn(expectedExceptionRecord);
 
         // when
-        Long ccdRef = exceptionRecordCreator(envelope.jurisdiction).tryCreateFrom(envelope);
+        Long ccdRef = exceptionRecordCreator.tryCreateFrom(envelope);
 
         assertThat(ccdRef).isSameAs(CASE_DETAILS_ID);
         assertExceptionRecordCreated(expectedExceptionRecord, envelope);
@@ -87,7 +76,7 @@ public class ExceptionRecordCreatorTest {
         Envelope envelope = envelope(1);
 
         // when
-        Long ccdRef = exceptionRecordCreator(envelope.jurisdiction).tryCreateFrom(envelope);
+        Long ccdRef = exceptionRecordCreator.tryCreateFrom(envelope);
 
         // then
         assertThat(ccdRef).isSameAs(existingExceptionRecordId);
@@ -95,14 +84,6 @@ public class ExceptionRecordCreatorTest {
         verify(ccdApi).getExceptionRecordRefsByEnvelopeId(envelope.id, envelope.container);
         verifyNoMoreInteractions(ccdApi);
         verifyNoMoreInteractions(exceptionRecordMapper);
-    }
-
-    private CreateExceptionRecord exceptionRecordCreator(String... jurisdictionsWithDuplicatePrevention) {
-        return new CreateExceptionRecord(
-            exceptionRecordMapper,
-            ccdApi,
-            newArrayList(jurisdictionsWithDuplicatePrevention)
-        );
     }
 
     private void assertExceptionRecordCreated(ExceptionRecord expectedExceptionRecord, Envelope envelope) {


### PR DESCRIPTION
### Change description ###

Always prevent creation of duplicate exception records. All services support it now, so there's no need to make it configurable.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
