### PR TITLE
Introduce service response parser

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/ServiceClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/ServiceClient.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.CaseTransformationException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.InvalidCaseDataException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.TransformationErrorResponse;
+
+import java.io.IOException;
+
+@Component
+public class ServiceClient {
+
+    protected final ObjectMapper objectMapper;
+
+    protected ServiceClient(
+        ObjectMapper objectMapper
+    ) {
+        this.objectMapper = objectMapper;
+    }
+
+    public void tryParseResponseBodyAndThrow(HttpStatusCodeException exception) throws CaseTransformationException {
+        try {
+            TransformationErrorResponse errorResponse = objectMapper.readValue(
+                exception.getResponseBodyAsByteArray(),
+                TransformationErrorResponse.class
+            );
+
+            throw new InvalidCaseDataException(exception, errorResponse);
+        } catch (IOException ioException) {
+            throw new CaseTransformationException(exception, ioException.getMessage());
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/ServiceResponseParser.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/ServiceResponseParser.java
@@ -10,11 +10,11 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.res
 import java.io.IOException;
 
 @Component
-public class ServiceClient {
+public class ServiceResponseParser {
 
     protected final ObjectMapper objectMapper;
 
-    protected ServiceClient(
+    protected ServiceResponseParser(
         ObjectMapper objectMapper
     ) {
         this.objectMapper = objectMapper;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClient.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.ServiceClient;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.ServiceResponseParser;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
 
@@ -22,14 +22,14 @@ public class TransformationClient {
 
     private final RestTemplate restTemplate;
 
-    private final ServiceClient serviceClient;
+    private final ServiceResponseParser serviceResponseParser;
 
     public TransformationClient(
         RestTemplate restTemplate,
-        ServiceClient serviceClient
+        ServiceResponseParser serviceResponseParser
     ) {
         this.restTemplate = restTemplate;
-        this.serviceClient = serviceClient;
+        this.serviceResponseParser = serviceResponseParser;
     }
 
     public SuccessfulTransformationResponse transformExceptionRecord(
@@ -62,7 +62,7 @@ public class TransformationClient {
             );
 
             if (ex.getStatusCode().equals(UNPROCESSABLE_ENTITY) || ex.getStatusCode().equals(BAD_REQUEST)) {
-                serviceClient.tryParseResponseBodyAndThrow(ex);
+                serviceResponseParser.tryParseResponseBodyAndThrow(ex);
             }
 
             throw new CaseTransformationException(ex, ex.getResponseBodyAsString());


### PR DESCRIPTION
### JIRA link (if applicable) ###
[Orchestrator to update cases with Supplementary Evidence](https://tools.hmcts.net/jira/browse/BPS-833)

### Change description ###
Added ServiceResponseParser - common component to be used in service client classes
In next PRs transformation specific classes will be renamed to more generic ones and UpdateClient will be introduced and called from service layer.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
