### PR TITLE
Add displayCaseReferenceType field to exception record

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/ExceptionRecord.java
@@ -55,6 +55,10 @@ public class ExceptionRecord implements CaseData {
     @JsonProperty("envelopeLegacyCaseReference")
     public final String envelopeLegacyCaseReference;
 
+    // Hidden field which derives the type of case reference to display on attach exception record to case page
+    @JsonProperty("displayCaseReferenceType")
+    public final String displayCaseReferenceType;
+
     public ExceptionRecord(
         String classification,
         String poBox,
@@ -70,7 +74,8 @@ public class ExceptionRecord implements CaseData {
         String awaitingPaymentDcnProcessing,
         String containsPayments,
         String envelopeCaseReference,
-        String envelopeLegacyCaseReference
+        String envelopeLegacyCaseReference,
+        String displayCaseReferenceType
     ) {
         this.classification = classification;
         this.poBox = poBox;
@@ -87,5 +92,6 @@ public class ExceptionRecord implements CaseData {
         this.containsPayments = containsPayments;
         this.envelopeCaseReference = envelopeCaseReference;
         this.envelopeLegacyCaseReference = envelopeLegacyCaseReference;
+        this.displayCaseReferenceType = displayCaseReferenceType;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdKeyValue;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.CcdCaseReferenceType;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.OcrDataField;
 
@@ -13,6 +14,7 @@ import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.DocumentMapper.getLocalDateTime;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.DocumentMapper.mapDocuments;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.YesNoFieldValues.NO;
@@ -48,7 +50,8 @@ public class ExceptionRecordMapper {
             CollectionUtils.isEmpty(envelope.payments) ? NO : YES,
             CollectionUtils.isEmpty(envelope.payments) ? NO : YES,
             isBlank(envelope.caseRef) ? null : envelope.caseRef,
-            isBlank(envelope.legacyCaseRef) ? null : envelope.legacyCaseRef
+            isBlank(envelope.legacyCaseRef) ? null : envelope.legacyCaseRef,
+            setDisplayCaseReferenceType(envelope.caseRef, envelope.legacyCaseRef)
         );
     }
 
@@ -68,5 +71,18 @@ public class ExceptionRecordMapper {
             .stream()
             .map(CcdCollectionElement::new)
             .collect(toList());
+    }
+
+    private String setDisplayCaseReferenceType(String caseRef, String legacyCaseRef) {
+        if (isNotBlank(caseRef) && isNotBlank(legacyCaseRef)) {
+            return CcdCaseReferenceType.ALL.name();
+        }
+        if (isNotBlank(caseRef)) {
+            return CcdCaseReferenceType.CASE_REFERENCE.name();
+        }
+        if (isNotBlank(legacyCaseRef)) {
+            return CcdCaseReferenceType.LEGACY_CASE_REFERENCE.name();
+        }
+        return null;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -184,6 +184,26 @@ public class SampleData {
         );
     }
 
+    public static Envelope envelope(String caseRef, String legacyCaseRef) {
+        return new Envelope(
+            ENVELOPE_ID,
+            caseRef,
+            legacyCaseRef,
+            PO_BOX,
+            JURSIDICTION,
+            CONTAINER,
+            "zip-file-test.zip",
+            FORM_TYPE,
+            Instant.now(),
+            Instant.now(),
+            Classification.SUPPLEMENTARY_EVIDENCE,
+            documents(1),
+            ImmutableList.of(new Payment("dcn1")),
+            ImmutableList.of(new OcrDataField("fieldName1", "value1")),
+            asList("warning 1", "warning 2")
+        );
+    }
+
     private static List<Document> documents(int numberOfDocuments) {
         return Stream.iterate(1, i -> i + 1)
             .map(index ->

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdCollectionElement;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdKeyValue;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.CcdCaseReferenceType;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Document;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
@@ -22,7 +23,8 @@ import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.JURSIDICTION;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.CASE_LEGACY_ID;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.CASE_REF;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelope;
 
 class ExceptionRecordMapperTest {
@@ -133,19 +135,36 @@ class ExceptionRecordMapperTest {
         // then
         assertThat(exceptionRecord.envelopeCaseReference).isEqualTo(envelope.caseRef);
         assertThat(exceptionRecord.envelopeLegacyCaseReference).isEqualTo(envelope.legacyCaseRef);
+        assertThat(exceptionRecord.displayCaseReferenceType).isEqualTo(CcdCaseReferenceType.ALL.name());
     }
 
     @Test
-    public void mapEnvelope_sets_envelope_case_reference_as_null_in_exception_record() {
+    public void mapEnvelope_sets_case_reference_type_when_legacy_case_reference_value_is_not_provided() {
         //given
-        Envelope envelope = envelope(Classification.SUPPLEMENTARY_EVIDENCE, JURSIDICTION, "  ");
+        Envelope envelope = envelope(CASE_REF, null);
+
+        // when
+        ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
+
+        // then
+        assertThat(exceptionRecord.envelopeCaseReference).isEqualTo(CASE_REF);
+        assertThat(exceptionRecord.envelopeLegacyCaseReference).isEqualTo(null);
+        assertThat(exceptionRecord.displayCaseReferenceType).isEqualTo(CcdCaseReferenceType.CASE_REFERENCE.name());
+    }
+
+    @Test
+    public void mapEnvelope_sets_case_reference_type_when_case_reference_value_is_not_provided() {
+        //given
+        Envelope envelope = envelope(null, CASE_LEGACY_ID);
 
         // when
         ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
 
         // then
         assertThat(exceptionRecord.envelopeCaseReference).isNull();
-        assertThat(exceptionRecord.envelopeLegacyCaseReference).isEqualTo(envelope.legacyCaseRef);
+        assertThat(exceptionRecord.envelopeLegacyCaseReference).isEqualTo(CASE_LEGACY_ID);
+        assertThat(exceptionRecord.displayCaseReferenceType)
+            .isEqualTo(CcdCaseReferenceType.LEGACY_CASE_REFERENCE.name());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-831

### Change description ###
- Add `displayCaseReferenceType` field to exception record
- This field is used only in the backend to show/hide the case reference and legacy case reference fields on attach exception record to the case screen on CCD UI.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
