### PR TITLE
Renamed transformation specific classes

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClientTest.java
@@ -33,7 +33,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
@@ -85,19 +85,15 @@ public class TransformationClientTest {
         stubFor(
             post(urlPathMatching(TRANSFORM_EXCEPTION_RECORD_URL))
                 .withHeader("ServiceAuthorization", equalTo(s2sToken))
-                .willReturn(aResponse().withBody(errorResponse().toString()).withStatus(422)));
+                .willReturn(aResponse().withBody(errorResponse().toString()).withStatus(UNPROCESSABLE_ENTITY.value())));
 
         // when
-        Throwable throwable = catchThrowable(
-            () -> client.transformExceptionRecord(url(), exceptionRecordRequestData(), s2sToken)
+        InvalidCaseDataException exception = catchThrowableOfType(
+            () -> client.transformExceptionRecord(url(), exceptionRecordRequestData(), s2sToken),
+            InvalidCaseDataException.class
         );
 
         // then
-        assertThat(throwable).isInstanceOf(InvalidCaseDataException.class);
-
-        // and
-        InvalidCaseDataException exception = (InvalidCaseDataException) throwable;
-
         assertThat(exception.getStatus()).isEqualTo(UNPROCESSABLE_ENTITY);
         assertThat(exception.getResponse()).isNotNull();
         assertThat(exception.getResponse().errors).isNotEmpty();
@@ -111,19 +107,15 @@ public class TransformationClientTest {
         stubFor(
             post(urlPathMatching(TRANSFORM_EXCEPTION_RECORD_URL))
                 .withHeader("ServiceAuthorization", equalTo(s2sToken))
-                .willReturn(aResponse().withBody(invalidDataResponse().toString()).withStatus(400)));
+                .willReturn(aResponse().withBody(invalidDataResponse().toString()).withStatus(BAD_REQUEST.value())));
 
         // when
-        Throwable throwable = catchThrowable(
-            () -> client.transformExceptionRecord(url(), exceptionRecordRequestData(), s2sToken)
+        InvalidCaseDataException exception = catchThrowableOfType(
+            () -> client.transformExceptionRecord(url(), exceptionRecordRequestData(), s2sToken),
+            InvalidCaseDataException.class
         );
 
         // then
-        assertThat(throwable).isInstanceOf(InvalidCaseDataException.class);
-
-        // and
-        InvalidCaseDataException exception = (InvalidCaseDataException) throwable;
-
         assertThat(exception.getStatus()).isEqualTo(BAD_REQUEST);
         assertThat(exception.getResponse()).isNotNull();
         assertThat(exception.getResponse().errors).isNotEmpty();
@@ -137,19 +129,15 @@ public class TransformationClientTest {
         stubFor(
             post(urlPathMatching(TRANSFORM_EXCEPTION_RECORD_URL))
                 .withHeader("ServiceAuthorization", equalTo(s2sToken))
-                .willReturn(aResponse().withBody(new byte[]{}).withStatus(400)));
+                .willReturn(aResponse().withBody(new byte[]{}).withStatus(BAD_REQUEST.value())));
 
         // when
-        Throwable throwable = catchThrowable(
-            () -> client.transformExceptionRecord(url(), exceptionRecordRequestData(), s2sToken)
+        CaseClientServiceException exception = catchThrowableOfType(
+            () -> client.transformExceptionRecord(url(), exceptionRecordRequestData(), s2sToken),
+            CaseClientServiceException.class
         );
 
         // then
-        assertThat(throwable).isInstanceOf(CaseClientServiceException.class);
-
-        // and
-        CaseClientServiceException exception = (CaseClientServiceException) throwable;
-
         assertThat(exception.getStatus()).isEqualTo(BAD_REQUEST);
         assertThat(exception.getResponse()).contains("No content to map due to end-of-input"); // because byte[]{}
         assertThat(exception.getResponseRawBody()).isEmpty();
@@ -163,15 +151,14 @@ public class TransformationClientTest {
                 .willReturn(forbidden().withBody("Calling service is not authorised")));
 
         // when
-        Throwable throwable = catchThrowable(
-            () -> client.transformExceptionRecord(url(), exceptionRecordRequestData(), randomUUID().toString())
+        CaseClientServiceException exception = catchThrowableOfType(
+            () -> client.transformExceptionRecord(url(), exceptionRecordRequestData(), randomUUID().toString()),
+            CaseClientServiceException.class
         );
 
         // then
-        assertThat(throwable).isInstanceOf(CaseClientServiceException.class);
-        CaseClientServiceException response = (CaseClientServiceException) throwable;
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN);
-        assertThat(response.getResponse()).contains("Calling service is not authorised");
+        assertThat(exception.getStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(exception.getResponse()).contains("Calling service is not authorised");
     }
 
     @Test
@@ -182,15 +169,14 @@ public class TransformationClientTest {
                 .willReturn(unauthorized().withBody("Invalid S2S token")));
 
         // when
-        Throwable throwable = catchThrowable(
-            () -> client.transformExceptionRecord(url(), exceptionRecordRequestData(), randomUUID().toString())
+        CaseClientServiceException exception = catchThrowableOfType(
+            () -> client.transformExceptionRecord(url(), exceptionRecordRequestData(), randomUUID().toString()),
+            CaseClientServiceException.class
         );
 
         // then
-        assertThat(throwable).isInstanceOf(CaseClientServiceException.class);
-        CaseClientServiceException response = (CaseClientServiceException) throwable;
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
-        assertThat(response.getResponse()).contains("Invalid S2S token");
+        assertThat(exception.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(exception.getResponse()).contains("Invalid S2S token");
     }
 
     @Test
@@ -201,15 +187,14 @@ public class TransformationClientTest {
                 .willReturn(serverError().withBody("Internal Server error")));
 
         // when
-        Throwable throwable = catchThrowable(
-            () -> client.transformExceptionRecord(url(), exceptionRecordRequestData(), randomUUID().toString())
+        CaseClientServiceException exception = catchThrowableOfType(
+            () -> client.transformExceptionRecord(url(), exceptionRecordRequestData(), randomUUID().toString()),
+            CaseClientServiceException.class
         );
 
         // then
-        assertThat(throwable).isInstanceOf(CaseClientServiceException.class);
-        CaseClientServiceException response = (CaseClientServiceException) throwable;
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-        assertThat(response.getResponse()).contains("Internal Server error");
+        assertThat(exception.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(exception.getResponse()).contains("Internal Server error");
     }
 
     private String url() {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClientTest.java
@@ -145,10 +145,10 @@ public class TransformationClientTest {
         );
 
         // then
-        assertThat(throwable).isInstanceOf(CaseTransformationException.class);
+        assertThat(throwable).isInstanceOf(CaseClientServiceException.class);
 
         // and
-        CaseTransformationException exception = (CaseTransformationException) throwable;
+        CaseClientServiceException exception = (CaseClientServiceException) throwable;
 
         assertThat(exception.getStatus()).isEqualTo(BAD_REQUEST);
         assertThat(exception.getResponse()).contains("No content to map due to end-of-input"); // because byte[]{}
@@ -168,8 +168,8 @@ public class TransformationClientTest {
         );
 
         // then
-        assertThat(throwable).isInstanceOf(CaseTransformationException.class);
-        CaseTransformationException response = (CaseTransformationException) throwable;
+        assertThat(throwable).isInstanceOf(CaseClientServiceException.class);
+        CaseClientServiceException response = (CaseClientServiceException) throwable;
         assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN);
         assertThat(response.getResponse()).contains("Calling service is not authorised");
     }
@@ -187,8 +187,8 @@ public class TransformationClientTest {
         );
 
         // then
-        assertThat(throwable).isInstanceOf(CaseTransformationException.class);
-        CaseTransformationException response = (CaseTransformationException) throwable;
+        assertThat(throwable).isInstanceOf(CaseClientServiceException.class);
+        CaseClientServiceException response = (CaseClientServiceException) throwable;
         assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertThat(response.getResponse()).contains("Invalid S2S token");
     }
@@ -206,8 +206,8 @@ public class TransformationClientTest {
         );
 
         // then
-        assertThat(throwable).isInstanceOf(CaseTransformationException.class);
-        CaseTransformationException response = (CaseTransformationException) throwable;
+        assertThat(throwable).isInstanceOf(CaseClientServiceException.class);
+        CaseClientServiceException response = (CaseClientServiceException) throwable;
         assertThat(response.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(response.getResponse()).contains("Internal Server error");
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/ServiceResponseParser.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/ServiceResponseParser.java
@@ -3,9 +3,9 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpStatusCodeException;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.CaseTransformationException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response.ClientServiceErrorResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.CaseClientServiceException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.InvalidCaseDataException;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.TransformationErrorResponse;
 
 import java.io.IOException;
 
@@ -20,16 +20,16 @@ public class ServiceResponseParser {
         this.objectMapper = objectMapper;
     }
 
-    public void tryParseResponseBodyAndThrow(HttpStatusCodeException exception) throws CaseTransformationException {
+    public void tryParseResponseBodyAndThrow(HttpStatusCodeException exception) throws CaseClientServiceException {
         try {
-            TransformationErrorResponse errorResponse = objectMapper.readValue(
+            ClientServiceErrorResponse errorResponse = objectMapper.readValue(
                 exception.getResponseBodyAsByteArray(),
-                TransformationErrorResponse.class
+                ClientServiceErrorResponse.class
             );
 
             throw new InvalidCaseDataException(exception, errorResponse);
         } catch (IOException ioException) {
-            throw new CaseTransformationException(exception, ioException.getMessage());
+            throw new CaseClientServiceException(exception, ioException.getMessage());
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/model/response/ClientServiceErrorResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/model/response/ClientServiceErrorResponse.java
@@ -1,15 +1,15 @@
-package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response;
+package uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-public class TransformationErrorResponse {
+public class ClientServiceErrorResponse {
 
     public final List<String> errors;
     public final List<String> warnings;
 
-    public TransformationErrorResponse(
+    public ClientServiceErrorResponse(
         @JsonProperty("errors") List<String> errors,
         @JsonProperty("warnings") List<String> warnings
     ) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/CaseClientServiceException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/CaseClientServiceException.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpStatusCodeException;
 
-public class CaseTransformationException extends Exception {
+public class CaseClientServiceException extends Exception {
 
     private static final long serialVersionUID = 8081182548244205380L;
 
@@ -11,7 +11,7 @@ public class CaseTransformationException extends Exception {
 
     private final transient String response;
 
-    public CaseTransformationException(HttpStatusCodeException cause, String response) {
+    public CaseClientServiceException(HttpStatusCodeException cause, String response) {
         super(cause);
 
         this.status = cause.getStatusCode();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/InvalidCaseDataException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/InvalidCaseDataException.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpStatusCodeException;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.TransformationErrorResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response.ClientServiceErrorResponse;
 
 public class InvalidCaseDataException extends RuntimeException {
 
@@ -10,11 +10,11 @@ public class InvalidCaseDataException extends RuntimeException {
 
     private final HttpStatus status;
 
-    private final transient TransformationErrorResponse response;
+    private final transient ClientServiceErrorResponse response;
 
     public InvalidCaseDataException(
         HttpStatusCodeException cause,
-        TransformationErrorResponse response
+        ClientServiceErrorResponse response
     ) {
         super(cause);
         this.status = cause.getStatusCode();
@@ -25,7 +25,7 @@ public class InvalidCaseDataException extends RuntimeException {
         return status;
     }
 
-    public TransformationErrorResponse getResponse() {
+    public ClientServiceErrorResponse getResponse() {
         return response;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClient.java
@@ -36,7 +36,7 @@ public class TransformationClient {
         String baseUrl,
         ExceptionRecord exceptionRecord,
         String s2sToken
-    ) throws CaseTransformationException {
+    ) throws CaseClientServiceException {
         HttpHeaders headers = new HttpHeaders();
         headers.add("ServiceAuthorization", s2sToken);
 
@@ -65,7 +65,7 @@ public class TransformationClient {
                 serviceResponseParser.tryParseResponseBodyAndThrow(ex);
             }
 
-            throw new CaseTransformationException(ex, ex.getResponseBodyAsString());
+            throw new CaseClientServiceException(ex, ex.getResponseBodyAsString());
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
@@ -8,13 +8,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.CaseTransformationException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response.ClientServiceErrorResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.CaseClientServiceException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.InvalidCaseDataException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.TransformationClient;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.CaseCreationDetails;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.TransformationErrorResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CallbackException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.ProcessResult;
@@ -224,13 +224,13 @@ class CcdNewCaseCreatorTest {
 
     @Test
     void should_throw_InvalidCaseDataException_when_transformation_client_returns_422()
-        throws IOException, CaseTransformationException {
+        throws IOException, CaseClientServiceException {
         // given
         when(s2sTokenGenerator.generate()).thenReturn(randomUUID().toString());
         //setUpTransformationUrl();
         InvalidCaseDataException exception = new InvalidCaseDataException(
             new HttpClientErrorException(HttpStatus.UNPROCESSABLE_ENTITY),
-            new TransformationErrorResponse(singletonList("error"), singletonList("warning"))
+            new ClientServiceErrorResponse(singletonList("error"), singletonList("warning"))
         );
         doThrow(exception)
             .when(transformationClient)


### PR DESCRIPTION
### JIRA link (if applicable) ###
[Orchestrator to update cases with Supplementary Evidence](https://tools.hmcts.net/jira/browse/BPS-833)


### Change description ###
Renamed transformation specific classes (CaseTransformationException, TransformationErrorResponse) to more generic (CaseClientServiceException, ClientServiceErrorResponse), moved ClientServiceErrorResponse to a higher level package.

The next PR will introduce UpdateClient class - implementing low level piece of functionality for the task.

There will be a PR to call UpdateClient from service layer


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
