### PR TITLE
Fix event id used in ccd calls

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
@@ -25,6 +25,8 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.http.HttpStatus.OK;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.EVENT_ID_CREATE_NEW_CASE;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.EXCEPTION;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.NEW_APPLICATION;
 
 @IntegrationTest
 class CreateCaseCallbackTest {
@@ -55,7 +57,7 @@ class CreateCaseCallbackTest {
         postWithBody(getRequestBody("invalid-new-application-without-ocr.json"))
             .statusCode(OK.value())
             .body("errors", contains("Event " + EVENT_ID_CREATE_NEW_CASE + " not allowed "
-                + "for the current journey classification NEW_APPLICATION without OCR"))
+                + "for the current journey classification " + NEW_APPLICATION.name() + " without OCR"))
             .body("warnings", nullValue())
             .body("data", nullValue());
     }
@@ -65,7 +67,7 @@ class CreateCaseCallbackTest {
         postWithBody(getRequestBody("invalid-exception-without-ocr.json"))
             .statusCode(OK.value())
             .body("errors", contains("Event " + EVENT_ID_CREATE_NEW_CASE + " not allowed "
-                + "for the current journey classification EXCEPTION without OCR"))
+                + "for the current journey classification " + EXCEPTION.name() + " without OCR"))
             .body("warnings", nullValue())
             .body("data", nullValue());
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.http.HttpStatus.OK;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.EVENT_ID_CREATE_NEW_CASE;
 
 @IntegrationTest
 class CreateCaseCallbackTest {
@@ -53,7 +54,7 @@ class CreateCaseCallbackTest {
     void should_not_create_case_if_classification_new_application_without_ocr_data() {
         postWithBody(getRequestBody("invalid-new-application-without-ocr.json"))
             .statusCode(OK.value())
-            .body("errors", contains("Event createNewCase not allowed "
+            .body("errors", contains("Event " + EVENT_ID_CREATE_NEW_CASE + " not allowed "
                 + "for the current journey classification NEW_APPLICATION without OCR"))
             .body("warnings", nullValue())
             .body("data", nullValue());
@@ -63,7 +64,7 @@ class CreateCaseCallbackTest {
     void should_not_create_case_if_classification_exception_without_ocr_data() {
         postWithBody(getRequestBody("invalid-exception-without-ocr.json"))
             .statusCode(OK.value())
-            .body("errors", contains("Event createNewCase not allowed "
+            .body("errors", contains("Event " + EVENT_ID_CREATE_NEW_CASE + " not allowed "
                 + "for the current journey classification EXCEPTION without OCR"))
             .body("warnings", nullValue())
             .body("data", nullValue());
@@ -125,7 +126,11 @@ class CreateCaseCallbackTest {
         givenThat(
             get(
                 // values from config + initial request body
-                "/caseworkers/" + USER_ID + "/jurisdictions/BULKSCAN/case-types/123/event-triggers/createNewCase/token"
+                "/caseworkers/"
+                    + USER_ID
+                    + "/jurisdictions/BULKSCAN/case-types/123/event-triggers/"
+                    + EVENT_ID_CREATE_NEW_CASE
+                    + "/token"
             )
             .withHeader("ServiceAuthorization", containing("Bearer"))
             .willReturn(okJson(startResponseBody))

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -33,6 +33,7 @@ import java.util.function.Function;
 import static java.util.Collections.emptyList;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasServiceNameInCaseTypeId;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.EVENT_ID_CREATE_NEW_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.isCreateNewCaseEvent;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.CASE_REFERENCE;
 
@@ -200,7 +201,7 @@ public class CreateCaseCallbackService {
             userId,
             jurisdiction,
             caseCreationDetails.caseTypeId,
-            caseCreationDetails.eventId
+            EVENT_ID_CREATE_NEW_CASE
         );
 
         return ccdApi.submitForCaseworker(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidator.java
@@ -12,7 +12,7 @@ import static java.lang.String.format;
 public final class EventIdValidator {
 
     private static final String EVENT_ID_ATTACH_TO_CASE = "attachToExistingCase";
-    private static final String EVENT_ID_CREATE_NEW_CASE = "createNewCase";
+    public static final String EVENT_ID_CREATE_NEW_CASE = "createNewCase";
 
     private EventIdValidator() {
         // utility class constructor

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -195,9 +195,10 @@ class CreateCaseCallbackServiceTest {
 
         // then
         assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly(
-            "Event " + EVENT_ID_CREATE_NEW_CASE
-                + " not allowed for the current journey classification NEW_APPLICATION without OCR"
+        assertThat(output.getLeft()).containsOnly("Event " + EVENT_ID_CREATE_NEW_CASE
+            + " not allowed for the current journey classification "
+            + NEW_APPLICATION.name()
+            + " without OCR"
         );
     }
 
@@ -232,9 +233,10 @@ class CreateCaseCallbackServiceTest {
 
         // then
         assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly(
-            "Event " + EVENT_ID_CREATE_NEW_CASE
-                + " not allowed for the current journey classification SUPPLEMENTARY_EVIDENCE"
+        assertThat(output.getLeft()).containsOnly("Event "
+            + EVENT_ID_CREATE_NEW_CASE
+            + " not allowed for the current journey classification "
+            + SUPPLEMENTARY_EVIDENCE.name()
         );
     }
 
@@ -368,7 +370,7 @@ class CreateCaseCallbackServiceTest {
         Map<String, Object> data = new HashMap<>();
 
         data.put("poBox", "12345");
-        data.put("journeyClassification", "EXCEPTION");
+        data.put("journeyClassification", EXCEPTION.name());
         data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
@@ -415,7 +417,7 @@ class CreateCaseCallbackServiceTest {
         Map<String, Object> data = new HashMap<>();
 
         data.put("poBox", "12345");
-        data.put("journeyClassification", "EXCEPTION");
+        data.put("journeyClassification", EXCEPTION.name());
         data.put("formType", "Form1");
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");
@@ -455,7 +457,7 @@ class CreateCaseCallbackServiceTest {
         Map<String, Object> data = new HashMap<>();
 
         data.put("poBox", "12345");
-        data.put("journeyClassification", "EXCEPTION");
+        data.put("journeyClassification", EXCEPTION.name());
         data.put("formType", null);
         data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
         data.put("openingDate", "2019-09-06T15:30:04.000Z");

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.EVENT_ID_CREATE_NEW_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.EXCEPTION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.NEW_APPLICATION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE;
@@ -48,7 +49,6 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.doma
 @ExtendWith(MockitoExtension.class)
 class CreateCaseCallbackServiceTest {
 
-    private static final String EVENT_ID = "createNewCase";
     private static final String IDAM_TOKEN = "idam-token";
     private static final String USER_ID = "user-id";
     private static final String SERVICE = "service";
@@ -100,7 +100,7 @@ class CreateCaseCallbackServiceTest {
 
         // when
         Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
-            EVENT_ID,
+            EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
@@ -117,7 +117,7 @@ class CreateCaseCallbackServiceTest {
 
         // when
         Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
-            EVENT_ID,
+            EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
@@ -136,7 +136,7 @@ class CreateCaseCallbackServiceTest {
 
         // when
         Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
-            EVENT_ID,
+            EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
@@ -154,7 +154,7 @@ class CreateCaseCallbackServiceTest {
 
         // when
         Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
-            EVENT_ID,
+            EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
@@ -188,7 +188,7 @@ class CreateCaseCallbackServiceTest {
 
         // when
         Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
-            EVENT_ID,
+            EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
@@ -196,7 +196,8 @@ class CreateCaseCallbackServiceTest {
         // then
         assertThat(output.isLeft()).isTrue();
         assertThat(output.getLeft()).containsOnly(
-            "Event " + EVENT_ID + " not allowed for the current journey classification NEW_APPLICATION without OCR"
+            "Event " + EVENT_ID_CREATE_NEW_CASE
+                + " not allowed for the current journey classification NEW_APPLICATION without OCR"
         );
     }
 
@@ -224,7 +225,7 @@ class CreateCaseCallbackServiceTest {
 
         // when
         Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
-            EVENT_ID,
+            EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
@@ -232,7 +233,8 @@ class CreateCaseCallbackServiceTest {
         // then
         assertThat(output.isLeft()).isTrue();
         assertThat(output.getLeft()).containsOnly(
-            "Event " + EVENT_ID + " not allowed for the current journey classification SUPPLEMENTARY_EVIDENCE"
+            "Event " + EVENT_ID_CREATE_NEW_CASE
+                + " not allowed for the current journey classification SUPPLEMENTARY_EVIDENCE"
         );
     }
 
@@ -269,7 +271,7 @@ class CreateCaseCallbackServiceTest {
 
         // when
         Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
-            EVENT_ID,
+            EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
@@ -303,7 +305,7 @@ class CreateCaseCallbackServiceTest {
 
         // when
         Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
-            EVENT_ID,
+            EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
@@ -336,7 +338,7 @@ class CreateCaseCallbackServiceTest {
 
         // when
         Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
-            EVENT_ID,
+            EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
@@ -381,7 +383,7 @@ class CreateCaseCallbackServiceTest {
 
         // when
         Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
-            EVENT_ID,
+            EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
@@ -431,7 +433,7 @@ class CreateCaseCallbackServiceTest {
 
         // when
         Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
-            EVENT_ID,
+            EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
@@ -468,7 +470,7 @@ class CreateCaseCallbackServiceTest {
 
         // when
         Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
-            EVENT_ID,
+            EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidatorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.EVENT_ID_CREATE_NEW_CASE;
 
 class EventIdValidatorTest {
 
@@ -28,8 +29,8 @@ class EventIdValidatorTest {
     private static Object[][] createCaseEventIdTestParams() {
         return new Object[][]{
             {"Invalid 'Create Case' event id", "invalid_event_id", false},
-            {"Valid 'Create Case' event id", "CreateNewCase", false},
-            {"Valid 'Create Case' event id", "createNewCase", true}
+            {"Valid 'Create Case' event id", EVENT_ID_CREATE_NEW_CASE.toUpperCase(), false},
+            {"Valid 'Create Case' event id", EVENT_ID_CREATE_NEW_CASE, true}
         };
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create case: add endpoint to orchestrator](https://tools.hmcts.net/jira/browse/BPS-741)

### Change description ###

Do not trust service return object for the time being and just use our own exception record event id configured in each jurisdiction.

Amending test cases to use classification enum as well as same lines got changed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
