### PR TITLE
Set envelope case reference values empty

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -58,7 +58,7 @@ public class ExceptionRecordMapper {
             envelope.id,
             CollectionUtils.isEmpty(envelope.payments) ? NO : YES,
             CollectionUtils.isEmpty(envelope.payments) ? NO : YES,
-            // Setting the value as "", as null values are causing issues when used in ImmutableMap
+            // Setting the values as "", as null values are not supported by ImmutableMap
             isBlank(envelope.caseRef) ? "" : envelope.caseRef,
             isBlank(envelope.legacyCaseRef) ? "" : envelope.legacyCaseRef,
             setDisplayCaseReferenceFlag(envelope.caseRef, envelope.classification),

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapper.java
@@ -58,8 +58,9 @@ public class ExceptionRecordMapper {
             envelope.id,
             CollectionUtils.isEmpty(envelope.payments) ? NO : YES,
             CollectionUtils.isEmpty(envelope.payments) ? NO : YES,
-            isBlank(envelope.caseRef) ? null : envelope.caseRef,
-            isBlank(envelope.legacyCaseRef) ? null : envelope.legacyCaseRef,
+            // Setting the value as "", as null values are causing issues when used in ImmutableMap
+            isBlank(envelope.caseRef) ? "" : envelope.caseRef,
+            isBlank(envelope.legacyCaseRef) ? "" : envelope.legacyCaseRef,
             setDisplayCaseReferenceFlag(envelope.caseRef, envelope.classification),
             setDisplayCaseReferenceFlag(envelope.legacyCaseRef, envelope.classification)
         );

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -163,8 +163,8 @@ class ExceptionRecordMapperTest {
         ExceptionRecord exceptionRecord = mapper.mapEnvelope(envelope);
 
         // then
-        assertThat(exceptionRecord.envelopeCaseReference).isNull();
-        assertThat(exceptionRecord.envelopeLegacyCaseReference).isNull();
+        assertThat(exceptionRecord.envelopeCaseReference).isEmpty();
+        assertThat(exceptionRecord.envelopeLegacyCaseReference).isEmpty();
         assertThat(exceptionRecord.showEnvelopeCaseReference).isEqualTo("No");
         assertThat(exceptionRecord.showEnvelopeLegacyCaseReference).isEqualTo("No");
     }


### PR DESCRIPTION
### Change description ###
Fix master build (Create case functional tests)
Envelope case references fields are set to "null" when values are provided in the envelope. 
This is causing issues when creating a case as we are using the immutable map in some places.
Immutable Map does not allow "null" values and causing problems when creating a case.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
