### PR TITLE
Return the whole modified exception record to CCD

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
@@ -129,6 +129,7 @@ class CreateCaseTest {
         AboutToStartOrSubmitCallbackResponse response = invokeCallbackEndpoint(exceptionRecord);
 
         // then
+        assertThat(response.getErrors()).isEmpty();
         assertThat(response.getData()).isNotNull();
         assertThat(response.getData().get(DISPLAY_WARNINGS_FIELD)).isEqualTo("No");
         assertThat(response.getData().get(OCR_DATA_VALIDATION_WARNINGS_FIELD)).asList().isEmpty();
@@ -179,6 +180,7 @@ class CreateCaseTest {
     }
 
     private String getCaseCcdId(AboutToStartOrSubmitCallbackResponse callbackResponse) {
+        assertThat(callbackResponse.getErrors()).isEmpty();
         assertThat(callbackResponse.getData()).isNotNull();
         assertThat(callbackResponse.getData().containsKey(CASE_REFERENCE)).isTrue();
         return (String) callbackResponse.getData().get(CASE_REFERENCE);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.controllers;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,6 +12,8 @@ import org.springframework.http.MediaType;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.IntegrationTest;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
@@ -21,6 +24,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.google.common.io.Resources.getResource;
 import static com.google.common.io.Resources.toByteArray;
 import static io.restassured.RestAssured.given;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -45,7 +49,7 @@ class CreateCaseCallbackTest {
     int serverPort;
 
     @Test
-    void should_create_case_if_classification_new_application_with_documents_and_ocr_data() {
+    void should_create_case_if_classification_new_application_with_documents_and_ocr_data() throws IOException {
         setUpTransformation(getTransformationResponseBody("ok-no-warnings.json"));
         setUpCcdSearchEmptyResult(getCcdResponseBody("search-result-empty.json"));
         setUpCcdCreateCase(
@@ -53,13 +57,21 @@ class CreateCaseCallbackTest {
             getCcdResponseBody("sample-case.json")
         );
 
-        postWithBody(getRequestBody("valid-new-application-with-ocr.json"))
+        byte[] requestBody = getRequestBody("valid-new-application-with-ocr.json");
+
+        postWithBody(requestBody)
             .statusCode(OK.value())
             .body("errors", empty())
             .body("warnings", empty())
-            .body("data.caseReference", equalTo("1539007368674134")) // from sample-case.json
-            .body("data.displayWarnings", equalTo("No"))
-            .body("data.ocrDataValidationWarnings", empty());
+            .body(
+                "data",
+                equalTo(
+                    expectedResponseExceptionRecordFields(
+                        requestBody,
+                        "1539007368674134" // from sample-case.json
+                    )
+                )
+            );
     }
 
     @Test
@@ -94,7 +106,7 @@ class CreateCaseCallbackTest {
     }
 
     @Test
-    void should_create_case_if_classification_exception_with_documents_and_ocr_data() {
+    void should_create_case_if_classification_exception_with_documents_and_ocr_data() throws IOException {
         setUpTransformation(getTransformationResponseBody("ok-no-warnings.json"));
         setUpCcdSearchEmptyResult(getCcdResponseBody("search-result-empty.json"));
         setUpCcdCreateCase(
@@ -102,11 +114,21 @@ class CreateCaseCallbackTest {
             getCcdResponseBody("sample-case.json")
         );
 
-        postWithBody(getRequestBody("valid-exception.json"))
+        byte[] requestBody = getRequestBody("valid-exception.json");
+
+        postWithBody(requestBody)
             .statusCode(OK.value())
             .body("errors", empty())
             .body("warnings", empty())
-            .body("data.caseReference", equalTo("1539007368674134")); // from sample-case.json
+            .body(
+                "data",
+                equalTo(
+                    expectedResponseExceptionRecordFields(
+                        requestBody,
+                        "1539007368674134" // from sample-case.json
+                    )
+                )
+            );
     }
 
     @ParameterizedTest
@@ -224,8 +246,8 @@ class CreateCaseCallbackTest {
                     + EVENT_ID
                     + "/token"
             )
-            .withHeader("ServiceAuthorization", containing("Bearer"))
-            .willReturn(okJson(startResponseBody))
+                .withHeader("ServiceAuthorization", containing("Bearer"))
+                .willReturn(okJson(startResponseBody))
         );
 
         givenThat(
@@ -281,5 +303,22 @@ class CreateCaseCallbackTest {
             .body(body)
             .post("http://localhost:" + serverPort + "/callback/create-new-case")
             .then();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> expectedResponseExceptionRecordFields(
+        byte[] callbackRequestBody,
+        String caseReference
+    ) throws IOException {
+        Map<String, Object> requestBodyAsMap = new ObjectMapper().readValue(callbackRequestBody, Map.class);
+        Map<String, Object> caseDetails = (Map<String, Object>) requestBodyAsMap.get("case_details");
+        Map<String, Object> originalFields = (Map<String, Object>) caseDetails.get("case_data");
+
+        Map<String, Object> expectedFields = new HashMap<>(originalFields);
+        expectedFields.put("displayWarnings", "No");
+        expectedFields.put("ocrDataValidationWarnings", emptyList());
+        expectedFields.put("caseReference", caseReference);
+
+        return expectedFields;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
@@ -67,7 +67,7 @@ public class CcdCallbackController {
 
             return AboutToStartOrSubmitCallbackResponse
                 .builder()
-                .data(result.getModifiedFields())
+                .data(result.getExceptionRecordData())
                 .warnings(result.getWarnings())
                 .errors(result.getErrors())
                 .build();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ProcessResult.java
@@ -11,26 +11,26 @@ import static java.util.Collections.emptyMap;
  */
 public class ProcessResult {
 
-    private final Map<String, Object> modifiedFields;
+    private final Map<String, Object> exceptionRecordData;
 
     private final List<String> warnings;
 
     private final List<String> errors;
 
-    public ProcessResult(Map<String, Object> modifiedFields) {
-        this.modifiedFields = modifiedFields;
+    public ProcessResult(Map<String, Object> exceptionRecordData) {
+        this.exceptionRecordData = exceptionRecordData;
         this.warnings = emptyList();
         this.errors = emptyList();
     }
 
     public ProcessResult(List<String> warnings, List<String> errors) {
-        this.modifiedFields = emptyMap();
+        this.exceptionRecordData = emptyMap();
         this.warnings = warnings;
         this.errors = errors;
     }
 
-    public Map<String, Object> getModifiedFields() {
-        return modifiedFields;
+    public Map<String, Object> getExceptionRecordData() {
+        return exceptionRecordData;
     }
 
     public List<String> getWarnings() {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -321,7 +321,7 @@ class CreateCaseCallbackServiceTest {
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(result.getModifiedFields()).isEmpty();
+        assertThat(result.getExceptionRecordData()).isEmpty();
         assertThat(result.getWarnings()).containsOnly("warning");
         assertThat(result.getErrors()).containsOnly("error");
     }
@@ -358,7 +358,7 @@ class CreateCaseCallbackServiceTest {
         ), IDAM_TOKEN, USER_ID);
 
         // then
-        assertThat(result.getModifiedFields().get(CASE_REFERENCE)).isEqualTo("345");
+        assertThat(result.getExceptionRecordData().get(CASE_REFERENCE)).isEqualTo("345");
         assertThat(result.getWarnings().isEmpty()).isTrue();
         assertThat(result.getErrors().isEmpty()).isTrue();
     }
@@ -397,7 +397,7 @@ class CreateCaseCallbackServiceTest {
         // then
 
         // then
-        assertThat(result.getModifiedFields()).isEmpty();
+        assertThat(result.getExceptionRecordData()).isEmpty();
         assertThat(result.getWarnings()).isEmpty();
         assertThat(result.getErrors()).containsOnly(
             "Multiple cases (345, 456) found for the given bulk scan case reference: 123"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-861

### Change description ###

Make case creation callback endpoint return the whole modified exception record, instead of just the changed fields. This is a bug fix. Previous way resulted in overwriting the whole exception record data.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
