### PR TITLE
Simplify service method - no need to flatmap at all

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -90,11 +90,19 @@ public class CreateCaseCallbackService {
             .getOrElseGet(errors -> new ProcessResult(emptyList(), errors));
 
         if (!result.getWarnings().isEmpty()) {
-            log.warn("Warnings found during callback process:\n  - {}", String.join("\n  - ", result.getWarnings()));
+            log.warn(
+                "Warnings found for {} during callback process:\n  - {}",
+                serviceConfigItem.getService(),
+                String.join("\n  - ", result.getWarnings())
+            );
         }
 
         if (!result.getErrors().isEmpty()) {
-            log.error("Errors found during callback process:\n  - {}", String.join("\n  - ", result.getErrors()));
+            log.error(
+                "Errors found for {} during callback process:\n  - {}",
+                serviceConfigItem.getService(),
+                String.join("\n  - ", result.getErrors())
+            );
         }
 
         return result;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import io.vavr.collection.Array;
 import io.vavr.collection.Seq;
 import io.vavr.control.Try;
 import io.vavr.control.Validation;
@@ -26,8 +25,6 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
-
-import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -76,19 +73,19 @@ public class CreateCaseCallbackService {
             return new ProcessResult(emptyList(), singletonList(canAccess.getError()));
         }
 
+        // already validated in mandatory section ^
+        ServiceConfigItem serviceConfigItem = getServiceConfig(request.getCaseDetails()).get();
+
         ProcessResult result = validator
             .getValidation(request.getCaseDetails())
-            .combine(getServiceConfig(request.getCaseDetails()).mapError(Array::of))
-            .ap((exceptionRecord, configItem) -> createNewCase(
+            .map(exceptionRecord -> createNewCase(
                 exceptionRecord,
-                configItem,
+                serviceConfigItem,
                 request.getCaseDetails().getId(),
                 request.isIgnoreWarnings(),
                 idamToken,
                 userId
             ))
-            .mapError(errors -> errors.flatMap(Function.identity()))
-            .flatMap(Function.identity())
             .mapError(Seq::asJava)
             .getOrElseGet(errors -> new ProcessResult(emptyList(), errors));
 
@@ -120,7 +117,7 @@ public class CreateCaseCallbackService {
             .getOrElse(Validation.invalid("Transformation URL is not configured"));
     }
 
-    private Validation<Seq<String>, ProcessResult> createNewCase(
+    private ProcessResult createNewCase(
         ExceptionRecord exceptionRecord,
         ServiceConfigItem configItem,
         long caseId,
@@ -143,10 +140,7 @@ public class CreateCaseCallbackService {
 
             if (!ignoreWarnings && !transformationResponse.warnings.isEmpty()) {
                 // do not log warnings
-                return Validation.valid(new ProcessResult(
-                    transformationResponse.warnings,
-                    emptyList()
-                ));
+                return new ProcessResult(transformationResponse.warnings, emptyList());
             }
 
             log.info(
@@ -171,23 +165,18 @@ public class CreateCaseCallbackService {
                 caseIdAsString
             );
 
-            return Validation.valid(
-                new ProcessResult(
-                    ImmutableMap.<String, Object>builder()
-                        .put(CASE_REFERENCE, Long.toString(newCaseId))
-                        .put(DISPLAY_WARNINGS, YesNoFieldValues.NO)
-                        .put(OCR_DATA_VALIDATION_WARNINGS, emptyList())
-                        .build()
-                )
+            return new ProcessResult(
+                ImmutableMap.<String, Object>builder()
+                    .put(CASE_REFERENCE, Long.toString(newCaseId))
+                    .put(DISPLAY_WARNINGS, YesNoFieldValues.NO)
+                    .put(OCR_DATA_VALIDATION_WARNINGS, emptyList())
+                    .build()
             );
         } catch (InvalidCaseDataException exception) {
             if (BAD_REQUEST.equals(exception.getStatus())) {
                 throw exception;
             } else {
-                return Validation.valid(new ProcessResult(
-                    exception.getResponse().warnings,
-                    exception.getResponse().errors
-                ));
+                return new ProcessResult(exception.getResponse().warnings, exception.getResponse().errors);
             }
         } catch (Exception exception) {
             log.error(
@@ -197,7 +186,7 @@ public class CreateCaseCallbackService {
                 exception
             );
 
-            return Validation.invalid(Array.of("Internal error. " + exception.getMessage()));
+            return new ProcessResult(emptyList(), singletonList("Internal error. " + exception.getMessage()));
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.FORMATTER;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.getOcrData;
@@ -48,18 +47,18 @@ public class CreateCaseValidator {
      * Easy extension for more mandatory prerequisites - just flatmap next Validation.
      *
      * @param prerequisites Top level requirements failing fast
-     * @return Either singleton list of errors or green pass to proceed further
+     * @return Validation an error or green pass to proceed further
      */
     @SafeVarargs
-    public final Validation<List<String>, Void> mandatoryPrerequisites(
+    public final Validation<String, Void> mandatoryPrerequisites(
         Supplier<Validation<String, Void>>... prerequisites
     ) {
         for (Supplier<Validation<String, Void>> prerequisite : prerequisites) {
-            Validation<List<String>, Void> requirement = prerequisite.get()
+            Validation<String, Void> requirement = prerequisite.get()
                 .mapError(error -> {
-                    log.warn("Validation error {}", error);
+                    log.warn("Validation error: {}", error);
 
-                    return singletonList(error);
+                    return error;
                 });
 
             if (requirement.isInvalid()) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create case: add endpoint to orchestrator](https://tools.hmcts.net/jira/browse/BPS-741)

### Change description ###

Reducing the nesting of validations causing multiple flatmaps. The fact that service config is a mandatory prerequisite allows to extract and use directly in single `map` statement after initial validation. Job done how it is done before

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
