### PR TITLE
Fix S2S token passed to Transformation service

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClientTest.java
@@ -53,7 +53,7 @@ public class TransformationClientTest {
 
         stubFor(
             post(urlPathMatching(TRANSFORM_EXCEPTION_RECORD_URL))
-                .withHeader("ServiceAuthorization", equalTo("Bearer " + s2sToken))
+                .withHeader("ServiceAuthorization", equalTo(s2sToken))
                 .willReturn(okJson(successResponse().toString()))
         );
 
@@ -80,7 +80,7 @@ public class TransformationClientTest {
         String s2sToken = randomUUID().toString();
         stubFor(
             post(urlPathMatching(TRANSFORM_EXCEPTION_RECORD_URL))
-                .withHeader("ServiceAuthorization", equalTo("Bearer " + s2sToken))
+                .withHeader("ServiceAuthorization", equalTo(s2sToken))
                 .willReturn(aResponse().withBody(errorResponse().toString()).withStatus(422)));
 
         // when
@@ -106,7 +106,7 @@ public class TransformationClientTest {
         String s2sToken = randomUUID().toString();
         stubFor(
             post(urlPathMatching(TRANSFORM_EXCEPTION_RECORD_URL))
-                .withHeader("ServiceAuthorization", equalTo("Bearer " + s2sToken))
+                .withHeader("ServiceAuthorization", equalTo(s2sToken))
                 .willReturn(aResponse().withBody(invalidDataResponse().toString()).withStatus(400)));
 
         // when

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClient.java
@@ -41,7 +41,7 @@ public class TransformationClient {
         String s2sToken
     ) throws IOException, CaseTransformationException {
         HttpHeaders headers = new HttpHeaders();
-        headers.add("ServiceAuthorization", "Bearer " + s2sToken);
+        headers.add("ServiceAuthorization", s2sToken);
 
         String url =
             UriComponentsBuilder


### PR DESCRIPTION
### Change description ###

`AuthTokenGenerator` already is wrapped with Bearer decorator - comes back with in the format already ready to use. Integration test mocks api interaction hence never tested nor will be

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
