### PR TITLE
Create Exception record when ccd returns 404 response for supplementary evidence

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/Environment.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/Environment.java
@@ -30,6 +30,7 @@ public final class Environment {
     public static final String CASE_EVENT_URL = CASE_URL + "/events";
     public static final String CASE_SUBMIT_URL = CASE_TYPE_URL + "/cases";
     public static final String CASE_EVENT_TRIGGER_START_URL = CASE_TYPE_URL + "/event-triggers/createException/token";
+    public static final String ATTACH_DOCS_START_EVENT_URL = CASE_URL + "/event-triggers/attachScannedDocs/token";
 
     private Environment() {
         // utility class construct

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/SupplementaryEvidenceCreatorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/SupplementaryEvidenceCreatorTest.java
@@ -1,26 +1,39 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.microsoft.azure.servicebus.IMessageReceiver;
 import com.microsoft.azure.servicebus.Message;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.HttpStatus;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.IntegrationTest;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.EnvelopeEventProcessor;
 
 import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.fileContentAsString;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.CASE_EVENT_URL;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.CASE_REF;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.CASE_SEARCH_URL;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.CASE_SUBMIT_URL;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.CASE_TYPE_BULK_SCAN;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.CASE_TYPE_EXCEPTION_RECORD;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.EXCEPTION_RECORD_SEARCH_URL;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.GET_CASE_URL;
 
 @IntegrationTest
@@ -37,14 +50,30 @@ class SupplementaryEvidenceCreatorTest {
     @Autowired
     private EnvelopeEventProcessor envelopeEventProcessor;
 
+    private static final String CREATE_ExCEPTION_RECORD_SUBMIT_URL = Environment.CASE_SUBMIT_URL
+        .replace(CASE_TYPE_BULK_SCAN, CASE_TYPE_EXCEPTION_RECORD);
+
+    private static final String CREATE_EXCEPTION_START_EVENT_URL = Environment.CASE_EVENT_TRIGGER_START_URL
+        .replace(CASE_TYPE_BULK_SCAN, CASE_TYPE_EXCEPTION_RECORD);
+
+    private static final String SERVICE_AUTHORIZATION_HEADER = "ServiceAuthorization";
+
+    // see WireMock mapping json files
+    private static final String MOCKED_IDAM_TOKEN_SIG = "q6hDG0Z1Qbinwtl8TgeDrAVV0LlCTRtbQqBYoMjd03k";
+    private static final String MOCKED_S2S_TOKEN_SIG =
+        "X1-LdZAd5YgGFP16-dQrpqEICqRmcu1zL_zeCLyUqMjb5DVx7xoU-r8yXHfgd4tmmjGqbsBz_kLqgu8yruSbtg";
+
+    private static final String ELASTICSEARCH_EMPTY_RESPONSE = "{\"total\": 0,\"cases\": []}";
+
+    @BeforeEach
+    void before() throws Exception {
+        givenThat(get(GET_CASE_URL).willReturn(aResponse().withBody(MOCK_RESPONSE)));
+        given(messageReceiver.receive()).willReturn(MOCK_MESSAGE).willReturn(null);
+    }
 
     @DisplayName("Should call ccd to attach supplementary evidence for caseworker")
     @Test
     void should_call_ccd_to_attach_supplementary_evidence_for_caseworker() throws Exception {
-        // given
-        givenThat(get(GET_CASE_URL).willReturn(aResponse().withBody(MOCK_RESPONSE)));
-        given(messageReceiver.receive()).willReturn(MOCK_MESSAGE).willReturn(null);
-
         // when
         envelopeEventProcessor.processNextMessage();
 
@@ -58,5 +87,78 @@ class SupplementaryEvidenceCreatorTest {
 
                 return true;
             });
+    }
+
+    @DisplayName("Should create Exception record when attachScannedDocs ccd event is not configured for case type")
+    @Test
+    void should_create_exception_record_when_attachScannedDocs_start_event_fails() throws Exception {
+        // given
+        givenThat(attachScannedDocsCcdStartEvent().willReturn(aResponse().withStatus(HttpStatus.NOT_FOUND.value())));
+        stubCreateExceptionCcdEvents();
+
+        // when
+        envelopeEventProcessor.processNextMessage();
+
+        // then
+        await()
+            .atMost(60, TimeUnit.SECONDS)
+            .ignoreExceptions()
+            .until(() -> {
+                WireMock.verify(postRequestedFor(urlPathEqualTo(CREATE_ExCEPTION_RECORD_SUBMIT_URL)));
+                return true;
+            });
+    }
+
+    @DisplayName("Should create Exception record when attachScannedDocs ccd event authorisation is missing")
+    @Test
+    void should_create_exception_record_when_attachScannedDocs_submit_event_fails() throws Exception {
+        // given
+        givenThat(attachScannedDocsCcdSubmitEvent().willReturn(aResponse().withStatus(HttpStatus.NOT_FOUND.value())));
+        stubCreateExceptionCcdEvents();
+
+        // when
+        envelopeEventProcessor.processNextMessage();
+
+        // then
+        await()
+            .atMost(60, TimeUnit.SECONDS)
+            .ignoreExceptions()
+            .until(() -> {
+                WireMock.verify(postRequestedFor(urlPathEqualTo(CREATE_ExCEPTION_RECORD_SUBMIT_URL)));
+                return true;
+            });
+    }
+
+    private void stubCreateExceptionCcdEvents() {
+        givenThat(exceptionRecordCcdStartEvent().willReturn(aResponse().withBody(
+            "{\"case_details\":null,\"event_id\":\"eid\",\"token\":\"etoken\"}"
+        )));
+
+        givenThat(post(CASE_SEARCH_URL).willReturn(
+            aResponse().withBody(ELASTICSEARCH_EMPTY_RESPONSE)
+        ));
+
+        givenThat(post(EXCEPTION_RECORD_SEARCH_URL).willReturn(
+            aResponse().withBody(ELASTICSEARCH_EMPTY_RESPONSE)
+        ));
+    }
+
+    private MappingBuilder attachScannedDocsCcdStartEvent() {
+        return get(Environment.ATTACH_DOCS_START_EVENT_URL)
+            .withHeader(AUTHORIZATION, containing(MOCKED_IDAM_TOKEN_SIG))
+            .withHeader(SERVICE_AUTHORIZATION_HEADER, containing(MOCKED_S2S_TOKEN_SIG));
+    }
+
+    private MappingBuilder attachScannedDocsCcdSubmitEvent() {
+        return post(CASE_SUBMIT_URL + "/" + CASE_REF + "/events?ignore-warning=true")
+            .withHeader(AUTHORIZATION, containing(MOCKED_IDAM_TOKEN_SIG))
+            .withHeader(SERVICE_AUTHORIZATION_HEADER, containing(MOCKED_S2S_TOKEN_SIG));
+    }
+
+
+    private MappingBuilder exceptionRecordCcdStartEvent() {
+        return get(CREATE_EXCEPTION_START_EVENT_URL)
+            .withHeader(AUTHORIZATION, containing(MOCKED_IDAM_TOKEN_SIG))
+            .withHeader(SERVICE_AUTHORIZATION_HEADER, containing(MOCKED_S2S_TOKEN_SIG));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/SupplementaryEvidenceCreatorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/SupplementaryEvidenceCreatorTest.java
@@ -27,7 +27,6 @@ import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.fileContentAsString;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.CASE_EVENT_URL;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.CASE_REF;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.CASE_SEARCH_URL;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.CASE_SUBMIT_URL;
@@ -50,7 +49,7 @@ class SupplementaryEvidenceCreatorTest {
     @Autowired
     private EnvelopeEventProcessor envelopeEventProcessor;
 
-    private static final String CREATE_ExCEPTION_RECORD_SUBMIT_URL = Environment.CASE_SUBMIT_URL
+    private static final String CREATE_EXCEPTION_RECORD_SUBMIT_URL = Environment.CASE_SUBMIT_URL
         .replace(CASE_TYPE_BULK_SCAN, CASE_TYPE_EXCEPTION_RECORD);
 
     private static final String CREATE_EXCEPTION_START_EVENT_URL = Environment.CASE_EVENT_TRIGGER_START_URL
@@ -67,6 +66,7 @@ class SupplementaryEvidenceCreatorTest {
 
     @BeforeEach
     void before() throws Exception {
+        WireMock.reset();
         givenThat(get(GET_CASE_URL).willReturn(aResponse().withBody(MOCK_RESPONSE)));
         given(messageReceiver.receive()).willReturn(MOCK_MESSAGE).willReturn(null);
     }
@@ -83,7 +83,7 @@ class SupplementaryEvidenceCreatorTest {
             .pollInterval(2, TimeUnit.SECONDS)
             .ignoreExceptions()
             .until(() -> {
-                WireMock.verify(postRequestedFor(urlPathEqualTo(CASE_EVENT_URL)));
+                WireMock.verify(postRequestedFor(urlPathEqualTo(Environment.CASE_EVENT_URL)));
 
                 return true;
             });
@@ -104,7 +104,7 @@ class SupplementaryEvidenceCreatorTest {
             .atMost(60, TimeUnit.SECONDS)
             .ignoreExceptions()
             .until(() -> {
-                WireMock.verify(postRequestedFor(urlPathEqualTo(CREATE_ExCEPTION_RECORD_SUBMIT_URL)));
+                WireMock.verify(postRequestedFor(urlPathEqualTo(CREATE_EXCEPTION_RECORD_SUBMIT_URL)));
                 return true;
             });
     }
@@ -124,7 +124,7 @@ class SupplementaryEvidenceCreatorTest {
             .atMost(60, TimeUnit.SECONDS)
             .ignoreExceptions()
             .until(() -> {
-                WireMock.verify(postRequestedFor(urlPathEqualTo(CREATE_ExCEPTION_RECORD_SUBMIT_URL)));
+                WireMock.verify(postRequestedFor(urlPathEqualTo(CREATE_EXCEPTION_RECORD_SUBMIT_URL)));
                 return true;
             });
     }
@@ -154,7 +154,6 @@ class SupplementaryEvidenceCreatorTest {
             .withHeader(AUTHORIZATION, containing(MOCKED_IDAM_TOKEN_SIG))
             .withHeader(SERVICE_AUTHORIZATION_HEADER, containing(MOCKED_S2S_TOKEN_SIG));
     }
-
 
     private MappingBuilder exceptionRecordCcdStartEvent() {
         return get(CREATE_EXCEPTION_START_EVENT_URL)

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -283,19 +283,17 @@ public class CcdApi {
                 caseRef,
                 eventTypeId
             );
+        } catch (FeignException.NotFound e) {
+            throw new UnableToAttachDocumentsException(
+                String.format(
+                    "Attach documents start event failed for case type: %s and case ref: %s", caseTypeId, caseRef
+                ),
+                e
+            );
         } catch (FeignException e) {
-            if (e.status() == 404) {
-                throw new UnableToAttachDocumentsException(
-                    String.format(
-                        "Attach documents start event failed for case type: %s and case ref: %s", caseTypeId, caseRef
-                    ),
-                    e
-                );
-            } else {
-                throw new CcdCallException(
-                    String.format("Could not attach documents for case ref: %s Error: %s", caseRef, e.status()), e
-                );
-            }
+            throw new CcdCallException(
+                String.format("Could not attach documents for case ref: %s Error: %s", caseRef, e.status()), e
+            );
         }
     }
 
@@ -334,19 +332,17 @@ public class CcdApi {
                 true,
                 caseDataContent
             );
+        } catch (FeignException.NotFound e) {
+            throw new UnableToAttachDocumentsException(
+                String.format(
+                    "Attach documents submit failed for case type: %s and case ref: %s", caseTypeId, caseRef
+                ),
+                e
+            );
         } catch (FeignException e) {
-            if (e.status() == 404) {
-                throw new UnableToAttachDocumentsException(
-                    String.format(
-                        "Attach documents submit failed for case type: %s and case ref: %s", caseTypeId, caseRef
-                    ),
-                    e
-                );
-            } else {
-                throw new CcdCallException(
-                    String.format("Could not attach documents for case ref: %s Error: %s", caseRef, e.status()), e
-                );
-            }
+            throw new CcdCallException(
+                String.format("Could not attach documents for case ref: %s Error: %s", caseRef, e.status()), e
+            );
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -266,7 +266,7 @@ public class CcdApi {
         );
     }
 
-    public StartEventResponse startEventForExistingCase(
+    public StartEventResponse startEventForAttachScannedDocs(
         CcdAuthenticator authenticator,
         String jurisdiction,
         String caseTypeId,
@@ -316,7 +316,7 @@ public class CcdApi {
         );
     }
 
-    public CaseDetails submitEventForExistingCase(
+    public CaseDetails submitEventForAttachScannedDocs(
         CcdAuthenticator authenticator,
         String jurisdiction,
         String caseTypeId,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -36,6 +36,8 @@ class AttachDocsToSupplementaryEvidence {
 
     /**
      * Attaches documents from given envelope to existing case.
+     *
+     * @return true when attaching documents to existing case is successful, otherwise false
      */
     public boolean attach(Envelope envelope, CaseDetails existingCase) {
         if (mapper.getDocsToAdd(getDocuments(existingCase), envelope.documents).isEmpty()) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -51,7 +51,7 @@ class AttachDocsToSupplementaryEvidence {
             try {
                 CcdAuthenticator authenticator = ccdApi.authenticateJurisdiction(envelope.jurisdiction);
 
-                StartEventResponse startEventResp = ccdApi.startEventForExistingCase(
+                StartEventResponse startEventResp = ccdApi.startEventForAttachScannedDocs(
                     authenticator,
                     envelope.jurisdiction,
                     existingCase.getCaseTypeId(),
@@ -66,7 +66,7 @@ class AttachDocsToSupplementaryEvidence {
                     existingCase.getId()
                 );
 
-                ccdApi.submitEventForExistingCase(
+                ccdApi.submitEventForAttachScannedDocs(
                     authenticator,
                     envelope.jurisdiction,
                     existingCase.getCaseTypeId(),

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -37,7 +37,7 @@ class AttachDocsToSupplementaryEvidence {
     /**
      * Attaches documents from given envelope to existing case.
      */
-    public void attach(Envelope envelope, CaseDetails existingCase) {
+    public boolean attach(Envelope envelope, CaseDetails existingCase) {
         if (mapper.getDocsToAdd(getDocuments(existingCase), envelope.documents).isEmpty()) {
             log.warn("Envelope {} has no new documents. CCD Case {} not updated", envelope.id, existingCase.getId());
         } else {
@@ -48,37 +48,48 @@ class AttachDocsToSupplementaryEvidence {
                 existingCase.getCaseTypeId()
             );
 
-            CcdAuthenticator authenticator = ccdApi.authenticateJurisdiction(envelope.jurisdiction);
+            try {
+                CcdAuthenticator authenticator = ccdApi.authenticateJurisdiction(envelope.jurisdiction);
 
-            StartEventResponse startEventResp = ccdApi.startEvent(
-                authenticator,
-                envelope.jurisdiction,
-                existingCase.getCaseTypeId(),
-                existingCase.getId().toString(),
-                EVENT_TYPE_ID
-            );
+                StartEventResponse startEventResp = ccdApi.startEventForExistingCase(
+                    authenticator,
+                    envelope.jurisdiction,
+                    existingCase.getCaseTypeId(),
+                    existingCase.getId().toString(),
+                    EVENT_TYPE_ID
+                );
 
-            log.info(
-                "Started event in CCD for envelope ID: {}. File name: {}. Case ref: {}",
-                envelope.id,
-                envelope.zipFileName,
-                existingCase.getId()
-            );
+                log.info(
+                    "Started event in CCD for envelope ID: {}. File name: {}. Case ref: {}",
+                    envelope.id,
+                    envelope.zipFileName,
+                    existingCase.getId()
+                );
 
-            ccdApi.submitEventForExistingCase(
-                authenticator,
-                envelope.jurisdiction,
-                existingCase.getCaseTypeId(),
-                existingCase.getId().toString(),
-                buildCaseDataContent(envelope, startEventResp)
-            );
+                ccdApi.submitEventForExistingCase(
+                    authenticator,
+                    envelope.jurisdiction,
+                    existingCase.getCaseTypeId(),
+                    existingCase.getId().toString(),
+                    buildCaseDataContent(envelope, startEventResp)
+                );
 
-            log.info(
-                "Attached documents from envelope to case. Case ID: {}, envelope ID: {}",
-                existingCase.getId(),
-                envelope.id
-            );
+                log.info(
+                    "Attached documents from envelope to case. Case ID: {}, envelope ID: {}",
+                    existingCase.getId(),
+                    envelope.id
+                );
+            } catch (UnableToAttachDocumentsException e) {
+                log.error(
+                    "Failed to attach documents from envelope to case. Case Type: {}, Case ID: {}, envelope ID: {}",
+                    existingCase.getCaseTypeId(),
+                    existingCase.getId(),
+                    envelope.id
+                );
+                return false;
+            }
         }
+        return true;
     }
 
     private CaseDataContent buildCaseDataContent(Envelope envelope, StartEventResponse startEventResponse) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CreateExceptionRecord.java
@@ -71,7 +71,6 @@ public class CreateExceptionRecord {
             authenticator,
             envelope.jurisdiction,
             caseTypeId,
-            null,
             EVENT_TYPE_ID
         );
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandler.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseFinder;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.PaymentsProcessor;
@@ -10,6 +12,8 @@ import java.util.Optional;
 
 @Service
 public class EnvelopeHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(EnvelopeHandler.class);
 
     private final AttachDocsToSupplementaryEvidence evidenceAttacher;
     private final CreateExceptionRecord exceptionRecordCreator;
@@ -39,6 +43,11 @@ public class EnvelopeHandler {
                     if (docsAttached) {
                         paymentsProcessor.createPayments(envelope, existingCase.getId(), false);
                     } else {
+                        log.info(
+                            "Creating exception record as supplementary evidence failed for envelope {} case {}",
+                            envelope.id,
+                            existingCase.getId()
+                        );
                         createExceptionRecord(envelope);
                     }
                 } else {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandler.java
@@ -35,12 +35,15 @@ public class EnvelopeHandler {
 
                 if (caseDetailsFound.isPresent()) {
                     CaseDetails existingCase = caseDetailsFound.get();
-                    evidenceAttacher.attach(envelope, existingCase);
-                    paymentsProcessor.createPayments(envelope, existingCase.getId(), false);
+                    boolean docsAttached = evidenceAttacher.attach(envelope, existingCase);
+                    if (docsAttached) {
+                        paymentsProcessor.createPayments(envelope, existingCase.getId(), false);
+                    } else {
+                        createExceptionRecord(envelope);
+                    }
                 } else {
                     createExceptionRecord(envelope);
                 }
-
                 break;
             case SUPPLEMENTARY_EVIDENCE_WITH_OCR:
             case EXCEPTION:

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/UnableToAttachDocumentsException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/UnableToAttachDocumentsException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
+
+public class UnableToAttachDocumentsException extends RuntimeException {
+
+    public UnableToAttachDocumentsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
@@ -65,8 +65,9 @@ class AttachDocsToSupplementaryEvidenceTest {
         given(startEventResponse.getCaseDetails()).willReturn(caseDetails);
         given(startEventResponse.getCaseDetails().getData()).willReturn(ccdData);
 
-        given(ccdApi.startEventForExistingCase(any(), any(), any(), any(), any())).willReturn(startEventResponse);
-        given(ccdApi.submitEventForExistingCase(any(), any(), any(), any(), any())).willReturn(caseDetails);
+        given(ccdApi.startEventForAttachScannedDocs(any(), any(), any(), any(), any()))
+            .willReturn(startEventResponse);
+        given(ccdApi.submitEventForAttachScannedDocs(any(), any(), any(), any(), any())).willReturn(caseDetails);
 
         String caseId = "1539007368674134";
         given(caseDetails.getId()).willReturn(Long.parseLong(caseId));
@@ -79,7 +80,7 @@ class AttachDocsToSupplementaryEvidenceTest {
         boolean docsAttached = attacher.attach(envelope, caseDetails);
 
         // then
-        verify(ccdApi).startEventForExistingCase(
+        verify(ccdApi).startEventForAttachScannedDocs(
             AUTH_DETAILS,
             envelope.jurisdiction,
             CASE_TYPE_ID,
@@ -88,7 +89,7 @@ class AttachDocsToSupplementaryEvidenceTest {
         );
         ArgumentCaptor<CaseDataContent> caseDataContentCaptor = ArgumentCaptor.forClass(CaseDataContent.class);
 
-        verify(ccdApi).submitEventForExistingCase(
+        verify(ccdApi).submitEventForAttachScannedDocs(
             eq(AUTH_DETAILS),
             eq(envelope.jurisdiction),
             eq(CASE_TYPE_ID),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
@@ -65,7 +65,7 @@ class AttachDocsToSupplementaryEvidenceTest {
         given(startEventResponse.getCaseDetails()).willReturn(caseDetails);
         given(startEventResponse.getCaseDetails().getData()).willReturn(ccdData);
 
-        given(ccdApi.startEvent(any(), any(), any(), any(), any())).willReturn(startEventResponse);
+        given(ccdApi.startEventForExistingCase(any(), any(), any(), any(), any())).willReturn(startEventResponse);
         given(ccdApi.submitEventForExistingCase(any(), any(), any(), any(), any())).willReturn(caseDetails);
 
         String caseId = "1539007368674134";
@@ -76,10 +76,10 @@ class AttachDocsToSupplementaryEvidenceTest {
         given(mapper.getDocsToAdd(any(), any())).willReturn(envelope.documents);
 
         // when
-        attacher.attach(envelope, caseDetails);
+        boolean docsAttached = attacher.attach(envelope, caseDetails);
 
         // then
-        verify(ccdApi).startEvent(
+        verify(ccdApi).startEventForExistingCase(
             AUTH_DETAILS,
             envelope.jurisdiction,
             CASE_TYPE_ID,
@@ -102,6 +102,7 @@ class AttachDocsToSupplementaryEvidenceTest {
         assertThat(caseDataContent.getEventToken()).isEqualTo(eventToken);
         assertThat(caseDataContent.getEvent().getId()).isEqualTo(EVENT_TYPE_ID);
         assertThat(caseDataContent.getEvent().getSummary()).isEqualTo("Attach scanned documents");
+        assertThat(docsAttached).isTrue();
     }
 
     @Test
@@ -117,6 +118,6 @@ class AttachDocsToSupplementaryEvidenceTest {
         attacher.attach(envelope, existingCase);
 
         // then
-        verify(ccdApi, never()).startEvent(any(), any(), any(), any(), any());
+        verify(ccdApi, never()).startEvent(any(), any(), any(), any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandlerTest.java
@@ -63,6 +63,7 @@ class EnvelopeHandlerTest {
         // given
         Envelope envelope = envelope(SUPPLEMENTARY_EVIDENCE, JURSIDICTION, CASE_REF);
         given(caseFinder.findCase(envelope)).willReturn(Optional.of(caseDetails));
+        given(attachDocsToSupplementaryEvidence.attach(envelope, caseDetails)).willReturn(true);
 
         // when
         envelopeHandler.handleEnvelope(envelope);
@@ -126,6 +127,23 @@ class EnvelopeHandlerTest {
         envelopeHandler.handleEnvelope(envelope);
 
         // then
+        verify(createExceptionRecord).tryCreateFrom(envelope);
+        verify(paymentsProcessor).createPayments(envelope, CASE_ID, true);
+    }
+
+    @Test
+    void should_call_CreateExceptionRecord_when_documents_attachment_fails_for_supplementary_evidence() {
+        // given
+        Envelope envelope = envelope(SUPPLEMENTARY_EVIDENCE, JURSIDICTION, CASE_REF);
+        given(caseFinder.findCase(envelope)).willReturn(Optional.of(caseDetails));
+        given(attachDocsToSupplementaryEvidence.attach(envelope, caseDetails)).willReturn(false);
+        given(createExceptionRecord.tryCreateFrom(envelope)).willReturn(CASE_ID);
+
+        // when
+        envelopeHandler.handleEnvelope(envelope);
+
+        // then
+        verify(attachDocsToSupplementaryEvidence).attach(envelope, caseDetails);
         verify(createExceptionRecord).tryCreateFrom(envelope);
         verify(paymentsProcessor).createPayments(envelope, CASE_ID, true);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/ExceptionRecordCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/ExceptionRecordCreatorTest.java
@@ -102,7 +102,7 @@ public class ExceptionRecordCreatorTest {
     }
 
     private void setupCcdApi() {
-        given(ccdApi.startEvent(any(), any(), any(), any(), any()))
+        given(ccdApi.startEvent(any(), any(), any(), any()))
             .willReturn(mock(StartEventResponse.class));
 
         CaseDetails caseDetails = mock(CaseDetails.class);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-932

### Change description ###
Create an Exception record when attaching scanned documents to the case fails.
CCD returns 404 response in 2 scenarios:
- **Start event** - returns 404 if `attachScannedDocs` event is not configured for the case type.
- **Submit event** - returns 404 if the caseworker does not have access to the`attachScannedDocs` event.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
