### PR TITLE
Use `LocalDateTime` instead of `Instant`

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClientTest.java
@@ -16,8 +16,6 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.res
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
 
-import java.time.Instant;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.forbidden;
@@ -27,6 +25,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.unauthorized;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static java.time.LocalDateTime.now;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
@@ -195,16 +194,16 @@ public class TransformationClientTest {
             "BULKSCAN",
             Classification.NEW_APPLICATION,
             "D8",
-            Instant.now(),
-            Instant.now(),
+            now(),
+            now(),
             singletonList(new ScannedDocument(
                 DocumentType.CHERISHED,
                 "D8",
                 "http://locahost",
                 "1234",
                 "file1.pdf",
-                Instant.now(),
-                Instant.now()
+                now(),
+                now()
             )),
             asList(
                 new OcrDataField("name1", "value1"),

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/request/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/request/ExceptionRecord.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.re
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class ExceptionRecord {
@@ -24,10 +24,10 @@ public class ExceptionRecord {
     public final String formType;
 
     @JsonProperty("delivery_date")
-    public final Instant deliveryDate;
+    public final LocalDateTime deliveryDate;
 
     @JsonProperty("opening_date")
-    public final Instant openingDate;
+    public final LocalDateTime openingDate;
 
     @JsonProperty("scanned_documents")
     public final List<ScannedDocument> scannedDocuments;
@@ -41,8 +41,8 @@ public class ExceptionRecord {
         String poBoxJurisdiction,
         Classification journeyClassification,
         String formType,
-        Instant deliveryDate,
-        Instant openingDate,
+        LocalDateTime deliveryDate,
+        LocalDateTime openingDate,
         List<ScannedDocument> scannedDocuments,
         List<OcrDataField> ocrDataFields
     ) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/request/ScannedDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/request/ScannedDocument.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.re
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 public class ScannedDocument {
 
@@ -22,10 +22,10 @@ public class ScannedDocument {
     public final String fileName;
 
     @JsonProperty("scanned_date")
-    public final Instant scannedDate;
+    public final LocalDateTime scannedDate;
 
     @JsonProperty("delivery_date")
-    public final Instant deliveryDate;
+    public final LocalDateTime deliveryDate;
 
     public ScannedDocument(
         DocumentType type,
@@ -33,8 +33,8 @@ public class ScannedDocument {
         String url,
         String controlNumber,
         String fileName,
-        Instant scannedDate,
-        Instant deliveryDate
+        LocalDateTime scannedDate,
+        LocalDateTime deliveryDate
     ) {
         this.type = type;
         this.subtype = subtype;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -238,11 +238,11 @@ public final class CallbackValidations {
         return valid(classification);
     }
 
-    public static Validation<String, Instant> hasDateField(CaseDetails theCase, String dateField) {
+    public static Validation<String, LocalDateTime> hasDateField(CaseDetails theCase, String dateField) {
         return Optional.ofNullable(theCase)
             .map(CaseDetails::getData)
             .map(data -> data.get(dateField))
-            .map(o -> Validation.<String, Instant>valid(Instant.from(FORMATTER.parse((String) o))))
+            .map(o -> Validation.<String, LocalDateTime>valid(LocalDateTime.parse((String) o, FORMATTER)))
             .orElse(invalid("Missing " + dateField));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
@@ -16,7 +16,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.model.Classification;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -77,8 +77,8 @@ public class CreateCaseValidator {
         Validation<String, String> jurisdictionValidation = hasJurisdiction(caseDetails);
         Validation<String, String> formTypeValidation = hasFormType(caseDetails);
         Validation<String, Classification> journeyClassificationValidation = hasJourneyClassification(caseDetails);
-        Validation<String, Instant> deliveryDateValidation = hasDateField(caseDetails, "deliveryDate");
-        Validation<String, Instant> openingDateValidation = hasDateField(caseDetails, "openingDate");
+        Validation<String, LocalDateTime> deliveryDateValidation = hasDateField(caseDetails, "deliveryDate");
+        Validation<String, LocalDateTime> openingDateValidation = hasDateField(caseDetails, "openingDate");
         Validation<String, List<ScannedDocument>> scannedDocumentsValidation = getScannedDocuments(caseDetails);
         Validation<String, List<OcrDataField>> ocrDataFieldsValidation = getOcrDataFields(caseDetails);
 
@@ -159,8 +159,8 @@ public class CreateCaseValidator {
             ((Map<String, String>) document.get("url")).get("document_url"),
             (String) document.get("controlNumber"),
             (String) document.get("fileName"),
-            Instant.from(FORMATTER.parse((String) document.get("scannedDate"))),
-            Instant.from(FORMATTER.parse((String) document.get("deliveryDate")))
+            LocalDateTime.parse((String) document.get("scannedDate"), FORMATTER),
+            LocalDateTime.parse((String) document.get("deliveryDate"), FORMATTER)
         );
     }
 }


### PR DESCRIPTION
### Change description ###

Looks like `RestTemplate` is dodgy with those timestamp restrictions. On the other side `LocalDateTime` is used. Aligning so internal serialisation/deserialisation fits.

Previous attempts:

- config doesn't work. we are in java 8 world atm
- spring boot `@config` doesn't work - rest template doesn't agree with it
- extra fiddling with spring boot `@config` doesn't work - breaks functional tests due to hard dependency of specific rest template serialisation (default!) setup which is used in document management client (in functional tests, reminding again). ref for this point (and previous): #625 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
