### PR TITLE
Create log entry after starting an event in CCD

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -31,6 +31,8 @@ public class CcdApi {
 
     public static final Logger log = LoggerFactory.getLogger(CcdApi.class);
 
+    public static final String EVENT_ID_ATTACH_SCANNED_DOCS = "attachScannedDocs";
+
     public static final String SEARCH_BY_LEGACY_ID_QUERY_FORMAT =
         "{\"query\": { \"match_phrase\" : { \"alias.previousServiceCaseReference\" : \"%s\" }}}";
 
@@ -72,7 +74,7 @@ public class CcdApi {
             jurisdiction,
             caseTypeId,
             caseRef,
-            "attachScannedDocs"
+            EVENT_ID_ATTACH_SCANNED_DOCS
         );
     }
 
@@ -82,7 +84,7 @@ public class CcdApi {
         try {
             //TODO We don't need to login here as we just need the service token
             CcdAuthenticator authenticator = authenticatorFactory.createForJurisdiction(theCase.getJurisdiction());
-            return startAttachScannedDocs(
+            StartEventResponse response = startAttachScannedDocs(
                 caseRef,
                 authenticator.getServiceToken(),
                 idamToken,
@@ -90,6 +92,18 @@ public class CcdApi {
                 theCase.getJurisdiction(),
                 theCase.getCaseTypeId()
             );
+
+            log.info(
+                "Started event to attach docs to case. "
+                    + "Event ID: {}. Case ID: {}. Case type: {}. Jurisdiction: {}. Case state: {}",
+                EVENT_ID_ATTACH_SCANNED_DOCS,
+                caseRef,
+                theCase.getCaseTypeId(),
+                theCase.getJurisdiction(),
+                theCase.getState()
+            );
+
+            return response;
         } catch (FeignException e) {
             throw new CcdCallException(
                 format("Internal Error: start event call failed case: %s Error: %s", caseRef, e.status()), e

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -79,6 +79,16 @@ public class CcdCaseUpdater {
                 EVENT_ID_ATTACH_SCANNED_DOCS_WITH_OCR
             );
 
+            log.info(
+                "Started CCD event to update case. "
+                    + "Event ID: {}. Case ID: {}. Exception record ID: {}. Case type: {}. Case state: {}",
+                startEvent.getEventId(),
+                existingCaseId,
+                exceptionRecord.id,
+                startEvent.getCaseDetails().getCaseTypeId(),
+                startEvent.getCaseDetails().getState()
+            );
+
             final CaseDetails existingCase = startEvent.getCaseDetails();
 
             SuccessfulUpdateResponse updateResponse = caseUpdateClient.updateCase(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
@@ -161,6 +161,15 @@ public class CcdNewCaseCreator {
                 caseCreationDetails.eventId
             );
 
+            log.info(
+                "Started event for creating case from exception record. "
+                    + "Event ID: {}. Exception record ID: {}. Jurisdiction: {}. Case type: {}",
+                caseCreationDetails.eventId,
+                exceptionRecord.id,
+                exceptionRecord.poBoxJurisdiction,
+                caseCreationDetails.caseTypeId
+            );
+
             return coreCaseDataApi.submitForCaseworker(
                 idamToken,
                 s2sToken,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -59,10 +59,12 @@ class AttachDocsToSupplementaryEvidence {
             );
 
             log.info(
-                "Started event in CCD for envelope ID: {}. File name: {}. Case ref: {}",
+                "Started event in CCD to attach exception record to case. "
+                    + "Envelope ID: {}. File name: {}. Case ref: {}. Case state: {}",
                 envelope.id,
                 envelope.zipFileName,
-                existingCase.getId()
+                existingCase.getId(),
+                existingCase.getState()
             );
 
             ccdApi.submitEventForExistingCase(


### PR DESCRIPTION
### Change description ###

Create log entry after starting an event in CCD, so that it's easier to trace what exactly went wrong in production.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
