### PR TITLE
set exception record case reference to create case data

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
@@ -94,7 +94,7 @@ class CreateCaseTest {
 
         assertThat(createdCase.getData().get("bulkScanCaseReference")).isNotNull();
         String bulkScanCaseReference = (String)createdCase.getData().get("bulkScanCaseReference");
-        assertThat(bulkScanCaseReference.equals(exceptionRecord.getId()));
+        assertThat(bulkScanCaseReference.equals(String.valueOf(exceptionRecord.getId())));
 
         await("Case is ingested")
             .atMost(2, TimeUnit.SECONDS)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
@@ -86,11 +86,6 @@ public class CcdNewCaseCreator {
                 exceptionRecord.id
             );
 
-            checkBulkScanReferenceIsSet(
-                (Map<String, ?>) transformationResponse.caseCreationDetails.caseData,
-                exceptionRecord.id
-            );
-
             long newCaseId = createNewCaseInCcd(
                 idamToken,
                 s2sToken,
@@ -161,7 +156,9 @@ public class CcdNewCaseCreator {
                 CaseDataContent
                     .builder()
                     .caseReference(exceptionRecord.id)
-                    .data(caseCreationDetails.caseData)
+                    .data(caseDataWithExceptionRecordId(
+                        caseCreationDetails.caseData, exceptionRecord.id
+                    )) // set bulk scan case reference
                     .event(Event
                         .builder()
                         .id(eventResponse.getEventId())
@@ -194,19 +191,10 @@ public class CcdNewCaseCreator {
         }
     }
 
-    private void checkBulkScanReferenceIsSet(Map<String, ?> caseData, String exceptionRecordId) {
-        if (!caseData.containsKey(EXCEPTION_RECORD_REFERENCE)) {
-            log.error(
-                "Transformation did not set '{}' with exception record id {}",
-                EXCEPTION_RECORD_REFERENCE,
-                exceptionRecordId
-            );
-        } else if (!caseData.get(EXCEPTION_RECORD_REFERENCE).equals(exceptionRecordId)) {
-            log.error(
-                "Transformation did not set exception record reference correctly. Actual: {}, expected: {}",
-                caseData.get(EXCEPTION_RECORD_REFERENCE),
-                exceptionRecordId
-            );
-        }
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> caseDataWithExceptionRecordId(Object caseData, String exceptionRecordId) {
+        Map<String, Object> data = (Map<String, Object>) caseData;
+        data.put(EXCEPTION_RECORD_REFERENCE, exceptionRecordId);
+        return data;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
@@ -31,7 +31,6 @@ import java.util.Map;
 
 import static java.time.LocalDateTime.now;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -90,13 +89,13 @@ class CcdNewCaseCreatorTest {
     @Test
     void should_call_payments_handler_when_case_has_payments() throws Exception {
         // given
-        given(transformationClient.transformExceptionRecord(any(),any(), any()))
+        given(transformationClient.transformExceptionRecord(any(), any(), any()))
             .willReturn(
                 new SuccessfulTransformationResponse(
                     new CaseCreationDetails(
                         "some_case_type",
                         "some_event_id",
-                        emptyMap()
+                        basicCaseData()
                     ),
                     emptyList()
                 )
@@ -117,23 +116,7 @@ class CcdNewCaseCreatorTest {
         ServiceConfigItem configItem = getConfigItem();
         ExceptionRecord exceptionRecord = getExceptionRecord();
 
-        Map<String, Object> data = new HashMap<>();
-
-        String envelopeId = "987";
-        String jurisdiction = "sample jurisdiction";
-
-        data.put("poBox", "12345");
-        data.put("journeyClassification", EXCEPTION.name());
-        data.put("formType", "A1");
-        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
-        data.put("openingDate", "2019-09-06T15:30:04.000Z");
-        data.put("scannedDocuments", TestCaseBuilder.document("https://url", "name"));
-        data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("key", "value"));
-        data.put(ExceptionRecordFields.CONTAINS_PAYMENTS, YesNoFieldValues.YES);
-        data.put(ExceptionRecordFields.ENVELOPE_ID, envelopeId);
-        data.put(ExceptionRecordFields.PO_BOX_JURISDICTION, jurisdiction);
-
-        CaseDetails caseDetails = getCaseDetails(data);
+        CaseDetails caseDetails = getCaseDetails(basicCaseData());
 
         // when
         ProcessResult result =
@@ -163,7 +146,7 @@ class CcdNewCaseCreatorTest {
                     new CaseCreationDetails(
                         "some_case_type",
                         "some_event_id",
-                        emptyMap()
+                        basicCaseData()
                     ),
                     emptyList()
                 )
@@ -275,7 +258,7 @@ class CcdNewCaseCreatorTest {
         given(transformationClient.transformExceptionRecord(any(), any(), any()))
             .willReturn(
                 new SuccessfulTransformationResponse(
-                    new CaseCreationDetails("some_case_type", "some_event_id", emptyMap()),
+                    new CaseCreationDetails("some_case_type", "some_event_id", basicCaseData()),
                     emptyList()
                 )
             );


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-896

### Change description ###
- Set the `bulkscanCaseRefernce` field value after receiving the Transformation response
- Removed checking if the transformation response has `bulkscanCaseRefernce` field value set

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
