### PR TITLE
Simplify 'create case' service

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
@@ -61,7 +61,7 @@ class CreateCaseCallbackTest {
             .statusCode(OK.value())
             .body("errors", contains("Event " + EVENT_ID_CREATE_NEW_CASE + " not allowed "
                 + "for the current journey classification " + NEW_APPLICATION.name() + " without OCR"))
-            .body("warnings", nullValue())
+            .body("warnings", empty())
             .body("data", nullValue());
     }
 
@@ -71,7 +71,7 @@ class CreateCaseCallbackTest {
             .statusCode(OK.value())
             .body("errors", contains("Event " + EVENT_ID_CREATE_NEW_CASE + " not allowed "
                 + "for the current journey classification " + EXCEPTION.name() + " without OCR"))
-            .body("warnings", nullValue())
+            .body("warnings", empty())
             .body("data", nullValue());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/CaseTransformationException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/CaseTransformationException.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpStatusCodeException;
 
-public class CaseTransformationException extends Exception {
+public class CaseTransformationException extends RuntimeException {
 
     private static final long serialVersionUID = 8081182548244205380L;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.in.CcdCallbackRequest;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.AttachCaseCallbackService;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CreateCaseCallbackService;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.ProcessResult;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackResponse;
@@ -62,16 +63,13 @@ public class CcdCallbackController {
         @RequestHeader(value = USER_ID, required = false) String userId
     ) {
         if (callbackRequest != null && callbackRequest.getCaseDetails() != null) {
-            return createCaseCallbackService
-                .process(callbackRequest, idamToken, userId)
-                .map(result -> AboutToStartOrSubmitCallbackResponse
+            ProcessResult result = createCaseCallbackService.process(callbackRequest, idamToken, userId);
+            return AboutToStartOrSubmitCallbackResponse
                     .builder()
                     .data(result.getModifiedFields())
                     .warnings(result.getWarnings())
                     .errors(result.getErrors())
-                    .build()
-                )
-                .getOrElseGet(this::errorResponse);
+                    .build();
         } else {
             return errorResponse(ImmutableList.of("Internal Error: callback or case details were empty"));
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.vavr.control.Validation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.InvalidCaseDataException;
@@ -108,7 +109,11 @@ public class CreateCaseCallbackService {
                     } catch (ServiceNotConfiguredException exc) {
                         return new ProcessResult(emptyList(), singletonList(exc.getMessage()));
                     } catch (InvalidCaseDataException exc) {
-                        return new ProcessResult(exc.getResponse().warnings, exc.getResponse().errors);
+                        if (exc.getStatus() == HttpStatus.BAD_REQUEST) {
+                            throw exc;
+                        } else {
+                            return new ProcessResult(exc.getResponse().warnings, exc.getResponse().errors);
+                        }
                     } catch (Exception exc) {
                         log.error("Error handling event", exc);
                         return new ProcessResult(emptyList(), singletonList("Internal error"));

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -61,9 +61,9 @@ public class CreateCaseCallbackService {
         String idamToken,
         String userId
     ) {
-        Validation<String, Void> event = isCreateNewCaseEvent(request.getEventId());
-        if (event.isInvalid()) {
-            return new ProcessResult(emptyList(), singletonList(event.getError()));
+        Validation<String, Void> eventValidation = isCreateNewCaseEvent(request.getEventId());
+        if (eventValidation.isInvalid()) {
+            return new ProcessResult(emptyList(), singletonList(eventValidation.getError()));
         } else {
             return hasServiceNameInCaseTypeId(request.getCaseDetails())
                 .map(serviceName -> {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -81,14 +81,21 @@ public class CreateCaseCallbackService {
                                             exceptionRecord,
                                             s2sTokenGenerator.generate()
                                         );
-                                    long newCaseId = createNewCaseInCcd(
-                                        idamToken,
-                                        userId,
-                                        exceptionRecord.poBoxJurisdiction,
-                                        transformationResp.caseCreationDetails,
-                                        request.getCaseDetails().getId().toString()
-                                    );
-                                    return new ProcessResult(ImmutableMap.of(CASE_REFERENCE, Long.toString(newCaseId)));
+                                    if (!transformationResp.warnings.isEmpty() && !request.isIgnoreWarnings()) {
+                                        return new ProcessResult(transformationResp.warnings, emptyList());
+                                    } else {
+                                        long newCaseId = createNewCaseInCcd(
+                                            idamToken,
+                                            userId,
+                                            exceptionRecord.poBoxJurisdiction,
+                                            transformationResp.caseCreationDetails,
+                                            request.getCaseDetails().getId().toString()
+                                        );
+                                        return new ProcessResult(ImmutableMap.of(
+                                            CASE_REFERENCE,
+                                            Long.toString(newCaseId)
+                                        ));
+                                    }
                                 })
                                 .getOrElseGet(errors -> new ProcessResult(emptyList(), errors.asJava()));
                         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
@@ -24,7 +24,7 @@ public class ProcessResult {
     }
 
     public ProcessResult(List<String> warnings, List<String> errors) {
-        this.modifiedFields = emptyMap();
+        this.modifiedFields = null;
         this.warnings = warnings;
         this.errors = errors;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 
 /**
  * Data model representing objects used in drafting a response to a callback request.

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/PaymentsPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/PaymentsPublisher.java
@@ -36,17 +36,23 @@ public class PaymentsPublisher implements IPaymentsPublisher {
     @Override
     public void send(PaymentCommand cmd) {
         try {
+            final String messageContent = objectMapper.writeValueAsString(cmd);
+
             IMessage message = new Message(
                 UUID.randomUUID().toString(),
-                objectMapper.writeValueAsString(cmd),
+                messageContent,
                 APPLICATION_JSON.toString()
             );
             message.setLabel(cmd.getLabel());
 
             queueClient.scheduleMessage(message, Instant.now().plusSeconds(10));
 
-            LOG.info("Sent message to payments queue. ID: {}, Label: {}", message.getMessageId(), message.getLabel());
-
+            LOG.info(
+                "Sent message to payments queue. ID: {}, Label: {}, Content: {}",
+                message.getMessageId(),
+                message.getLabel(),
+                messageContent
+            );
         } catch (Exception ex) {
             throw new PaymentsPublishingException(
                 "An error occurred when trying to publish message to payments queue.",

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.vavr.control.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +28,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
@@ -82,14 +80,14 @@ class CreateCaseCallbackServiceTest {
 
     @Test
     void should_not_allow_to_process_callback_in_case_wrong_event_id_is_received() {
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             "some event",
             null,
             true
         ), IDAM_TOKEN, USER_ID);
 
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("The some event event is not supported. Please contact service team");
+        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getErrors()).containsOnly("The some event event is not supported. Please contact service team");
         verify(serviceConfigProvider, never()).getConfig(anyString());
     }
 
@@ -99,14 +97,14 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.id(1L));
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("No case type ID supplied");
+        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getErrors()).containsOnly("No case type ID supplied");
         verify(serviceConfigProvider, never()).getConfig(anyString());
     }
 
@@ -116,15 +114,15 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.caseTypeId(""));
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("Case type ID () has invalid format");
+        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getErrors()).containsOnly("Case type ID () has invalid format");
         verify(serviceConfigProvider, never()).getConfig(anyString());
     }
 
@@ -135,15 +133,15 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.caseTypeId(CASE_TYPE_ID));
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("oh no");
+        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getErrors()).containsOnly("oh no");
     }
 
     @Test
@@ -153,15 +151,15 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.caseTypeId(CASE_TYPE_ID));
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("Transformation URL is not configured");
+        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getErrors()).containsOnly("Transformation URL is not configured");
     }
 
     @Test
@@ -187,15 +185,15 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("Event " + EVENT_ID_CREATE_NEW_CASE
+        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getErrors()).containsOnly("Event " + EVENT_ID_CREATE_NEW_CASE
             + " not allowed for the current journey classification "
             + NEW_APPLICATION.name()
             + " without OCR"
@@ -225,15 +223,15 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("Event "
+        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getErrors()).containsOnly("Event "
             + EVENT_ID_CREATE_NEW_CASE
             + " not allowed for the current journey classification "
             + SUPPLEMENTARY_EVIDENCE.name()
@@ -272,17 +270,16 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isRight()).isTrue();
-        assertThat(output.get().getModifiedFields()).isEmpty();
-        assertThat(output.get().getWarnings()).containsOnly("warning");
-        assertThat(output.get().getErrors()).containsOnly("error");
+        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getWarnings()).containsOnly("warning");
+        assertThat(output.getErrors()).containsOnly("error");
     }
 
     @Test
@@ -306,15 +303,15 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("Missing journeyClassification");
+        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getErrors()).containsOnly("Missing journeyClassification");
     }
 
     @Test
@@ -339,13 +336,13 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
-        assertThat(output.getLeft()).containsOnly(
+        assertThat(output.getErrors()).containsOnly(
             "Invalid journeyClassification. Error: No enum constant " + Classification.class.getName() + ".EXCEPTIONS"
         );
     }
@@ -384,13 +381,13 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
-        assertThat(output.getLeft()).containsOnly(
+        assertThat(output.getErrors()).containsOnly(
             "Invalid scannedDocuments format. Error: No enum constant " + DocumentType.class.getName() + ".OTHERS"
         );
     }
@@ -434,7 +431,7 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
@@ -442,7 +439,7 @@ class CreateCaseCallbackServiceTest {
 
         String match =
             "Invalid OCR data format. Error: (class )?java.lang.Integer cannot be cast to (class )?java.lang.String.*";
-        assertThat(output.getLeft())
+        assertThat(output.getErrors())
             .hasSize(1)
             .element(0)
             .asString()
@@ -471,14 +468,14 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult output = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         String match = "Missing Form Type";
-        assertThat(output.getLeft())
+        assertThat(output.getErrors())
             .hasSize(1)
             .element(0)
             .asString()

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -44,6 +44,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.doma
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.NEW_APPLICATION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE;
 
+@SuppressWarnings("checkstyle:LineLength")
 @ExtendWith(MockitoExtension.class)
 class CreateCaseCallbackServiceTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -87,7 +87,7 @@ class CreateCaseCallbackServiceTest {
             true
         ), IDAM_TOKEN, USER_ID);
 
-        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getModifiedFields()).isNull();
         assertThat(output.getErrors()).containsOnly("The some event event is not supported. Please contact service team");
         verify(serviceConfigProvider, never()).getConfig(anyString());
     }
@@ -104,7 +104,7 @@ class CreateCaseCallbackServiceTest {
             true
         ), IDAM_TOKEN, USER_ID);
 
-        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getModifiedFields()).isNull();
         assertThat(output.getErrors()).containsOnly("No case type ID supplied");
         verify(serviceConfigProvider, never()).getConfig(anyString());
     }
@@ -122,7 +122,7 @@ class CreateCaseCallbackServiceTest {
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getModifiedFields()).isNull();
         assertThat(output.getErrors()).containsOnly("Case type ID () has invalid format");
         verify(serviceConfigProvider, never()).getConfig(anyString());
     }
@@ -141,7 +141,7 @@ class CreateCaseCallbackServiceTest {
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getModifiedFields()).isNull();
         assertThat(output.getErrors()).containsOnly("oh no");
     }
 
@@ -159,7 +159,7 @@ class CreateCaseCallbackServiceTest {
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getModifiedFields()).isNull();
         assertThat(output.getErrors()).containsOnly("Transformation URL is not configured");
     }
 
@@ -193,7 +193,7 @@ class CreateCaseCallbackServiceTest {
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getModifiedFields()).isNull();
         assertThat(output.getErrors()).containsOnly("Event " + EVENT_ID_CREATE_NEW_CASE
             + " not allowed for the current journey classification "
             + NEW_APPLICATION.name()
@@ -231,7 +231,7 @@ class CreateCaseCallbackServiceTest {
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getModifiedFields()).isNull();
         assertThat(output.getErrors()).containsOnly("Event "
             + EVENT_ID_CREATE_NEW_CASE
             + " not allowed for the current journey classification "
@@ -278,7 +278,7 @@ class CreateCaseCallbackServiceTest {
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getModifiedFields()).isNull();
         assertThat(output.getWarnings()).containsOnly("warning");
         assertThat(output.getErrors()).containsOnly("error");
     }
@@ -311,7 +311,7 @@ class CreateCaseCallbackServiceTest {
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.getModifiedFields()).isEmpty();
+        assertThat(output.getModifiedFields()).isNull();
         assertThat(output.getErrors()).containsOnly("Missing journeyClassification");
     }
 


### PR DESCRIPTION
Service used to return `Either<List<String>, ProcessResult>` which is list of errors or result which can also have errors...

Also avoiding obscure methods and types that are result of calling them, like
```
Validation<Seq<Seq<String>>, Validation<Seq<String>, ProcessResult>>
```

Separated calling transformation from creating case in ccd.

Retrieving transformation is now done once, twice before (which was easy to miss)