### PR TITLE
separate submit event methods for exception record creation and automatic attachment

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -258,50 +258,57 @@ public class CcdApi {
     ) {
         return caseRef == null
             ? feignCcdApi.startForCaseworker(
-                authenticator.getUserToken(),
-                authenticator.getServiceToken(),
-                authenticator.getUserDetails().getId(),
-                jurisdiction,
-                caseTypeId,
-                eventTypeId
-            )
+            authenticator.getUserToken(),
+            authenticator.getServiceToken(),
+            authenticator.getUserDetails().getId(),
+            jurisdiction,
+            caseTypeId,
+            eventTypeId
+        )
             : feignCcdApi.startEventForCaseWorker(
-                authenticator.getUserToken(),
-                authenticator.getServiceToken(),
-                authenticator.getUserDetails().getId(),
-                jurisdiction,
-                caseTypeId,
-                caseRef,
-                eventTypeId
-            );
+            authenticator.getUserToken(),
+            authenticator.getServiceToken(),
+            authenticator.getUserDetails().getId(),
+            jurisdiction,
+            caseTypeId,
+            caseRef,
+            eventTypeId
+        );
     }
 
     public CaseDetails submitEvent(
         CcdAuthenticator authenticator,
         String jurisdiction,
         String caseTypeId,
+        CaseDataContent caseDataContent
+    ) {
+        return feignCcdApi.submitForCaseworker(
+            authenticator.getUserToken(),
+            authenticator.getServiceToken(),
+            authenticator.getUserDetails().getId(),
+            jurisdiction,
+            caseTypeId,
+            true,
+            caseDataContent
+        );
+    }
+
+    public CaseDetails submitEventForExistingCase(
+        CcdAuthenticator authenticator,
+        String jurisdiction,
+        String caseTypeId,
         String caseRef,
         CaseDataContent caseDataContent
     ) {
-        return caseRef == null
-            ? feignCcdApi.submitForCaseworker(
-                authenticator.getUserToken(),
-                authenticator.getServiceToken(),
-                authenticator.getUserDetails().getId(),
-                jurisdiction,
-                caseTypeId,
-                true,
-                caseDataContent
-            )
-            : feignCcdApi.submitEventForCaseWorker(
-                authenticator.getUserToken(),
-                authenticator.getServiceToken(),
-                authenticator.getUserDetails().getId(),
-                jurisdiction,
-                caseTypeId,
-                caseRef,
-                true,
-                caseDataContent
-            );
+        return feignCcdApi.submitEventForCaseWorker(
+            authenticator.getUserToken(),
+            authenticator.getServiceToken(),
+            authenticator.getUserDetails().getId(),
+            jurisdiction,
+            caseTypeId,
+            caseRef,
+            true,
+            caseDataContent
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -65,7 +65,7 @@ class AttachDocsToSupplementaryEvidence {
                 existingCase.getId()
             );
 
-            ccdApi.submitEvent(
+            ccdApi.submitEventForExistingCase(
                 authenticator,
                 envelope.jurisdiction,
                 existingCase.getCaseTypeId(),

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -81,7 +81,6 @@ public class CreateExceptionRecord {
             authenticator,
             envelope.jurisdiction,
             caseTypeId,
-            null,
             buildCaseDataContent(envelope, startEventResponse.getToken())
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
@@ -66,7 +66,7 @@ class AttachDocsToSupplementaryEvidenceTest {
         given(startEventResponse.getCaseDetails().getData()).willReturn(ccdData);
 
         given(ccdApi.startEvent(any(), any(), any(), any(), any())).willReturn(startEventResponse);
-        given(ccdApi.submitEvent(any(), any(), any(), any(), any())).willReturn(caseDetails);
+        given(ccdApi.submitEventForExistingCase(any(), any(), any(), any(), any())).willReturn(caseDetails);
 
         String caseId = "1539007368674134";
         given(caseDetails.getId()).willReturn(Long.parseLong(caseId));
@@ -88,7 +88,7 @@ class AttachDocsToSupplementaryEvidenceTest {
         );
         ArgumentCaptor<CaseDataContent> caseDataContentCaptor = ArgumentCaptor.forClass(CaseDataContent.class);
 
-        verify(ccdApi).submitEvent(
+        verify(ccdApi).submitEventForExistingCase(
             eq(AUTH_DETAILS),
             eq(envelope.jurisdiction),
             eq(CASE_TYPE_ID),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/ExceptionRecordCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/ExceptionRecordCreatorTest.java
@@ -94,7 +94,6 @@ public class ExceptionRecordCreatorTest {
             any(),
             eq(envelope.jurisdiction),
             eq(expectedCaseTypeId),
-            eq(null),
             caseDataContentArgumentCaptor.capture()
         );
 
@@ -108,7 +107,7 @@ public class ExceptionRecordCreatorTest {
 
         CaseDetails caseDetails = mock(CaseDetails.class);
         given(caseDetails.getId()).willReturn(CASE_DETAILS_ID);
-        given(ccdApi.submitEvent(any(),any(), any(), any(), any()))
+        given(ccdApi.submitEvent(any(),any(), any(), any()))
             .willReturn(caseDetails);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-932

### Change description ###
Separating exception record creation and automatic attachment submit event calls in `CcdApi` class.
In the next pr, exception handling will be added for automatic attachment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
