### PR TITLE
Include exception record ID in transformation

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClientTest.java
@@ -193,6 +193,7 @@ public class TransformationClientTest {
 
     private ExceptionRecord exceptionRecordRequestData() {
         return new ExceptionRecord(
+            "id",
             "some_case_type",
             "poBox",
             "BULKSCAN",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/request/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/request/ExceptionRecord.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 public class ExceptionRecord {
 
+    public final String id;
+
     @JsonProperty("case_type_id")
     public final String caseTypeId;
 
@@ -36,6 +38,7 @@ public class ExceptionRecord {
     public final List<OcrDataField> ocrDataFields;
 
     public ExceptionRecord(
+        String id,
         String caseTypeId,
         String poBox,
         String poBoxJurisdiction,
@@ -46,6 +49,7 @@ public class ExceptionRecord {
         List<ScannedDocument> scannedDocuments,
         List<OcrDataField> ocrDataFields
     ) {
+        this.id = id;
         this.caseTypeId = caseTypeId;
         this.poBox = poBox;
         this.poBoxJurisdiction = poBoxJurisdiction;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -104,7 +104,7 @@ public final class CallbackValidations {
     }
 
     @Nonnull
-    static Validation<String, Long> hasAnId(CaseDetails theCase) {
+    public static Validation<String, Long> hasAnId(CaseDetails theCase) {
         return theCase != null
             && theCase.getId() != null
             ? valid(theCase.getId())

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseValidator.java
@@ -26,6 +26,7 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.FORMATTER;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.getOcrData;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasAnId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasCaseTypeId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasDateField;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasFormType;
@@ -70,7 +71,7 @@ public class CreateCaseValidator {
     }
 
     public Validation<Seq<String>, ExceptionRecord> getValidation(CaseDetails caseDetails) {
-
+        Validation<String, Long> exceptionRecordIdValidation = hasAnId(caseDetails);
         Validation<String, String> caseTypeIdValidation = hasCaseTypeId(caseDetails);
         Validation<String, String> poBoxValidation = hasPoBox(caseDetails);
         Validation<String, String> jurisdictionValidation = hasJurisdiction(caseDetails);
@@ -82,6 +83,7 @@ public class CreateCaseValidator {
         Validation<String, List<OcrDataField>> ocrDataFieldsValidation = getOcrDataFields(caseDetails);
 
         Seq<Validation<String, ?>> validations = Array.of(
+            exceptionRecordIdValidation,
             caseTypeIdValidation,
             poBoxValidation,
             jurisdictionValidation,
@@ -96,6 +98,7 @@ public class CreateCaseValidator {
         Seq<String> errors = getValidationErrors(validations);
         if (errors.isEmpty()) {
             return Validation.valid(new ExceptionRecord(
+                Long.toString(exceptionRecordIdValidation.get()),
                 caseTypeIdValidation.get(),
                 poBoxValidation.get(),
                 jurisdictionValidation.get(),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -50,6 +50,7 @@ class CreateCaseCallbackServiceTest {
     private static final String IDAM_TOKEN = "idam-token";
     private static final String USER_ID = "user-id";
     private static final String SERVICE = "service";
+    private static final long CASE_ID = 123;
     private static final String CASE_TYPE_ID = SERVICE + "_ExceptionRecord";
     private static final CreateCaseValidator VALIDATOR = new CreateCaseValidator();
 
@@ -178,7 +179,7 @@ class CreateCaseCallbackServiceTest {
         data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
-            .id(1L)
+            .id(CASE_ID)
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)
@@ -216,7 +217,7 @@ class CreateCaseCallbackServiceTest {
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
-            .id(1L)
+            .id(CASE_ID)
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)
@@ -263,7 +264,7 @@ class CreateCaseCallbackServiceTest {
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
-            .id(1L)
+            .id(CASE_ID)
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)
@@ -297,6 +298,7 @@ class CreateCaseCallbackServiceTest {
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .id(CASE_ID)
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)
@@ -330,6 +332,7 @@ class CreateCaseCallbackServiceTest {
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("key", "value"));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .id(CASE_ID)
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)
@@ -375,6 +378,7 @@ class CreateCaseCallbackServiceTest {
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("key", "value"));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .id(CASE_ID)
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)
@@ -425,6 +429,7 @@ class CreateCaseCallbackServiceTest {
         ))));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .id(CASE_ID)
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)
@@ -462,6 +467,7 @@ class CreateCaseCallbackServiceTest {
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("key", "value"));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .id(CASE_ID)
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create case: add endpoint to orchestrator](https://tools.hmcts.net/jira/browse/BPS-741)

### Change description ###

Exception record is needed for references and for idempotency. Depends on these PRs:

- hmcts/bulk-scan-ccd-definitions#74
- hmcts/bulk-scan-ccd-event-handler-sample-app#83

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
