### PR TITLE
Bumped chart version as it was not done when osba was disabled

### DIFF
--- a/charts/bulk-scan-orchestrator/Chart.yaml
+++ b/charts/bulk-scan-orchestrator/Chart.yaml
@@ -1,7 +1,7 @@
 name: bulk-scan-orchestrator
 apiVersion: v1
 home: https://github.com/hmcts/bulk-scan-orchestrator
-version: 0.1.9
+version: 0.2.0
 description: HMCTS Bulk scan orchestrator service
 maintainers:
   - name: HMCTS BSP Team


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-839

### Change description ###

- When OSBA was disabled as part of https://github.com/hmcts/bulk-scan-orchestrator/pull/704 chart version was not bumped as a result flux fails to deploy this on AAT clusters.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
