### PR TITLE
Add envelope case reference fields to the exception record

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
@@ -47,6 +47,10 @@ public class ExceptionRecord implements CaseData {
     @JsonProperty("containsPayments")
     public final String containsPayments;
 
+    // Case reference received to attach the scanned documents received
+    @JsonProperty("envelopeCaseReference")
+    public final String envelopeCaseReference;
+
     public ExceptionRecord(
         String classification,
         String poBox,
@@ -60,7 +64,8 @@ public class ExceptionRecord implements CaseData {
         String displayWarnings,
         String envelopeId,
         String awaitingPaymentDcnProcessing,
-        String containsPayments
+        String containsPayments,
+        String envelopeCaseReference
     ) {
         this.classification = classification;
         this.poBox = poBox;
@@ -75,5 +80,6 @@ public class ExceptionRecord implements CaseData {
         this.envelopeId = envelopeId;
         this.awaitingPaymentDcnProcessing = awaitingPaymentDcnProcessing;
         this.containsPayments = containsPayments;
+        this.envelopeCaseReference = envelopeCaseReference;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
@@ -51,6 +51,18 @@ public class ExceptionRecord implements CaseData {
     @JsonProperty("envelopeCaseReference")
     public final String envelopeCaseReference;
 
+    // Legacy case reference received to attach the scanned documents received
+    @JsonProperty("envelopeLegacyCaseReference")
+    public final String envelopeLegacyCaseReference;
+
+    // Yes/No field indicating to show or hide envelope case reference
+    @JsonProperty("showEnvelopeCaseReference")
+    public final String showEnvelopeCaseReference;
+
+    // Yes/No field indicating to show or hide envelope legacy case reference
+    @JsonProperty("showEnvelopeLegacyCaseReference")
+    public final String showEnvelopeLegacyCaseReference;
+
     public ExceptionRecord(
         String classification,
         String poBox,
@@ -65,7 +77,10 @@ public class ExceptionRecord implements CaseData {
         String envelopeId,
         String awaitingPaymentDcnProcessing,
         String containsPayments,
-        String envelopeCaseReference
+        String envelopeCaseReference,
+        String envelopeLegacyCaseReference,
+        String showEnvelopeCaseReference,
+        String showEnvelopeLegacyCaseReference
     ) {
         this.classification = classification;
         this.poBox = poBox;
@@ -81,5 +96,8 @@ public class ExceptionRecord implements CaseData {
         this.awaitingPaymentDcnProcessing = awaitingPaymentDcnProcessing;
         this.containsPayments = containsPayments;
         this.envelopeCaseReference = envelopeCaseReference;
+        this.envelopeLegacyCaseReference = envelopeLegacyCaseReference;
+        this.showEnvelopeCaseReference = showEnvelopeCaseReference;
+        this.showEnvelopeLegacyCaseReference = showEnvelopeLegacyCaseReference;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -45,7 +45,8 @@ public class ExceptionRecordMapper {
             envelope.ocrDataValidationWarnings.isEmpty() ? NO : YES,
             envelope.id,
             CollectionUtils.isEmpty(envelope.payments) ? NO : YES,
-            CollectionUtils.isEmpty(envelope.payments) ? NO : YES
+            CollectionUtils.isEmpty(envelope.payments) ? NO : YES,
+            envelope.caseRef
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.env
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.OcrDataField;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
@@ -27,6 +28,12 @@ public class ExceptionRecordMapper {
 
     private final String documentManagementUrl;
     private final String contextPath;
+
+    // Display Envelope case references for the specified classifications
+    EnumSet<Classification> allowedClassifications = EnumSet.of(
+        SUPPLEMENTARY_EVIDENCE,
+        SUPPLEMENTARY_EVIDENCE_WITH_OCR
+    );
 
     public ExceptionRecordMapper(
         @Value("${document_management.url}") final String documentManagementUrl,
@@ -59,9 +66,7 @@ public class ExceptionRecordMapper {
     }
 
     private String setDisplayCaseReferenceFlag(String caseRef, Classification classification) {
-        if (isNotBlank(caseRef) && (SUPPLEMENTARY_EVIDENCE.equals(classification)
-            || SUPPLEMENTARY_EVIDENCE_WITH_OCR.equals(classification))
-        ) {
+        if (isNotBlank(caseRef) && allowedClassifications.contains(classification)) {
             return YES;
         }
         return NO;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -30,7 +30,7 @@ public class ExceptionRecordMapper {
     private final String contextPath;
 
     // Display Envelope case references for the specified classifications
-    EnumSet<Classification> allowedClassifications = EnumSet.of(
+    private static final EnumSet<Classification> allowedClassifications = EnumSet.of(
         SUPPLEMENTARY_EVIDENCE,
         SUPPLEMENTARY_EVIDENCE_WITH_OCR
     );

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -30,7 +30,7 @@ public class ExceptionRecordMapper {
     private final String contextPath;
 
     // Display Envelope case references for the specified classifications
-    private static final EnumSet<Classification> allowedClassifications = EnumSet.of(
+    private static final EnumSet<Classification> ALLOWED_CLASSIFICATIONS = EnumSet.of(
         SUPPLEMENTARY_EVIDENCE,
         SUPPLEMENTARY_EVIDENCE_WITH_OCR
     );
@@ -66,7 +66,7 @@ public class ExceptionRecordMapper {
     }
 
     private String setDisplayCaseReferenceFlag(String caseRef, Classification classification) {
-        if (isNotBlank(caseRef) && allowedClassifications.contains(classification)) {
+        if (isNotBlank(caseRef) && ALLOWED_CLASSIFICATIONS.contains(classification)) {
             return YES;
         }
         return NO;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -184,6 +184,26 @@ public class SampleData {
         );
     }
 
+    public static Envelope envelope(String caseRef, String legacyCaseRef, Classification classification) {
+        return new Envelope(
+            ENVELOPE_ID,
+            caseRef,
+            legacyCaseRef,
+            PO_BOX,
+            JURSIDICTION,
+            CONTAINER,
+            "zip-file-test.zip",
+            FORM_TYPE,
+            Instant.now(),
+            Instant.now(),
+            classification,
+            documents(1),
+            ImmutableList.of(new Payment("dcn1")),
+            ImmutableList.of(new OcrDataField("fieldName1", "value1")),
+            asList("warning 1", "warning 2")
+        );
+    }
+
     private static List<Document> documents(int numberOfDocuments) {
         return Stream.iterate(1, i -> i + 1)
             .map(index ->

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -67,6 +67,7 @@ class ExceptionRecordMapperTest {
             .containsExactlyElementsOf(envelope.ocrDataValidationWarnings);
 
         assertThat(exceptionRecord.envelopeId).isEqualTo(envelope.id);
+        assertThat(exceptionRecord.envelopeCaseReference).isEqualTo(envelope.caseRef);
     }
 
     @Test
@@ -149,6 +150,19 @@ class ExceptionRecordMapperTest {
         assertThat(exceptionRecord.awaitingPaymentDcnProcessing).isEqualTo("No");
         assertThat(exceptionRecord.containsPayments).isEqualTo("No");
     }
+
+    @Test
+    public void mapEnvelope_sets_envelope_case_ref_to_exception_record() {
+        //given
+        Envelope envelope = envelope(1, null, null, emptyList());
+
+        // when
+        ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
+
+        // then
+        assertThat(exceptionRecord.envelopeCaseReference).isEqualTo(envelope.caseRef);
+    }
+
 
     private Envelope envelopeWithJurisdiction(String jurisdiction) {
         return envelope(Classification.NEW_APPLICATION, jurisdiction, "1231231232312765");

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -68,6 +68,9 @@ class ExceptionRecordMapperTest {
 
         assertThat(exceptionRecord.envelopeId).isEqualTo(envelope.id);
         assertThat(exceptionRecord.envelopeCaseReference).isEqualTo(envelope.caseRef);
+        assertThat(exceptionRecord.envelopeLegacyCaseReference).isEqualTo(envelope.legacyCaseRef);
+        assertThat(exceptionRecord.showEnvelopeCaseReference).isEqualTo("No"); // for "New Application"
+        assertThat(exceptionRecord.showEnvelopeLegacyCaseReference).isEqualTo("No"); // for "New Application"
     }
 
     @Test
@@ -152,17 +155,34 @@ class ExceptionRecordMapperTest {
     }
 
     @Test
-    public void mapEnvelope_sets_envelope_case_ref_to_exception_record() {
+    public void mapEnvelope_sets_display_case_reference_fields_to_no_when_envelope_case_reference_values_are_null() {
         //given
-        Envelope envelope = envelope(1, null, null, emptyList());
+        Envelope envelope = envelope(null, null, Classification.SUPPLEMENTARY_EVIDENCE_WITH_OCR);
 
         // when
         ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
 
         // then
-        assertThat(exceptionRecord.envelopeCaseReference).isEqualTo(envelope.caseRef);
+        assertThat(exceptionRecord.envelopeCaseReference).isNull();
+        assertThat(exceptionRecord.envelopeLegacyCaseReference).isNull();
+        assertThat(exceptionRecord.showEnvelopeCaseReference).isEqualTo("No");
+        assertThat(exceptionRecord.showEnvelopeLegacyCaseReference).isEqualTo("No");
     }
 
+    @Test
+    public void mapEnvelope_sets_display_case_reference_fields_to_yes_when_envelope_case_reference_values_exist() {
+        //given
+        Envelope envelope = envelope("CASE_123", "LEGACY_CASE_123", Classification.SUPPLEMENTARY_EVIDENCE_WITH_OCR);
+
+        // when
+        ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
+
+        // then
+        assertThat(exceptionRecord.envelopeCaseReference).isEqualTo("CASE_123");
+        assertThat(exceptionRecord.envelopeLegacyCaseReference).isEqualTo("LEGACY_CASE_123");
+        assertThat(exceptionRecord.showEnvelopeCaseReference).isEqualTo("Yes");
+        assertThat(exceptionRecord.showEnvelopeLegacyCaseReference).isEqualTo("Yes");
+    }
 
     private Envelope envelopeWithJurisdiction(String jurisdiction) {
         return envelope(Classification.NEW_APPLICATION, jurisdiction, "1231231232312765");


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-831

### Change description ###
Add `envelopeCaseReference` field to exception record ccd model.
This change is tested on demo for all services. (https://github.com/hmcts/bulk-scan-orchestrator/pull/709)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
