### PR TITLE
Use event id from transformation endpoint as it is service specific

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
@@ -31,6 +31,9 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.doma
 @IntegrationTest
 class CreateCaseCallbackTest {
 
+    // event id used for service specific case creation
+    private static final String EVENT_ID = "createCase";
+
     private static final String IDAM_TOKEN = "idam-token";
     private static final String USER_ID = "user-id";
 
@@ -131,7 +134,7 @@ class CreateCaseCallbackTest {
                 "/caseworkers/"
                     + USER_ID
                     + "/jurisdictions/BULKSCAN/case-types/123/event-triggers/"
-                    + EVENT_ID_CREATE_NEW_CASE
+                    + EVENT_ID
                     + "/token"
             )
             .withHeader("ServiceAuthorization", containing("Bearer"))

--- a/src/integrationTest/resources/ccd/callback/transformation-client/response/ok-no-warnings.json
+++ b/src/integrationTest/resources/ccd/callback/transformation-client/response/ok-no-warnings.json
@@ -1,7 +1,7 @@
 {
   "case_creation_details": {
     "case_type_id": "123",
-    "event_id": "createNewCase",
+    "event_id": "createCase",
     "case_data": {}
   },
   "warnings": []

--- a/src/integrationTest/resources/ccd/callback/transformation-client/response/ok-with-warnings.json
+++ b/src/integrationTest/resources/ccd/callback/transformation-client/response/ok-with-warnings.json
@@ -1,7 +1,7 @@
 {
   "case_creation_details": {
     "case_type_id": "123",
-    "event_id": "createNewCase",
+    "event_id": "createCase",
     "case_data": {}
   },
   "warnings": [

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -33,7 +33,6 @@ import java.util.function.Function;
 import static java.util.Collections.emptyList;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasServiceNameInCaseTypeId;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.EVENT_ID_CREATE_NEW_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.isCreateNewCaseEvent;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.CASE_REFERENCE;
 
@@ -201,7 +200,8 @@ public class CreateCaseCallbackService {
             userId,
             jurisdiction,
             caseCreationDetails.caseTypeId,
-            EVENT_ID_CREATE_NEW_CASE
+            // when onboarding remind services to not configure about to submit callback for this event
+            caseCreationDetails.eventId
         );
 
         return ccdApi.submitForCaseworker(


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create case: add endpoint to orchestrator](https://tools.hmcts.net/jira/browse/BPS-741)

### Change description ###

Use eventId for CCD which is returned from transformation as it is service specific

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
