### PR TITLE
Merge exception record fields in a safe way

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import io.vavr.collection.Seq;
 import io.vavr.control.Either;
 import io.vavr.control.Validation;
@@ -386,8 +387,10 @@ public class AttachCaseCallbackService {
         Map<String, Object> originalFields,
         Map<String, Object> modifiedFields
     ) {
-        Map<String, Object> merged = new HashMap<>();
-        merged.putAll(originalFields);
+        Map<String, Object> merged = new HashMap<>(
+            Maps.difference(originalFields, modifiedFields).entriesOnlyOnLeft()
+        );
+
         merged.putAll(modifiedFields);
         return merged;
     }


### PR DESCRIPTION
### Change description ###

Merge exception record fields in a safe way when updating fields as part of "attach to case" callback handling. This change doesn't have any effect given current version of code, as we can't have a situation when the only updated field (`attachToCaseReference`) has already been set (the data would be rejected by the same class), but if we add more fields in the future, this could potentially become a bug.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
