### PR TITLE
Add functional test for supplementary evidence with ocr classification

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
@@ -146,7 +146,7 @@ class ExceptionRecordCreationTest {
 
         // when
         String envelopeId = envelopeMessager.sendMessageFromFile(
-            "envelopes/supplementary-evidence-with-ocr-envelope.json", // no payments
+            "envelopes/supplementary-evidence-with-ocr-envelope.json",
             envelopeCaseRef,
             null,
             null,
@@ -160,10 +160,11 @@ class ExceptionRecordCreationTest {
             .until(() -> findCasesByEnvelopeId(envelopeId).size() == 1);
 
         CaseDetails exceptionRecord = findCasesByEnvelopeId(envelopeId).get(0);
-        assertThat(getCaseDataForField(exceptionRecord, "journeyClassification")).isEqualTo("SUPPLEMENTARY_EVIDENCE_WITH_OCR");
+        assertThat(getCaseDataForField(exceptionRecord, "journeyClassification"))
+            .isEqualTo("SUPPLEMENTARY_EVIDENCE_WITH_OCR");
         assertThat(getOcrData(exceptionRecord)).isEqualTo(expectedOcrData);
         assertThat(getCaseDataForField(exceptionRecord, "envelopeCaseReference")).isEqualTo(envelopeCaseRef);
-        assertThat(getCaseDataForField(exceptionRecord, "envelopeLegacyCaseReference")).isNull();
+        assertThat(getCaseDataForField(exceptionRecord, "envelopeLegacyCaseReference")).isEmpty();
     }
 
     private List<CaseDetails> findCasesByPoBox(UUID poBox) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ExceptionRecordCreationTest.java
@@ -135,12 +135,53 @@ class ExceptionRecordCreationTest {
             .until(() -> findCasesByPoBox(randomPoBox).size() == 1);
     }
 
+    @DisplayName("Should create ExceptionRecord when classification is SUPPLEMENTARY_EVIDENCE_WITH_OCR")
+    @Test
+    void create_exception_record_for_supplementary_evidence_with_ocr() throws Exception {
+        //given
+        String envelopeCaseRef = "1539860706648396";
+        Map<String, String> expectedOcrData = ImmutableMap.of(
+            "first_name", "value1", "last_name", "value2", "email", "hello@test.com"
+        );
+
+        // when
+        String envelopeId = envelopeMessager.sendMessageFromFile(
+            "envelopes/supplementary-evidence-with-ocr-envelope.json", // no payments
+            envelopeCaseRef,
+            null,
+            null,
+            dmUrl
+        );
+
+        // then
+        await("Exception record being created")
+            .atMost(60, TimeUnit.SECONDS)
+            .pollInterval(Duration.ofSeconds(5))
+            .until(() -> findCasesByEnvelopeId(envelopeId).size() == 1);
+
+        CaseDetails exceptionRecord = findCasesByEnvelopeId(envelopeId).get(0);
+        assertThat(getCaseDataForField(exceptionRecord, "journeyClassification")).isEqualTo("SUPPLEMENTARY_EVIDENCE_WITH_OCR");
+        assertThat(getOcrData(exceptionRecord)).isEqualTo(expectedOcrData);
+        assertThat(getCaseDataForField(exceptionRecord, "envelopeCaseReference")).isEqualTo(envelopeCaseRef);
+        assertThat(getCaseDataForField(exceptionRecord, "envelopeLegacyCaseReference")).isNull();
+    }
+
     private List<CaseDetails> findCasesByPoBox(UUID poBox) {
         return caseSearcher.search(
             SampleData.JURSIDICTION,
             SampleData.CONTAINER.toUpperCase() + "_" + CreateExceptionRecord.CASE_TYPE,
             ImmutableMap.of(
                 "case.poBox", poBox.toString()
+            )
+        );
+    }
+
+    private List<CaseDetails> findCasesByEnvelopeId(String envelopeId) {
+        return caseSearcher.search(
+            SampleData.JURSIDICTION,
+            SampleData.CONTAINER.toUpperCase() + "_" + CreateExceptionRecord.CASE_TYPE,
+            ImmutableMap.of(
+                "case.envelopeId", envelopeId
             )
         );
     }

--- a/src/functionalTest/resources/envelopes/supplementary-evidence-with-ocr-envelope.json
+++ b/src/functionalTest/resources/envelopes/supplementary-evidence-with-ocr-envelope.json
@@ -1,0 +1,40 @@
+{
+  "id": "{ENVELOPE_ID}",
+  "case_ref": "1539860706648396",
+  "po_box": "BULKSCAN PO BOX",
+  "jurisdiction": "BULKSCAN",
+  "container": "bulkscan",
+  "formType": "B123",
+  "classification": "SUPPLEMENTARY_EVIDENCE_WITH_OCR",
+  "zip_file_name": "zip-file-test-updated.zip",
+  "delivery_date": "1970-01-01T00:00:00.000Z",
+  "opening_date": "1970-01-01T00:00:00.000Z",
+  "documents": [
+    {
+      "file_name": "certificate1.pdf",
+      "control_number": "1545657689",
+      "type": "other",
+      "subtype": null,
+      "scanned_at": "2018-01-01T11:20:00.000Z",
+      "uuid": "ee69aee8-1a33-40dd-9af9-d90da1b104babc"
+    }
+  ],
+  "ocr_data": [
+    {
+      "metadata_field_name": "first_name",
+      "metadata_field_value": "value1"
+    },
+    {
+      "metadata_field_name": "last_name",
+      "metadata_field_value": "value2"
+    },
+    {
+      "metadata_field_name": "email",
+      "metadata_field_value": "hello@test.com"
+    }
+  ],
+  "ocr_data_validation_warnings": [
+  ],
+  "payments": [
+  ]
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-831


### Change description ###
Add functional test to check if an exception record is created 
for an envelope with "SUPPLEMENTARY_EVIDENCE_WITH_OCR" classification.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
