### PR TITLE
Editorconfig settings: paramater wrapping

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ insert_final_newline = true
 
 [*.{java,kt}]
 indent_size = 4
+ij_java_call_parameters_new_line_after_left_paren = true
+ij_java_call_parameters_right_paren_on_new_line = true
+ij_java_call_parameters_wrap = on_every_item

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -427,17 +427,21 @@ public class AttachCaseCallbackService {
 
         if (attachedToCase.isPresent()) {
             if (targetCaseCcdRef.equals(attachedToCase.get())) {
-                log.warn("There has been an attempt to attach an already attached exception record to another case. "
+                log.warn(
+                    "There has been an attempt to attach an already attached exception record to another case. "
                         + "Exception record ID: {}, attempt to attach to case: {}",
                     callBackEvent.exceptionRecordId,
-                    targetCaseCcdRef);
+                    targetCaseCcdRef
+                );
                 return Optional.empty();
             } else {
-                log.warn("There has been an attempt to attach an already attached exception record to another case. "
+                log.warn(
+                    "There has been an attempt to attach an already attached exception record to another case. "
                         + "Exception record ID: {}, attempt to attach to case: {}, already attached to case: {}",
                     callBackEvent.exceptionRecordId,
                     targetCaseCcdRef,
-                    attachedToCase.get());
+                    attachedToCase.get()
+                );
                 throw new AlreadyAttachedToCaseException("Exception record is already attached to case "
                     + attachedToCase.get());
             }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseFinder.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseFinder.java
@@ -49,7 +49,8 @@ public class CaseFinder {
                 details.isPresent(),
                 caseCcdRef,
                 envelope.legacyCaseRef,
-                envelope.id);
+                envelope.id
+            );
 
             return details;
         } else {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -119,7 +119,7 @@ public class CcdCaseUpdater {
                 );
                 return new ProcessResult(updateResponse.warnings, emptyList());
             } else {
-                Optional<String> updateResult =  updateCaseInCcd(
+                Optional<String> updateResult = updateCaseInCcd(
                     configItem.getService(),
                     ignoreWarnings,
                     idamToken,
@@ -233,7 +233,8 @@ public class CcdCaseUpdater {
 
             return Optional.empty();
         } catch (FeignException.UnprocessableEntity exception) {
-            String msg = format("Service returned 422 Unprocessable Entity response "
+            String msg = format(
+                "Service returned 422 Unprocessable Entity response "
                     + "when trying to update case for %s jurisdiction "
                     + "with case Id %s "
                     + "based on exception record with Id %s. "
@@ -241,7 +242,8 @@ public class CcdCaseUpdater {
                 exceptionRecord.poBoxJurisdiction,
                 existingCase.getId(),
                 exceptionRecord.id,
-                exception.contentUTF8());
+                exception.contentUTF8()
+            );
             log.error(msg, exception);
 
             return Optional.of(msg);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -48,7 +48,8 @@ public class SampleData {
     public static final String BULK_SCANNED_CASE_TYPE = "Bulk_Scanned";
 
     public static final UserDetails USER_DETAILS = new UserDetails(USER_ID,
-        null, null, null, emptyList());
+        null, null, null, emptyList()
+    );
     public static final Credential USER_CREDS = new Credential(USER_NAME, PASSWORD);
     public static final CcdAuthenticator AUTH_DETAILS = new CcdAuthenticator(
         () -> SERVICE_TOKEN,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/mappers/ExceptionRecordMapperTest.java
@@ -267,7 +267,7 @@ class ExceptionRecordMapperTest {
     public void mapEnvelope_sets_surname_with_first_matching_ocr_conf_when_multiple_conf_available() {
         //given
         given(serviceConfigItem.getSurnameOcrFieldNameList("FORM_TYPE"))
-            .willReturn(asList("field_surname_not_found", "field_surname","fieldName1"));
+            .willReturn(asList("field_surname_not_found", "field_surname", "fieldName1"));
 
 
         Envelope envelope = envelope(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -319,7 +319,8 @@ class CcdCaseUpdaterTest {
             anyString(),
             anyString(),
             anyString(),
-            anyString()))
+            anyString()
+        ))
             .willThrow(HttpClientErrorException.create(
                 HttpStatus.BAD_REQUEST,
                 "bad request message",
@@ -370,7 +371,8 @@ class CcdCaseUpdaterTest {
             anyString(),
             anyString(),
             anyString(),
-            anyString()))
+            anyString()
+        ))
             .willThrow(unprocessableEntity);
         given(serviceResponseParser.parseResponseBody(unprocessableEntity))
             .willReturn(new ClientServiceErrorResponse(asList("error1", "error2"), emptyList()));
@@ -400,7 +402,8 @@ class CcdCaseUpdaterTest {
             anyString(),
             anyString(),
             anyString(),
-            anyString()))
+            anyString()
+        ))
             .willThrow(new FeignException.BadRequest("Msg", "Body".getBytes()));
 
         // when
@@ -433,7 +436,8 @@ class CcdCaseUpdaterTest {
             anyString(),
             anyString(),
             anyString(),
-            anyString()))
+            anyString()
+        ))
             .willThrow(new RuntimeException());
 
         // when
@@ -477,7 +481,8 @@ class CcdCaseUpdaterTest {
             anyString(),
             anyString(),
             anyString(),
-            anyString()))
+            anyString()
+        ))
             .willReturn(eventResponse);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
@@ -146,7 +146,7 @@ class CcdNewCaseCreatorTest {
     @Test
     void should_call_payments_handler_when_case_has_no_payments() throws Exception {
         // given
-        given(transformationClient.transformExceptionRecord(any(),any(), any()))
+        given(transformationClient.transformExceptionRecord(any(), any(), any()))
             .willReturn(
                 new SuccessfulTransformationResponse(
                     new CaseCreationDetails(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
@@ -47,7 +47,8 @@ class DocumentsTest {
             .map(String::valueOf)
             .map(dcn -> ImmutableMap.<String, Object>of(
                 DOCUMENT_NUMBER, UUID.randomUUID().toString(),
-                "value", ImmutableMap.of("controlNumber", dcn))
+                "value", ImmutableMap.of("controlNumber", dcn)
+                )
             )
             .collect(toImmutableList());
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/ExceptionRecordCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/ExceptionRecordCreatorTest.java
@@ -107,7 +107,7 @@ public class ExceptionRecordCreatorTest {
 
         CaseDetails caseDetails = mock(CaseDetails.class);
         given(caseDetails.getId()).willReturn(CASE_DETAILS_ID);
-        given(ccdApi.submitEvent(any(),any(), any(), any()))
+        given(ccdApi.submitEvent(any(), any(), any(), any()))
             .willReturn(caseDetails);
     }
 }


### PR DESCRIPTION
IntelliJ specific config to automatically fix code formatted like this:
```java
myfunction("aaa",
    "bbb",
    4));
```
into:
```java
myfunction(
    "aaa",
    "bbb",
    4)
);
```
Also a few other random formatting fixes...
