### PR TITLE
Make `idamToken` and `userId` mandatory prerequisite

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -38,7 +38,9 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.joining;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasIdamToken;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasServiceNameInCaseTypeId;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasUserId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.isCreateNewCaseEvent;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.AWAITING_PAYMENT_DCN_PROCESSING;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.CASE_REFERENCE;
@@ -87,7 +89,12 @@ public class CreateCaseCallbackService {
      * @return ProcessResult map of changes or list of errors/warnings
      */
     public ProcessResult process(CcdCallbackRequest request, String idamToken, String userId) {
-        Validation<String, Void> canAccess = assertAllowToAccess(request.getCaseDetails(), request.getEventId());
+        Validation<String, Void> canAccess = assertAllowToAccess(
+            request.getCaseDetails(),
+            request.getEventId(),
+            idamToken,
+            userId
+        );
 
         if (canAccess.isInvalid()) {
             log.warn("Validation error: {}", canAccess.getError());
@@ -138,10 +145,17 @@ public class CreateCaseCallbackService {
         return result;
     }
 
-    private Validation<String, Void> assertAllowToAccess(CaseDetails caseDetails, String eventId) {
+    private Validation<String, Void> assertAllowToAccess(
+        CaseDetails caseDetails,
+        String eventId,
+        String idamToken,
+        String userId
+    ) {
         return validator.mandatoryPrerequisites(
             () -> isCreateNewCaseEvent(eventId),
-            () -> getServiceConfig(caseDetails).map(item -> null)
+            () -> getServiceConfig(caseDetails).map(item -> null),
+            () -> hasIdamToken(idamToken).map(item -> null),
+            () -> hasUserId(userId).map(item -> null)
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -207,6 +207,58 @@ class CreateCaseCallbackServiceTest {
     }
 
     @Test
+    void should_not_allow_to_process_callback_when_idam_token_is_missing() {
+        // given
+        setUpTransformationUrl();
+
+        CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .id(CASE_ID)
+            .caseTypeId(CASE_TYPE_ID)
+            .jurisdiction("some jurisdiction")
+        );
+
+        // when
+        CallbackException callbackException = catchThrowableOfType(() ->
+            service.process(new CcdCallbackRequest(
+                EVENT_ID_CREATE_NEW_CASE,
+                caseDetails,
+                true
+            ), null, USER_ID),
+            CallbackException.class
+        );
+
+        // then
+        assertThat(callbackException.getCause()).isNull();
+        assertThat(callbackException).hasMessage("Callback has no Idam token received in the header");
+    }
+
+    @Test
+    void should_not_allow_to_process_callback_when_user_id_is_missing() {
+        // given
+        setUpTransformationUrl();
+
+        CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
+            .id(CASE_ID)
+            .caseTypeId(CASE_TYPE_ID)
+            .jurisdiction("some jurisdiction")
+        );
+
+        // when
+        CallbackException callbackException = catchThrowableOfType(() ->
+            service.process(new CcdCallbackRequest(
+                EVENT_ID_CREATE_NEW_CASE,
+                caseDetails,
+                true
+            ), IDAM_TOKEN, null),
+            CallbackException.class
+        );
+
+        // then
+        assertThat(callbackException.getCause()).isNull();
+        assertThat(callbackException).hasMessage("Callback has no user id received in the header");
+    }
+
+    @Test
     void should_report_error_if_classification_new_application_with_documents_and_without_ocr_data() {
         // given
         setUpTransformationUrl();


### PR DESCRIPTION
### Change description ###

Similarly (Or same) as callback for attaching documents, we require idam token to be there along with user id. They are mandatory and used in case creation so ccd has correct tracking and ownership.

Flags in request header annotations are marked as false so the response could be made properly to UI

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
