### PR TITLE
Add envelope legacy case reference

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
@@ -74,6 +74,8 @@ class ExceptionRecordCreationTest {
         CaseDetails caseDetails = findCasesByPoBox(randomPoBox).get(0);
         assertThat(getCaseDataForField(caseDetails, "awaitingPaymentDCNProcessing")).isEqualTo("No");
         assertThat(getCaseDataForField(caseDetails, "containsPayments")).isEqualTo("No");
+        assertThat(getCaseDataForField(caseDetails, "envelopeCaseReference")).isEqualTo("0000000000000000");
+        assertThat(getCaseDataForField(caseDetails, "envelopeLegacyCaseReference")).isEqualTo(null);
     }
 
     @DisplayName("Should create ExceptionRecord when classification is NEW_APPLICATION")

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
@@ -51,6 +51,10 @@ public class ExceptionRecord implements CaseData {
     @JsonProperty("envelopeCaseReference")
     public final String envelopeCaseReference;
 
+    // Legacy case reference received to attach the scanned documents received
+    @JsonProperty("envelopeLegacyCaseReference")
+    public final String envelopeLegacyCaseReference;
+
     public ExceptionRecord(
         String classification,
         String poBox,
@@ -65,7 +69,8 @@ public class ExceptionRecord implements CaseData {
         String envelopeId,
         String awaitingPaymentDcnProcessing,
         String containsPayments,
-        String envelopeCaseReference
+        String envelopeCaseReference,
+        String envelopeLegacyCaseReference
     ) {
         this.classification = classification;
         this.poBox = poBox;
@@ -81,5 +86,6 @@ public class ExceptionRecord implements CaseData {
         this.awaitingPaymentDcnProcessing = awaitingPaymentDcnProcessing;
         this.containsPayments = containsPayments;
         this.envelopeCaseReference = envelopeCaseReference;
+        this.envelopeLegacyCaseReference = envelopeLegacyCaseReference;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -46,7 +46,8 @@ public class ExceptionRecordMapper {
             envelope.id,
             CollectionUtils.isEmpty(envelope.payments) ? NO : YES,
             CollectionUtils.isEmpty(envelope.payments) ? NO : YES,
-            envelope.caseRef
+            envelope.caseRef,
+            envelope.legacyCaseRef
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -68,6 +68,7 @@ class ExceptionRecordMapperTest {
 
         assertThat(exceptionRecord.envelopeId).isEqualTo(envelope.id);
         assertThat(exceptionRecord.envelopeCaseReference).isEqualTo(envelope.caseRef);
+        assertThat(exceptionRecord.envelopeLegacyCaseReference).isEqualTo(envelope.legacyCaseRef);
     }
 
     @Test
@@ -121,7 +122,7 @@ class ExceptionRecordMapperTest {
     }
 
     @Test
-    public void mapEnvelope_sets_envelope_case_ref_to_exception_record() {
+    public void mapEnvelope_sets_envelope_case_reference_fields_to_exception_record() {
         //given
         Envelope envelope = envelope(1, null, null, emptyList());
 
@@ -130,6 +131,7 @@ class ExceptionRecordMapperTest {
 
         // then
         assertThat(exceptionRecord.envelopeCaseReference).isEqualTo(envelope.caseRef);
+        assertThat(exceptionRecord.envelopeLegacyCaseReference).isEqualTo(envelope.legacyCaseRef);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-831

### Change description ###
- Adding `envelopeLegacyCaseReference` field to exception record to store the legacy case reference received for "supplementary evidence" or "supplementary evidence with ocr" classifications.
- This field will be displayed on CCD UI (if value present) when attaching the exception record to an existing case.
- This change should be tested on `demo` to verify the CCD definition changes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
