### PR TITLE
Updated charts configuration for AKS migration

### DIFF
--- a/charts/bulk-scan-orchestrator/Chart.yaml
+++ b/charts/bulk-scan-orchestrator/Chart.yaml
@@ -1,6 +1,6 @@
 name: bulk-scan-orchestrator
 home: https://github.com/hmcts/bulk-scan-orchestrator
-version: 0.1.7
+version: 0.1.8
 description: HMCTS Bulk scan orchestrator service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/bulk-scan-orchestrator/values.aat.template.yaml
+++ b/charts/bulk-scan-orchestrator/values.aat.template.yaml
@@ -2,15 +2,4 @@ java:
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
-  environment:
-    APPINSIGHTS_INSTRUMENTATIONKEY: "00000000-0000-0000-0000-000000000000"
-    S2S_NAME: "bulk_scan_orchestrator"
-    S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-    IDAM_API_URL: "https://idam-api.aat.platform.hmcts.net"
-    IDAM_CLIENT_REDIRECT_URI: "https://bulk-scan-orchestrator-aat.service.core-compute-aat.internal/oauth2/callback"
-    CORE_CASE_DATA_API_URL: "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
-    DOCUMENT_MANAGEMENT_URL: "http://dm-store-aat.service.core-compute-aat.internal"
-    QUEUE_READ_INTERVAL: "30000"
-    DELETE_ENVELOPES_DLQ_MESSAGES_ENABLED: "true"
-    DELETE_ENVELOPES_DLQ_MESSAGES_CRON: "0 * * * * *"
-    DELETE_ENVELOPES_DLQ_MESSAGES_TTL: "10s"
+  devApplicationInsightsInstrumentKey: "f666440f-43c0-4abb-9c20-2ce175a374f0"

--- a/charts/bulk-scan-orchestrator/values.preview.template.yaml
+++ b/charts/bulk-scan-orchestrator/values.preview.template.yaml
@@ -4,19 +4,27 @@ java:
       secretRef: servicebus-secret-namespace-{{ .Release.Name }}
       key: connectionString
   environment:
-    APPINSIGHTS_INSTRUMENTATIONKEY: "00000000-0000-0000-0000-000000000000"
+    S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
+    IDAM_API_URL: "https://idam-api.aat.platform.hmcts.net"
+    IDAM_CLIENT_REDIRECT_URI: "https://bulk-scan-orchestrator-aat.service.core-compute-aat.internal/oauth2/callback"
+    CORE_CASE_DATA_API_URL: "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
+    DOCUMENT_MANAGEMENT_URL: "http://dm-store-aat.service.core-compute-aat.internal"
+    TRANSFORMATION_URL_BULKSCAN: "http://bulk-scan-sample-app-aat.service.core-compute-aat.internal"
     ENVELOPES_QUEUE_CONNECTION_STRING: "$(SB_CONN_STRING);EntityPath=envelopes"
     ENVELOPES_QUEUE_MAX_DELIVERY_COUNT: "10"
     PROCESSED_ENVELOPES_QUEUE_CONNECTION_STRING: "$(SB_CONN_STRING);EntityPath=processed-envelopes"
     PAYMENTS_QUEUE_CONNECTION_STRING: "$(SB_CONN_STRING);EntityPath=payments"
-    QUEUE_READ_INTERVAL: "30000"
-    DELETE_ENVELOPES_DLQ_MESSAGES_ENABLED: "true"
-    DELETE_ENVELOPES_DLQ_MESSAGES_CRON: "0 * * * * *"
-    DELETE_ENVELOPES_DLQ_MESSAGES_TTL: "10s"
-    TRANSFORMATION_URL_BULKSCAN: "http://bulk-scan-sample-app-aat.service.core-compute-aat.internal"
+  keyVaults:
+    "bulk-scan":
+      secrets:
+        - idam-client-secret
+        - s2s-secret-bulk-scan-orchestrator
+        - idam-users-bulkscan-username
+        - idam-users-bulkscan-password
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
+  aadIdentityName:
 
 servicebus:
   resourceGroup: bulk-scan-aks

--- a/charts/bulk-scan-orchestrator/values.yaml
+++ b/charts/bulk-scan-orchestrator/values.yaml
@@ -1,5 +1,7 @@
 java:
   applicationPort: 8582
+  ingressHost: bulk-scan-orchestrator-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+  aadIdentityName: bsp
   environment:
     S2S_NAME: "bulk_scan_orchestrator"
     S2S_URL: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
