### PR TITLE
BPS-932 Add functional test

### DIFF
--- a/src/functionalTest/resources/envelopes/supplementary-evidence-envelope-with-payment.json
+++ b/src/functionalTest/resources/envelopes/supplementary-evidence-envelope-with-payment.json
@@ -11,7 +11,7 @@
   "documents": [
     {
       "file_name": "certificate2.pdf",
-      "control_number": "1545657689",
+      "control_number": "15456576894456733",
       "type": "other",
       "subtype": null,
       "scanned_at": "2018-01-01T11:20:00.000Z",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-932

### Change description ###
Add a functional test to check if the Exception Record is created when CCD returns 404 response. 

When an envelope with `supplementary evidence` classification is received for **Bulkscan_ExceptionRecord** case type, Orchestrator should create an exception record as the  `attachScannedDocs` CCD event is not configured for the **Bulkscan_ExceptionRecord**.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
