### PR TITLE
Create a new map when updating the case data in the transformation response

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -203,7 +204,7 @@ public class CcdNewCaseCreator {
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> caseDataWithExceptionRecordId(Object caseData, String exceptionRecordId) {
-        Map<String, Object> data = (Map<String, Object>) caseData;
+        Map<String, Object> data = new HashMap((Map<String, Object>) caseData);
         data.put(EXCEPTION_RECORD_REFERENCE, exceptionRecordId);
         return data;
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-896

### Change description ###
- `bulkScanCaseReference` value can not be set to the `caseData` in transformation response if the `caseData` returned from the service is an Immutable Map.
- Creating a new map from the `caseData` in transformation response and set the `bulkScanCaseReference`  field value.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
