### PR TITLE
Return the whole modified exception record to CCD

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
@@ -67,7 +67,7 @@ public class CcdCallbackController {
 
             return AboutToStartOrSubmitCallbackResponse
                 .builder()
-                .data(result.getModifiedFields())
+                .data(result.getExceptionRecordData())
                 .warnings(result.getWarnings())
                 .errors(result.getErrors())
                 .build();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -160,6 +160,7 @@ public class CreateCaseCallbackService {
         } else if (ids.size() == 1) {
             return new ProcessResult(
                 ImmutableMap.<String, Object>builder()
+                    .putAll(exceptionRecordData.getData())
                     .put(CASE_REFERENCE, Long.toString(ids.get(0)))
                     .put(DISPLAY_WARNINGS, YesNoFieldValues.NO)
                     .put(OCR_DATA_VALIDATION_WARNINGS, emptyList())
@@ -238,6 +239,7 @@ public class CreateCaseCallbackService {
 
             return new ProcessResult(
                 ImmutableMap.<String, Object>builder()
+                    .putAll(exceptionRecordData.getData())
                     .put(CASE_REFERENCE, Long.toString(newCaseId))
                     .put(DISPLAY_WARNINGS, YesNoFieldValues.NO)
                     .put(OCR_DATA_VALIDATION_WARNINGS, emptyList())

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
@@ -11,26 +11,26 @@ import static java.util.Collections.emptyMap;
  */
 public class ProcessResult {
 
-    private final Map<String, Object> modifiedFields;
+    private final Map<String, Object> exceptionRecordData;
 
     private final List<String> warnings;
 
     private final List<String> errors;
 
-    public ProcessResult(Map<String, Object> modifiedFields) {
-        this.modifiedFields = modifiedFields;
+    public ProcessResult(Map<String, Object> exceptionRecordData) {
+        this.exceptionRecordData = exceptionRecordData;
         this.warnings = emptyList();
         this.errors = emptyList();
     }
 
     public ProcessResult(List<String> warnings, List<String> errors) {
-        this.modifiedFields = emptyMap();
+        this.exceptionRecordData = emptyMap();
         this.warnings = warnings;
         this.errors = errors;
     }
 
-    public Map<String, Object> getModifiedFields() {
-        return modifiedFields;
+    public Map<String, Object> getExceptionRecordData() {
+        return exceptionRecordData;
     }
 
     public List<String> getWarnings() {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -299,7 +299,7 @@ class CreateCaseCallbackServiceTest {
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(result.getModifiedFields()).isEmpty();
+        assertThat(result.getExceptionRecordData()).isEmpty();
         assertThat(result.getWarnings()).containsOnly("warning");
         assertThat(result.getErrors()).containsOnly("error");
     }
@@ -337,7 +337,7 @@ class CreateCaseCallbackServiceTest {
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(result.getModifiedFields().get(CASE_REFERENCE)).isEqualTo("345");
+        assertThat(result.getExceptionRecordData().get(CASE_REFERENCE)).isEqualTo("345");
         assertThat(result.getWarnings().isEmpty()).isTrue();
         assertThat(result.getErrors().isEmpty()).isTrue();
     }
@@ -377,7 +377,7 @@ class CreateCaseCallbackServiceTest {
         // then
 
         // then
-        assertThat(result.getModifiedFields()).isEmpty();
+        assertThat(result.getExceptionRecordData()).isEmpty();
         assertThat(result.getWarnings()).isEmpty();
         assertThat(result.getErrors()).containsOnly(
             "Multiple cases (345, 456) found for the given bulk scan case reference: 123"
@@ -594,7 +594,7 @@ class CreateCaseCallbackServiceTest {
         // given
         setUpTransformationUrl();
 
-        given(transformationClient.transformExceptionRecord(any(),any(), any()))
+        given(transformationClient.transformExceptionRecord(any(), any(), any()))
             .willReturn(
                 new SuccessfulTransformationResponse(
                     new CaseCreationDetails(
@@ -663,7 +663,7 @@ class CreateCaseCallbackServiceTest {
         // given
         setUpTransformationUrl();
 
-        given(transformationClient.transformExceptionRecord(any(),any(), any()))
+        given(transformationClient.transformExceptionRecord(any(), any(), any()))
             .willReturn(
                 new SuccessfulTransformationResponse(
                     new CaseCreationDetails(


### PR DESCRIPTION
### Change description ###

Make case creation callback endpoint return the whole modified exception record, instead of just the changed fields. This is a bug fix. Previous way resulted in overwriting the whole exception record data.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