@@ -9,15 +11,30 @@ java:
     DOCUMENT_MANAGEMENT_URL: "http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     TRANSFORMATION_URL_BULKSCAN: "http://bulk-scan-sample-app-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     TRANSFORMATION_URL_PROBATE: "http://probate-back-office-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    QUEUE_READ_INTERVAL: "30000"
+    DELETE_ENVELOPES_DLQ_MESSAGES_ENABLED: "true"
+    DELETE_ENVELOPES_DLQ_MESSAGES_CRON: "0 * * * * *"
+    DELETE_ENVELOPES_DLQ_MESSAGES_TTL: "10s"
+    CCD_LOG_LEVEL: "full"
   keyVaults:
     bulk-scan:
       resourceGroup: bulk-scan
       secrets:
         - idam-client-secret
+        - s2s-secret-bulk-scan-orchestrator
         - idam-users-bulkscan-username
         - idam-users-bulkscan-password
-    s2s:
-      resourceGroup: rpe-service-auth-provider
-      secrets:
-        - microservicekey-bulk-scan-orchestrator
+        - idam-users-cmc-username
+        - idam-users-cmc-password
+        - idam-users-div-username
+        - idam-users-div-password
+        - idam-users-probate-username
+        - idam-users-probate-password
+        - idam-users-sscs-username
+        - idam-users-sscs-password
+        - envelopes-queue-listen-connection-string
+        - payments-queue-send-connection-string
+        - processed-envelopes-queue-send-connection-string
+        - envelopes-queue-max-delivery-count
+        - app-insights-instrumentation-key
   image: hmctspublic.azurecr.io/bulk-scan/orchestrator:latest

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -1,12 +1,23 @@
 spring:
   cloud:
     propertiesvolume:
-      enabled: true
-      prefixed: true
-      paths: /mnt/secrets/bulk-scan,/mnt/secrets/s2s
+      prefixed: false
+      paths: /mnt/secrets/bulk-scan
       aliases:
-        bulk-scan.idam-users-bulkscan-username: IDAM_USERS_BULKSCAN_USERNAME
-        bulk-scan.idam-users-bulkscan-password: IDAM_USERS_BULKSCAN_PASSWORD
-        bulk-scan.idam-client-secret: IDAM_CLIENT_SECRET
-        bulk-scan.payments-queue-send-connection-string: PAYMENTS_QUEUE_CONNECTION_STRING
-        s2s.microservicekey-bulk-scan-orchestrator: S2S_SECRET
+        idam-client-secret: IDAM_CLIENT_SECRET
+        s2s-secret-bulk-scan-orchestrator: S2S_SECRET
+        idam-users-bulkscan-username: IDAM_USERS_BULKSCAN_USERNAME
+        idam-users-bulkscan-password: IDAM_USERS_BULKSCAN_PASSWORD
+        idam-users-cmc-username: IDAM_USERS_CMC_USERNAME
+        idam-users-cmc-password: IDAM_USERS_CMC_PASSWORD
+        idam-users-div-username: IDAM_USERS_DIVORCE_USERNAME
+        idam-users-div-password: IDAM_USERS_DIVORCE_PASSWORD
+        idam-users-probate-username: IDAM_USERS_PROBATE_USERNAME
+        idam-users-probate-password: IDAM_USERS_PROBATE_PASSWORD
+        idam-users-sscs-username: IDAM_USERS_SSCS_USERNAME
+        idam-users-sscs-password: IDAM_USERS_SSCS_PASSWORD
+        envelopes-queue-listen-connection-string: ENVELOPES_QUEUE_CONNECTION_STRING
+        processed-envelopes-queue-send-connection-string: PROCESSED_ENVELOPES_QUEUE_CONNECTION_STRING
+        payments-queue-send-connection-string: PAYMENTS_QUEUE_CONNECTION_STRING
+        envelopes-queue-max-delivery-count: ENVELOPES_QUEUE_MAX_DELIVERY_COUNT
+        app-insights-instrumentation-key: azure.application-insights.instrumentation-key


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-839

### Change description ###

- Needs https://github.com/hmcts/bulk-scan-orchestrator/pull/680 to be merged so secrets are available in bulk scan vault.

- Moved configuration in AAT yaml file to default values yaml file.

- Added configuration to load configuration for secrets from bulk scan vault only.

- Added Ingres host and identity config.

- Updated boot strap config to not use prefix as we are just loading from single vault.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```

