### PR TITLE
Update `jackson-databind` to be used latest from spring boot itself

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,10 +169,6 @@ ext["rest-assured.version"] = '4.1.2'
 
 dependencyManagement {
   dependencies {
-    // CVE-2019-14540, CVE-2019-16335 - until 2.9.9.3 HikariCP issue :o
-    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.10') {
-      entry 'jackson-databind'
-    }
     // CVE-2018-10237 - Unbounded memory allocation
     dependencySet(group: 'com.google.guava', version: '28.1-jre') {
       entry 'guava'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -120,11 +120,6 @@
     <cve>CVE-2019-14439</cve>
     <cve>CVE-2019-14540</cve>
     <cve>CVE-2019-16335</cve>
-  </suppress>
-
-  <suppress until="2019-10-31">
-    <notes><![CDATA[ file name: jackson-databind-2.9.10.jar ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
     <cve>CVE-2019-16942</cve>
     <cve>CVE-2019-16943</cve>
     <cve>CVE-2019-17531</cve>


### PR DESCRIPTION
### Change description ###

Spring boot 2.2 shipped together with latest jackson. Customly bumped databind one in configs is not needed anymore

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
