### PR TITLE
Extend payments queue message by service name

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessor.java
@@ -27,6 +27,7 @@ public class PaymentsProcessor {
             PaymentsData paymentsData = new PaymentsData(
                 Long.toString(ccdId),
                 envelope.jurisdiction,
+                envelope.container,
                 envelope.poBox,
                 isExceptionRecord,
                 envelope.payments.stream()

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/PaymentsData.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/model/PaymentsData.java
@@ -12,6 +12,9 @@ public class PaymentsData {
     @JsonProperty("jurisdiction")
     public final String jurisdiction;
 
+    @JsonProperty("service")
+    public final String service;
+
     @JsonProperty("po_box")
     public final String poBox;
 
@@ -24,12 +27,14 @@ public class PaymentsData {
     public PaymentsData(
         String ccdReference,
         String jurisdiction,
+        String service,
         String poBox,
         boolean isExceptionRecord,
         List<PaymentData> payments
     ) {
         this.ccdReference = ccdReference;
         this.jurisdiction = jurisdiction;
+        this.service = service;
         this.poBox = poBox;
         this.isExceptionRecord = isExceptionRecord;
         this.payments = payments;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/PaymentsPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/PaymentsPublisherTest.java
@@ -70,11 +70,12 @@ class PaymentsPublisherTest {
 
         String messageBodyJson = new String(MessageBodyRetriever.getBinaryData(message.getMessageBody()));
         String expectedMessageBodyJson = String.format(
-            "{\"ccd_reference\":\"%s\", \"jurisdiction\":\"%s\", \"po_box\":\"%s\", "
+            "{\"ccd_reference\":\"%s\", \"jurisdiction\":\"%s\", \"service\":\"%s\", \"po_box\":\"%s\", "
                 + "\"is_exception_record\":%s, "
                 + "\"payments\":[{\"document_control_number\":\"%s\"}]}",
             paymentsData.ccdReference,
             paymentsData.jurisdiction,
+            paymentsData.service,
             paymentsData.poBox,
             Boolean.toString(paymentsData.isExceptionRecord),
             paymentsData.payments.get(0).documentControlNumber
@@ -105,6 +106,7 @@ class PaymentsPublisherTest {
         return new PaymentsData(
                 Long.toString(10L),
                 "jurisdiction",
+                "service",
                 "pobox",
                 isExceptionRecord,
                 asList(new PaymentData("dcn1"))


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-810

### Change description ###

Extend payments queue message by service name. Payment processor needs to know the service in order to determine case type ID when talking to CCD.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
