### PR TITLE
Prepare for 'update payments' command

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessor.java
@@ -5,8 +5,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.IPaymentsPublisher;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.PaymentData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.CreatePaymentsCommand;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.PaymentData;
 
 import static java.util.stream.Collectors.toList;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessor.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.IPaymentsPublisher;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.PaymentData;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.PaymentsData;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.CreatePaymentsCommand;
 
 import static java.util.stream.Collectors.toList;
 
@@ -24,7 +24,7 @@ public class PaymentsProcessor {
 
     public void processPayments(Envelope envelope, Long ccdId, boolean isExceptionRecord) {
         if (envelope.payments != null && !envelope.payments.isEmpty()) {
-            PaymentsData paymentsData = new PaymentsData(
+            CreatePaymentsCommand cmd = new CreatePaymentsCommand(
                 Long.toString(ccdId),
                 envelope.jurisdiction,
                 envelope.container,
@@ -35,9 +35,9 @@ public class PaymentsProcessor {
                     .collect(toList())
             );
 
-            LOG.info("Started processing payments for case with CCD reference {}", paymentsData.ccdReference);
-            paymentsPublisher.publishPayments(paymentsData);
-            LOG.info("Finished processing payments for case with CCD reference {}", paymentsData.ccdReference);
+            LOG.info("Started processing payments for case with CCD reference {}", cmd.ccdReference);
+            paymentsPublisher.send(cmd);
+            LOG.info("Finished processing payments for case with CCD reference {}", cmd.ccdReference);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/IPaymentsPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/IPaymentsPublisher.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments;
 
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.PaymentsData;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.CreatePaymentsCommand;
 
 public interface IPaymentsPublisher {
 
-    void publishPayments(PaymentsData paymentsData);
+    void send(CreatePaymentsCommand createPaymentsCommand);
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/Labels.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/Labels.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments;
+
+public final class Labels {
+
+    public static final String CREATE = "CREATE";
+
+    private Labels() {
+        // util class
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/model/CreatePaymentsCommand.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/model/CreatePaymentsCommand.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-public class PaymentsData {
+public class CreatePaymentsCommand {
 
     @JsonProperty("ccd_reference")
     public final String ccdReference;
@@ -24,7 +24,7 @@ public class PaymentsData {
     @JsonProperty("payments")
     public final List<PaymentData> payments;
 
-    public PaymentsData(
+    public CreatePaymentsCommand(
         String ccdReference,
         String jurisdiction,
         String service,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessorTest.java
@@ -10,7 +10,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Payment;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.PaymentsPublisher;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.PaymentsData;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.CreatePaymentsCommand;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -42,20 +42,20 @@ class PaymentsProcessorTest {
             emptyList(),
             emptyList()
         );
-        ArgumentCaptor<PaymentsData> paymentsDataCaptor = ArgumentCaptor.forClass(PaymentsData.class);
+        ArgumentCaptor<CreatePaymentsCommand> paymentsDataCaptor = ArgumentCaptor.forClass(CreatePaymentsCommand.class);
 
         // when
         paymentsProcessor.processPayments(envelope, CCD_REFERENCE, true);
 
         // then
-        verify(paymentsPublisher).publishPayments(paymentsDataCaptor.capture());
-        PaymentsData paymentsData = paymentsDataCaptor.getValue();
-        assertThat(paymentsData.ccdReference).isEqualTo(Long.toString(CCD_REFERENCE));
-        assertThat(paymentsData.jurisdiction).isEqualTo(envelope.jurisdiction);
-        assertThat(paymentsData.poBox).isEqualTo(envelope.poBox);
-        assertThat(paymentsData.isExceptionRecord).isTrue();
-        assertThat(paymentsData.payments.size()).isEqualTo(envelope.payments.size());
-        assertThat(paymentsData.payments.get(0).documentControlNumber)
+        verify(paymentsPublisher).send(paymentsDataCaptor.capture());
+        CreatePaymentsCommand createPaymentsCommand = paymentsDataCaptor.getValue();
+        assertThat(createPaymentsCommand.ccdReference).isEqualTo(Long.toString(CCD_REFERENCE));
+        assertThat(createPaymentsCommand.jurisdiction).isEqualTo(envelope.jurisdiction);
+        assertThat(createPaymentsCommand.poBox).isEqualTo(envelope.poBox);
+        assertThat(createPaymentsCommand.isExceptionRecord).isTrue();
+        assertThat(createPaymentsCommand.payments.size()).isEqualTo(envelope.payments.size());
+        assertThat(createPaymentsCommand.payments.get(0).documentControlNumber)
             .isEqualTo(envelope.payments.get(0).documentControlNumber);
     }
 
@@ -73,7 +73,7 @@ class PaymentsProcessorTest {
         paymentsProcessor.processPayments(envelope, CCD_REFERENCE, true);
 
         // then
-        verify(paymentsPublisher, never()).publishPayments(any());
+        verify(paymentsPublisher, never()).send(any());
     }
 
     @Test
@@ -90,6 +90,6 @@ class PaymentsProcessorTest {
         paymentsProcessor.processPayments(envelope, CCD_REFERENCE, true);
 
         // then
-        verify(paymentsPublisher, never()).publishPayments(any());
+        verify(paymentsPublisher, never()).send(any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessorTest.java
@@ -42,20 +42,20 @@ class PaymentsProcessorTest {
             emptyList(),
             emptyList()
         );
-        ArgumentCaptor<CreatePaymentsCommand> paymentsDataCaptor = ArgumentCaptor.forClass(CreatePaymentsCommand.class);
+        ArgumentCaptor<CreatePaymentsCommand> cmdCaptor = ArgumentCaptor.forClass(CreatePaymentsCommand.class);
 
         // when
         paymentsProcessor.processPayments(envelope, CCD_REFERENCE, true);
 
         // then
-        verify(paymentsPublisher).send(paymentsDataCaptor.capture());
-        CreatePaymentsCommand createPaymentsCommand = paymentsDataCaptor.getValue();
-        assertThat(createPaymentsCommand.ccdReference).isEqualTo(Long.toString(CCD_REFERENCE));
-        assertThat(createPaymentsCommand.jurisdiction).isEqualTo(envelope.jurisdiction);
-        assertThat(createPaymentsCommand.poBox).isEqualTo(envelope.poBox);
-        assertThat(createPaymentsCommand.isExceptionRecord).isTrue();
-        assertThat(createPaymentsCommand.payments.size()).isEqualTo(envelope.payments.size());
-        assertThat(createPaymentsCommand.payments.get(0).documentControlNumber)
+        verify(paymentsPublisher).send(cmdCaptor.capture());
+        CreatePaymentsCommand cmd = cmdCaptor.getValue();
+        assertThat(cmd.ccdReference).isEqualTo(Long.toString(CCD_REFERENCE));
+        assertThat(cmd.jurisdiction).isEqualTo(envelope.jurisdiction);
+        assertThat(cmd.poBox).isEqualTo(envelope.poBox);
+        assertThat(cmd.isExceptionRecord).isTrue();
+        assertThat(cmd.payments.size()).isEqualTo(envelope.payments.size());
+        assertThat(cmd.payments.get(0).documentControlNumber)
             .isEqualTo(envelope.payments.get(0).documentControlNumber);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/PaymentsPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/PaymentsPublisherTest.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
+@SuppressWarnings("checkstyle:LineLength")
 @ExtendWith(MockitoExtension.class)
 class PaymentsPublisherTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/PaymentsPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/PaymentsPublisherTest.java
@@ -13,10 +13,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.Labels;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.PaymentsPublisher;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.PaymentsPublishingException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.CreatePaymentsCommand;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.PaymentData;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.PaymentsData;
 
 import java.time.Instant;
 
@@ -49,13 +50,13 @@ class PaymentsPublisherTest {
 
     @ParameterizedTest
     @MethodSource("getIsExceptionRecord")
-    void notify_should_send_message_with_right_content(boolean isExceptionRecord) throws Exception {
+    void sending_create_command_should_send_message_with_right_content(boolean isExceptionRecord) throws Exception {
         // given
-        PaymentsData paymentsData = getPaymentsData(isExceptionRecord);
+        CreatePaymentsCommand cmd = getCreatePaymentsCommand(isExceptionRecord);
         Instant startTime = Instant.now();
 
         // when
-        paymentsPublisher.publishPayments(paymentsData);
+        paymentsPublisher.send(cmd);
 
         // then
         ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
@@ -67,51 +68,52 @@ class PaymentsPublisherTest {
 
         Message message = messageCaptor.getValue();
 
-        assertThat(message.getMessageId()).isEqualTo(paymentsData.ccdReference);
+        assertThat(message.getMessageId()).isEqualTo(cmd.ccdReference);
         assertThat(message.getContentType()).isEqualTo("application/json");
+        assertThat(message.getLabel()).isEqualTo(Labels.CREATE);
 
         String messageBodyJson = new String(MessageBodyRetriever.getBinaryData(message.getMessageBody()));
         String expectedMessageBodyJson = String.format(
             "{\"ccd_reference\":\"%s\", \"jurisdiction\":\"%s\", \"service\":\"%s\", \"po_box\":\"%s\", "
                 + "\"is_exception_record\":%s, "
                 + "\"payments\":[{\"document_control_number\":\"%s\"}]}",
-            paymentsData.ccdReference,
-            paymentsData.jurisdiction,
-            paymentsData.service,
-            paymentsData.poBox,
-            Boolean.toString(paymentsData.isExceptionRecord),
-            paymentsData.payments.get(0).documentControlNumber
+            cmd.ccdReference,
+            cmd.jurisdiction,
+            cmd.service,
+            cmd.poBox,
+            Boolean.toString(cmd.isExceptionRecord),
+            cmd.payments.get(0).documentControlNumber
         );
         JSONAssert.assertEquals(expectedMessageBodyJson, messageBodyJson, JSONCompareMode.LENIENT);
     }
 
     @ParameterizedTest
     @MethodSource("getIsExceptionRecord")
-    void notify_should_throw_exception_when_queue_client_fails(boolean isExceptionRecord) throws Exception {
-        PaymentsData paymentsData = getPaymentsData(isExceptionRecord);
+    void sending_create_command_should_throw_exception_when_queue_client_fails(boolean isExceptionRecord) throws Exception {
+        CreatePaymentsCommand cmd = getCreatePaymentsCommand(isExceptionRecord);
 
         ServiceBusException exceptionToThrow = new ServiceBusException(true, "test exception");
         willThrow(exceptionToThrow).given(queueClient).scheduleMessage(any(), any());
 
-        assertThatThrownBy(() -> paymentsPublisher.publishPayments(paymentsData))
+        assertThatThrownBy(() -> paymentsPublisher.send(cmd))
             .isInstanceOf(PaymentsPublishingException.class)
             .hasMessage(
                 String.format(
                     "An error occurred when trying to publish payments for CCD Ref %s",
-                    paymentsData.ccdReference
+                    cmd.ccdReference
                 )
             )
             .hasCause(exceptionToThrow);
     }
 
-    private PaymentsData getPaymentsData(boolean isExceptionRecord) {
-        return new PaymentsData(
-                Long.toString(10L),
-                "jurisdiction",
-                "service",
-                "pobox",
-                isExceptionRecord,
-                asList(new PaymentData("dcn1"))
-            );
+    private CreatePaymentsCommand getCreatePaymentsCommand(boolean isExceptionRecord) {
+        return new CreatePaymentsCommand(
+            Long.toString(10L),
+            "jurisdiction",
+            "service",
+            "pobox",
+            isExceptionRecord,
+            asList(new PaymentData("dcn1"))
+        );
     }
 }


### PR DESCRIPTION
- rename queue model (as there will soon be a new one, used for updates) to `CreatePaymentsCommand`
- set label on the queue message: `"CREATE"`

I went with `XxxCommand` convention, feel free to suggest alternatives.

In next PR I plan to add a new model `UpdatePaymentsCommand` and a new label: `"UPDATE"`.
The service class will also have a new method for sending this command.