### PR TITLE
Fix DateTime serialisation for RestTemplate requests

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/HttpConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/HttpConfiguration.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Client;
 import feign.httpclient.ApacheHttpClient;
 import org.apache.http.client.config.RequestConfig;
@@ -8,7 +9,12 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Configuration
 public class HttpConfiguration {
@@ -19,8 +25,16 @@ public class HttpConfiguration {
     }
 
     @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate(clientHttpRequestFactory());
+    public RestTemplate restTemplate(ObjectMapper objectMapper) {
+        RestTemplate restTemplate = new RestTemplate(clientHttpRequestFactory());
+
+        List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+        MappingJackson2HttpMessageConverter jsonMessageConverter = new MappingJackson2HttpMessageConverter();
+        jsonMessageConverter.setObjectMapper(objectMapper);
+        messageConverters.add(jsonMessageConverter);
+        restTemplate.setMessageConverters(messageConverters);
+
+        return restTemplate;
     }
 
     @Bean

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/TimeConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/TimeConfiguration.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.config;
+
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.format.DateTimeFormatter;
+
+@Configuration
+public class TimeConfiguration {
+
+    private static final String DATE_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+
+    // global setting via config files not working with java8
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jsonCustomiser() {
+        return builder -> {
+            builder.simpleDateFormat(DATE_TIME_PATTERN);
+
+            builder.serializers(
+                new LocalDateSerializer(DateTimeFormatter.ISO_LOCAL_DATE),
+                new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(DATE_TIME_PATTERN)),
+                new ZonedDateTimeSerializer(DateTimeFormatter.ofPattern(DATE_TIME_PATTERN))
+            );
+        };
+    }
+}


### PR DESCRIPTION
### Change description ###

Kept on getting floating point and/or array of integers for datetime no matter what. This PR follows hmcts/send-letter-service#440 as this issue caused problems before and only today remembered it. The follow up didn't quite work and as you can see in the `HttpConfiguration`, some amendments to `RestTemplate` had to be done so it can identify relevant serialisation plugins

Planned to sneak in test upgrade for transformation client but it didn't seem trivial so parked it for the time being - the fix right now has higher priority

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
