### PR TITLE
Simplify create case callback service signature

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.collection.IsMapWithSize.anEmptyMap;
 import static org.springframework.http.HttpStatus.OK;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.EVENT_ID_CREATE_NEW_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.EXCEPTION;
@@ -61,8 +61,8 @@ class CreateCaseCallbackTest {
             .statusCode(OK.value())
             .body("errors", contains("Event " + EVENT_ID_CREATE_NEW_CASE + " not allowed "
                 + "for the current journey classification " + NEW_APPLICATION.name() + " without OCR"))
-            .body("warnings", nullValue())
-            .body("data", nullValue());
+            .body("warnings", empty())
+            .body("data", anEmptyMap());
     }
 
     @Test
@@ -71,8 +71,8 @@ class CreateCaseCallbackTest {
             .statusCode(OK.value())
             .body("errors", contains("Event " + EVENT_ID_CREATE_NEW_CASE + " not allowed "
                 + "for the current journey classification " + EXCEPTION.name() + " without OCR"))
-            .body("warnings", nullValue())
-            .body("data", nullValue());
+            .body("warnings", empty())
+            .body("data.", anEmptyMap());
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.in.CcdCallbackRequest;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.AttachCaseCallbackService;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CreateCaseCallbackService;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.ProcessResult;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackResponse;
@@ -62,16 +63,14 @@ public class CcdCallbackController {
         @RequestHeader(value = USER_ID, required = false) String userId
     ) {
         if (callbackRequest != null && callbackRequest.getCaseDetails() != null) {
-            return createCaseCallbackService
-                .process(callbackRequest, idamToken, userId)
-                .map(result -> AboutToStartOrSubmitCallbackResponse
-                    .builder()
-                    .data(result.getModifiedFields())
-                    .warnings(result.getWarnings())
-                    .errors(result.getErrors())
-                    .build()
-                )
-                .getOrElseGet(this::errorResponse);
+            ProcessResult result = createCaseCallbackService.process(callbackRequest, idamToken, userId);
+
+            return AboutToStartOrSubmitCallbackResponse
+                .builder()
+                .data(result.getModifiedFields())
+                .warnings(result.getWarnings())
+                .errors(result.getErrors())
+                .build();
         } else {
             return errorResponse(ImmutableList.of("Internal Error: callback or case details were empty"));
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -4,7 +4,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import io.vavr.collection.Array;
 import io.vavr.collection.Seq;
-import io.vavr.control.Either;
 import io.vavr.control.Try;
 import io.vavr.control.Validation;
 import org.slf4j.Logger;
@@ -35,7 +34,6 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasServiceNameInCaseTypeId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.isCreateNewCaseEvent;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.CASE_REFERENCE;
-
 
 @Service
 public class CreateCaseCallbackService {
@@ -82,8 +80,7 @@ public class CreateCaseCallbackService {
                 ))
                 .mapError(errors -> errors.flatMap(Function.identity()))
                 .flatMap(Function.identity())
-                .toEither()
-                .mapLeft(Seq::asJava)
+                .mapError(Seq::asJava)
             )
             .getOrElseGet(errors -> new ProcessResult(emptyList(), errors));
 
@@ -98,7 +95,7 @@ public class CreateCaseCallbackService {
         return result;
     }
 
-    private Either<List<String>, Void> assertAllowToAccess(CaseDetails caseDetails, String eventId) {
+    private Validation<List<String>, Void> assertAllowToAccess(CaseDetails caseDetails, String eventId) {
         return validator.mandatoryPrerequisites(
             () -> isCreateNewCaseEvent(eventId),
             () -> getServiceConfig(caseDetails).map(item -> null)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback;
 
 import io.vavr.collection.Array;
 import io.vavr.collection.Seq;
-import io.vavr.control.Either;
 import io.vavr.control.Try;
 import io.vavr.control.Validation;
 import org.slf4j.Logger;
@@ -52,7 +51,7 @@ public class CreateCaseValidator {
      * @return Either singleton list of errors or green pass to proceed further
      */
     @SafeVarargs
-    public final Either<List<String>, Void> mandatoryPrerequisites(
+    public final Validation<List<String>, Void> mandatoryPrerequisites(
         Supplier<Validation<String, Void>>... prerequisites
     ) {
         for (Supplier<Validation<String, Void>> prerequisite : prerequisites) {
@@ -64,11 +63,11 @@ public class CreateCaseValidator {
                 });
 
             if (requirement.isInvalid()) {
-                return requirement.toEither();
+                return requirement;
             }
         }
 
-        return Either.right(null);
+        return Validation.valid(null);
     }
 
     public Validation<Seq<String>, ExceptionRecord> getValidation(CaseDetails caseDetails) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -164,8 +164,7 @@ class CreateCaseCallbackServiceTest {
     }
 
     @Test
-    void should_report_error_if_classification_new_application_with_documents_and_without_ocr_data()
-        throws IOException, CaseTransformationException {
+    void should_report_error_if_classification_new_application_with_documents_and_without_ocr_data() {
         // given
         setUpTransformationUrl();
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.vavr.control.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +28,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
@@ -82,14 +80,15 @@ class CreateCaseCallbackServiceTest {
 
     @Test
     void should_not_allow_to_process_callback_in_case_wrong_event_id_is_received() {
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             "some event",
             null,
             true
         ), IDAM_TOKEN, USER_ID);
 
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("The some event event is not supported. Please contact service team");
+        assertThat(result.getWarnings()).isEmpty();
+        assertThat(result.getErrors())
+            .containsOnly("The some event event is not supported. Please contact service team");
         verify(serviceConfigProvider, never()).getConfig(anyString());
     }
 
@@ -99,14 +98,14 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.id(1L));
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("No case type ID supplied");
+        assertThat(result.getWarnings()).isEmpty();
+        assertThat(result.getErrors()).containsOnly("No case type ID supplied");
         verify(serviceConfigProvider, never()).getConfig(anyString());
     }
 
@@ -116,15 +115,15 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.caseTypeId(""));
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("Case type ID () has invalid format");
+        assertThat(result.getWarnings()).isEmpty();
+        assertThat(result.getErrors()).containsOnly("Case type ID () has invalid format");
         verify(serviceConfigProvider, never()).getConfig(anyString());
     }
 
@@ -135,15 +134,15 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.caseTypeId(CASE_TYPE_ID));
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("oh no");
+        assertThat(result.getWarnings()).isEmpty();
+        assertThat(result.getErrors()).containsOnly("oh no");
     }
 
     @Test
@@ -153,15 +152,15 @@ class CreateCaseCallbackServiceTest {
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder.caseTypeId(CASE_TYPE_ID));
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("Transformation URL is not configured");
+        assertThat(result.getWarnings()).isEmpty();
+        assertThat(result.getErrors()).containsOnly("Transformation URL is not configured");
     }
 
     @Test
