### PR TITLE
Removed integration test for ocr

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
@@ -578,7 +578,7 @@ class AttachExceptionRecordToExistingCaseTest {
                     RESPONSE_FIELD_ERRORS,
                     hasItem("The 'attach to case' event is not supported for supplementary evidence with OCR "
                         + "but not containing OCR data")
-        );
+                );
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
@@ -559,27 +559,6 @@ class AttachExceptionRecordToExistingCaseTest {
     }
 
     @Test
-    public void should_succeed_when_classification_is_supplementary_evidence_with_ocr() {
-        CallbackRequest callbackRequest =
-            callbackRequestWith(
-                EVENT_ID_ATTACH_TO_CASE,
-                SUPPLEMENTARY_EVIDENCE_WITH_OCR.name(),
-                true
-            );
-
-        ValidatableResponse response =
-            given()
-                .body(callbackRequest)
-                .headers(userHeaders())
-                .post(CALLBACK_ATTACH_CASE_PATH)
-                .then()
-                .statusCode(200);
-
-        verifySuccessResponse(response, callbackRequest);
-        verifyRequestedAttachingToCase();
-    }
-
-    @Test
     public void should_fail_when_classification_is_supplementary_evidence_with_ocr_does_not_include_ocr() {
         CallbackRequest callbackRequest =
             callbackRequestWith(

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
@@ -578,7 +578,7 @@ class AttachExceptionRecordToExistingCaseTest {
                     RESPONSE_FIELD_ERRORS,
                     hasItem("The 'attach to case' event is not supported for supplementary evidence with OCR "
                         + "but not containing OCR data")
-                );
+        );
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-833


### Change description ###
Removed integration test for ocr, all tests are in AttachExceptionRecordWithOcrTest which is currently disabled.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
