### PR TITLE
Copy orchestrator s2s secret from s2s key vault to bulk scan

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -164,3 +164,10 @@ data "azurerm_key_vault_secret" "payments_queue_send_conn_str" {
   key_vault_id = "${data.azurerm_key_vault.key_vault.id}"
   name         = "payments-queue-send-connection-string"
 }
+
+# Copy orchestrator s2s secret from s2s key vault to bulkscan key vault
+resource "azurerm_key_vault_secret" "bulk_scan_orchestrator_app_s2s_secret" {
+  name         = "s2s-secret-bulk-scan-orchestrator"
+  value        = "${data.azurerm_key_vault_secret.s2s_secret.value}"
+  key_vault_id = "${data.azurerm_key_vault.key_vault.id}"
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-839

### Change description ###

- As part of preparation to AKS copying secret to bulk scan vault as orchestrator will have only access to bulk scan key vaults in AAT/PROD.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
