### PR TITLE
Disabled osba service bus by default as it is enabled only for preview

### DIFF
--- a/charts/bulk-scan-orchestrator/values.yaml
+++ b/charts/bulk-scan-orchestrator/values.yaml
@@ -38,3 +38,7 @@ java:
         - envelopes-queue-max-delivery-count
         - app-insights-instrumentation-key
   image: hmctspublic.azurecr.io/bulk-scan/orchestrator:latest
+
+bso:
+  servicebus:
+    enabled: false


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-839

### Change description ###

- By default Helm will evaluate condition to true. Hence setting it false by default.

- This is enabled in preview so that we can use OSBA.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
