### PR TITLE
Used HashMap instead of ImmutableMap to handle null values

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import feign.FeignException;
 import io.vavr.collection.Seq;
 import io.vavr.control.Try;
@@ -30,6 +29,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -386,9 +386,14 @@ public class CreateCaseCallbackService {
                 .put(OCR_DATA_VALIDATION_WARNINGS, emptyList())
                 .build();
 
-        return ImmutableMap.<String, Object>builder()
-            .putAll(Maps.difference(originalFields, fieldsToUpdate).entriesOnlyOnLeft())
-            .putAll(fieldsToUpdate)
-            .build();
+        Map<String, Object> finalizedMap = new HashMap<>();
+        for (String key: originalFields.keySet()) {
+            if (!fieldsToUpdate.containsKey(key)) {
+                finalizedMap.put(key, originalFields.get(key));
+            }
+        }
+        finalizedMap.putAll(fieldsToUpdate);
+
+        return finalizedMap;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -799,6 +799,7 @@ class CreateCaseCallbackServiceTest {
 
     private Map<String, Object> basicCaseData() {
         Map<String, Object> data = new HashMap<>();
+        data.put("envelopeLegacyCaseReference", null);
         data.put("poBox", "12345");
         data.put("journeyClassification", EXCEPTION.name());
         data.put("formType", "A1");


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
ImmutableMap does not allow null values as might be necessary for envelopeLegacyCaseReference or envelopeCaseReference in exception record, HashMap is used instead.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
