### PR TITLE
Clear warnings after case creation from exception record

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
@@ -95,7 +95,7 @@ class CreateCaseTest {
     @Test
     public void should_clear_exception_record_warnings() throws Exception {
         // given
-        CaseDetails exceptionRecord = createExceptionRecord("new-application-with-ocr-data-warnings.json");
+        CaseDetails exceptionRecord = createExceptionRecord("envelopes/new-application-with-ocr-data-warnings.json");
 
         // warnings are present
         assertThat(exceptionRecord).isNotNull();

--- a/src/functionalTest/resources/envelopes/new-application-with-ocr-data-warnings.json
+++ b/src/functionalTest/resources/envelopes/new-application-with-ocr-data-warnings.json
@@ -1,0 +1,40 @@
+{
+  "id": "{ENVELOPE_ID}",
+  "case_ref": "",
+  "po_box": "BULKSCAN PO BOX",
+  "jurisdiction": "BULKSCAN",
+  "container": "bulkscan",
+  "formType": "B123",
+  "classification": "NEW_APPLICATION",
+  "zip_file_name": "zip-file-test-1.zip",
+  "delivery_date": "1970-01-02T00:00:00.000Z",
+  "opening_date": "1970-01-03T00:00:00.000Z",
+  "documents": [
+    {
+      "file_name": "certificate2.pdf",
+      "control_number": "154565879",
+      "type": "other",
+      "subtype": null,
+      "scanned_at": "2018-02-01T10:30:00.000Z",
+      "uuid": "ee69aee8-1a33-40dd-9af9-d90da1b105cb"
+    }
+  ],
+  "ocr_data": [
+    {
+      "metadata_field_name": "first_name",
+      "metadata_field_value": "value1"
+    },
+    {
+      "metadata_field_name": "last_name",
+      "metadata_field_value": "value2"
+    },
+    {
+      "metadata_field_name": "email",
+      "metadata_field_value": "hello@test.com"
+    }
+  ],
+  "ocr_data_validation_warnings": [
+    "warning 1",
+    "warning 2"
+  ]
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
@@ -52,7 +52,9 @@ class CreateCaseCallbackTest {
             .statusCode(OK.value())
             .body("errors", empty())
             .body("warnings", empty())
-            .body("data.caseReference", equalTo("1539007368674134")); // from sample-case.json
+            .body("data.caseReference", equalTo("1539007368674134")) // from sample-case.json
+            .body("data.displayWarnings", equalTo("No"))
+            .body("data.ocrDataValidationWarnings", empty());
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.in.CcdCallbackRequest;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CreateCaseValidator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.ProcessResult;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.YesNoFieldValues;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.config.ServiceConfigProvider;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
@@ -35,6 +36,8 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasServiceNameInCaseTypeId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.isCreateNewCaseEvent;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.CASE_REFERENCE;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.DISPLAY_WARNINGS;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.OCR_DATA_VALIDATION_WARNINGS;
 
 
 @Service
@@ -162,9 +165,15 @@ public class CreateCaseCallbackService {
                 caseIdAsString
             );
 
-            return Validation.valid(new ProcessResult(
-                ImmutableMap.of(CASE_REFERENCE, Long.toString(newCaseId))
-            ));
+            return Validation.valid(
+                new ProcessResult(
+                    ImmutableMap.<String, Object>builder()
+                        .put(CASE_REFERENCE, Long.toString(newCaseId))
+                        .put(DISPLAY_WARNINGS, YesNoFieldValues.NO)
+                        .put(OCR_DATA_VALIDATION_WARNINGS, emptyList())
+                        .build()
+                )
+            );
         } catch (InvalidCaseDataException exception) {
             if (BAD_REQUEST.equals(exception.getStatus())) {
                 throw exception;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/definition/ExceptionRecordFields.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/definition/ExceptionRecordFields.java
@@ -11,6 +11,8 @@ public final class ExceptionRecordFields {
     public static final String SCANNED_DOCUMENTS = "scannedDocuments";
     public static final String EVIDENCE_HANDLED = "evidenceHandled";
     public static final String CASE_REFERENCE = "caseReference";
+    public static final String DISPLAY_WARNINGS = "displayWarnings";
+    public static final String OCR_DATA_VALIDATION_WARNINGS = "ocrDataValidationWarnings";
 
     private ExceptionRecordFields() {
         // hiding the constructor


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-758

### Change description ###

Clear warnings in exception records when the case was successfully created from it.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
