### PR TITLE
Remove 'service' property from payment update message

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/model/UpdatePaymentsCommand.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/model/UpdatePaymentsCommand.java
@@ -11,16 +11,21 @@ public class UpdatePaymentsCommand implements PaymentCommand {
     @JsonProperty("new_case_ref")
     public final String newCaseRef;
 
+    @JsonProperty("envelope_id")
+    public final String envelopeId;
+
     @JsonProperty("jurisdiction")
     public final String jurisdiction;
 
     public UpdatePaymentsCommand(
         String exceptionRecordRef,
         String newCaseRef,
+        String envelopeId,
         String jurisdiction
     ) {
         this.exceptionRecordRef = exceptionRecordRef;
         this.newCaseRef = newCaseRef;
+        this.envelopeId = envelopeId;
         this.jurisdiction = jurisdiction;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/model/UpdatePaymentsCommand.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/model/UpdatePaymentsCommand.java
@@ -11,26 +11,16 @@ public class UpdatePaymentsCommand implements PaymentCommand {
     @JsonProperty("new_case_ref")
     public final String newCaseRef;
 
-    @JsonProperty("envelope_id")
-    public final String envelopeId;
-
-    @JsonProperty("service")
-    public final String service;
-
     @JsonProperty("jurisdiction")
     public final String jurisdiction;
 
     public UpdatePaymentsCommand(
         String exceptionRecordRef,
         String newCaseRef,
-        String envelopeId,
-        String service,
         String jurisdiction
     ) {
         this.exceptionRecordRef = exceptionRecordRef;
         this.newCaseRef = newCaseRef;
-        this.envelopeId = envelopeId;
-        this.service = service;
         this.jurisdiction = jurisdiction;
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/PaymentsPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/PaymentsPublisherTest.java
@@ -112,8 +112,6 @@ class PaymentsPublisherTest {
             new UpdatePaymentsCommand(
                 "er-ref",
                 "new-case-ref",
-                "envelope-id",
-                "service",
                 "jurisdiction"
             );
 
@@ -133,8 +131,6 @@ class PaymentsPublisherTest {
                 "{"
                     + "'exception_record_ref': 'er-ref',"
                     + "'new_case_ref': 'new-case-ref',"
-                    + "'envelope_id': 'envelope-id',"
-                    + "'service': 'service',"
                     + "'jurisdiction': 'jurisdiction'"
                     + "}"
             ).replace("'", "\""),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/PaymentsPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/PaymentsPublisherTest.java
@@ -112,6 +112,7 @@ class PaymentsPublisherTest {
             new UpdatePaymentsCommand(
                 "er-ref",
                 "new-case-ref",
+                "envelope-id",
                 "jurisdiction"
             );
 
@@ -131,6 +132,7 @@ class PaymentsPublisherTest {
                 "{"
                     + "'exception_record_ref': 'er-ref',"
                     + "'new_case_ref': 'new-case-ref',"
+                    + "'envelope_id': 'envelope-id',"
                     + "'jurisdiction': 'jurisdiction'"
                     + "}"
             ).replace("'", "\""),


### PR DESCRIPTION
not available on exception record in CCD