### PR TITLE
Revert #746 Disable `case-creation` functional test

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
@@ -38,10 +38,6 @@ import static org.awaitility.Awaitility.await;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.BULK_SCANNED_CASE_TYPE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.EVENT_ID_CREATE_NEW_CASE;
 
-// remove once master build is green
-@Disabled(
-    "Incompatible version in AAT makes this suite un-passable until the fix which is currently in master is deployed"
-)
 @SpringBootTest
 @ActiveProfiles("nosb") // no servicebus queue handler registration
 class CreateCaseTest {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableMap;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;


### PR DESCRIPTION
### Change description ###
Create case functional tests were disabled in #746 
Enabling them as the master build is fixed now. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
