### PR TITLE
Exclude junit vintage platform from test scope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,6 +217,7 @@ dependencies {
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, {
     exclude group: 'junit', module: 'junit'
+    exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
   testCompile group: 'com.typesafe', name: 'config', version: '1.4.0'
   testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.1.0'


### PR DESCRIPTION
### Change description ###

junit4 has been completely eradicated. Since spring boot 2.2 test framework moves to junit5 + vintage (aka junit4) support. tiny feature: if junit4 dependency is not present - there's a warning:

> TestEngine with ID 'junit-vintage' failed to discover tests

Removing unnecessary engine

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