@@ -187,15 +186,15 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("Event " + EVENT_ID_CREATE_NEW_CASE
+        assertThat(result.getWarnings()).isEmpty();
+        assertThat(result.getErrors()).containsOnly("Event " + EVENT_ID_CREATE_NEW_CASE
             + " not allowed for the current journey classification "
             + NEW_APPLICATION.name()
             + " without OCR"
@@ -225,15 +224,15 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("Event "
+        assertThat(result.getWarnings()).isEmpty();
+        assertThat(result.getErrors()).containsOnly("Event "
             + EVENT_ID_CREATE_NEW_CASE
             + " not allowed for the current journey classification "
             + SUPPLEMENTARY_EVIDENCE.name()
@@ -272,17 +271,16 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isRight()).isTrue();
-        assertThat(output.get().getModifiedFields()).isEmpty();
-        assertThat(output.get().getWarnings()).containsOnly("warning");
-        assertThat(output.get().getErrors()).containsOnly("error");
+        assertThat(result.getModifiedFields()).isEmpty();
+        assertThat(result.getWarnings()).containsOnly("warning");
+        assertThat(result.getErrors()).containsOnly("error");
     }
 
     @Test
@@ -306,15 +304,15 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(output.isLeft()).isTrue();
-        assertThat(output.getLeft()).containsOnly("Missing journeyClassification");
+        assertThat(result.getWarnings()).isEmpty();
+        assertThat(result.getErrors()).containsOnly("Missing journeyClassification");
     }
 
     @Test
@@ -339,13 +337,13 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
-        assertThat(output.getLeft()).containsOnly(
+        assertThat(result.getErrors()).containsOnly(
             "Invalid journeyClassification. Error: No enum constant " + Classification.class.getName() + ".EXCEPTIONS"
         );
     }
@@ -384,13 +382,13 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
-        assertThat(output.getLeft()).containsOnly(
+        assertThat(result.getErrors()).containsOnly(
             "Invalid scannedDocuments format. Error: No enum constant " + DocumentType.class.getName() + ".OTHERS"
         );
     }
@@ -434,7 +432,7 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
@@ -442,7 +440,7 @@ class CreateCaseCallbackServiceTest {
 
         String match =
             "Invalid OCR data format. Error: (class )?java.lang.Integer cannot be cast to (class )?java.lang.String.*";
-        assertThat(output.getLeft())
+        assertThat(result.getErrors())
             .hasSize(1)
             .element(0)
             .asString()
@@ -471,14 +469,14 @@ class CreateCaseCallbackServiceTest {
         );
 
         // when
-        Either<List<String>, ProcessResult> output = service.process(new CcdCallbackRequest(
+        ProcessResult result = service.process(new CcdCallbackRequest(
             EVENT_ID_CREATE_NEW_CASE,
             caseDetails,
             true
         ), IDAM_TOKEN, USER_ID);
 
         String match = "Missing Form Type";
-        assertThat(output.getLeft())
+        assertThat(result.getErrors())
             .hasSize(1)
             .element(0)
             .asString()


### PR DESCRIPTION
### Change description ###

The idea looks like partially applied from #654. This PR meant to address the signature as wrapping with `Either<ListOfSomething, ProcessResult>` became really irrelevant.

What we benefit here?

- straight-forward conversion to response object for ccd
- logging is more to the topic
  - if error - error
  - if warning - warning

There could be more verbose things happening if we try to move away from vavr but ideally would keep it separately as it tends to blow. Plus there are still "tiny" validations should come in shortly:

- must have at least one scanned document
- make sure idam token and user id are not empty

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
