### PR TITLE
Idempotent supplementary evidence with ocr updates

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.controllers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.google.common.collect.ImmutableList;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
@@ -120,6 +120,7 @@ class AttachExceptionRecordWithOcrTest {
     @Test
     void should_pass_if_record_already_attached_to_the_same_case() throws Exception {
         setUpCaseSearchByCcdId(okJson(mapper.writeValueAsString(exceptionRecord(CASE_ID))));
+        setUpCcdStartEvent(okJson(getResponseBody("ccd-start-event-for-case-worker_with_document.json")));
 
         Map<String, Object> caseData = getCaseData();
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
@@ -89,7 +89,7 @@ class AttachExceptionRecordWithOcrTest {
 
     @DisplayName("Should successfully update the case with ocr data if document control numbers do not match")
     @Test
-    void should_update_case_with_ocr_data_even_record_already_attached_if_doc_numbers_not_match() throws Exception {
+    void should_update_case_with_ocr_data_if_doc_numbers_not_match() throws Exception {
 
         CaseDetails existingCase = exceptionRecord(
             null,

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
@@ -88,8 +88,8 @@ class AttachExceptionRecordWithOcrTest {
         verifySuccessResponse(response, caseData);
     }
 
-    @DisplayName("Should successfully update the case with ocr data even exception already attached to the same case if "
-        + "document control numbers do not match")
+    @DisplayName("Should successfully update the case with ocr data even exception already attached to the same case "
+        + "if document control numbers do not match")
     @Test
     void should_update_case_with_ocr_data_even_record_already_attached_if_doc_numbers_not_match() throws Exception {
 
@@ -318,7 +318,7 @@ class AttachExceptionRecordWithOcrTest {
         );
     }
 
-    private void setUpCaseSearchByCcdId(ResponseDefinitionBuilder responseBuilder) throws JsonProcessingException {
+    private void setUpCaseSearchByCcdId(ResponseDefinitionBuilder responseBuilder) {
         givenThat(
             get("/cases/" + CASE_ID)
                 .withHeader(SERVICE_AUTHORIZATION_HEADER, containing(BEARER_TOKEN_PREFIX))

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
@@ -88,6 +88,35 @@ class AttachExceptionRecordWithOcrTest {
         verifySuccessResponse(response, caseData);
     }
 
+    @DisplayName("Should successfully update the case with ocr data even exception already attached to the same case if "
+        + "document control numbers do not match")
+    @Test
+    void should_update_case_with_ocr_data_even_record_already_attached_if_doc_numbers_not_match() throws Exception {
+
+        CaseDetails existingCase = exceptionRecord(
+            CASE_ID,
+            null,
+            null,
+            CASE_TYPE_EXCEPTION_RECORD,
+            document("record.pdf", "123456"),
+            false
+        );
+
+        setUpCaseSearchByCcdId(okJson(mapper.writeValueAsString(existingCase)));
+        setUpClientUpdate(getResponseBody("client-update-ok-no-warnings.json"));
+        setUpCcdStartEvent(okJson(getResponseBody("ccd-start-event-for-case-worker.json")));
+        setUpCcdSubmitEvent(okJson(getResponseBody("ccd-submit-event-for-case-worker.json")));
+
+        Map<String, Object> caseData = getCaseData();
+
+        byte[] requestBody = getRequestBody("valid-supplementary-evidence-with-ocr.json");
+
+        ValidatableResponse response = postWithBody(requestBody)
+            .statusCode(OK.value());
+
+        verifySuccessResponse(response, caseData);
+    }
+
     @DisplayName("Should successfully pass if exception record already attached to the same case")
     @Test
     void should_pass_if_record_already_attached_to_the_same_case() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
@@ -87,13 +87,12 @@ class AttachExceptionRecordWithOcrTest {
         verifySuccessResponse(response, caseData);
     }
 
-    @DisplayName("Should successfully update the case with ocr data even exception already attached to the same case "
-        + "if document control numbers do not match")
+    @DisplayName("Should successfully update the case with ocr data if document control numbers do not match")
     @Test
     void should_update_case_with_ocr_data_even_record_already_attached_if_doc_numbers_not_match() throws Exception {
 
         CaseDetails existingCase = exceptionRecord(
-            CASE_ID,
+            null,
             null,
             null,
             CASE_TYPE_EXCEPTION_RECORD,
@@ -116,10 +115,10 @@ class AttachExceptionRecordWithOcrTest {
         verifySuccessResponse(response, caseData);
     }
 
-    @DisplayName("Should successfully pass if exception record already attached to the same case")
+    @DisplayName("Should successfully pass if exception record already has same document case numbers")
     @Test
     void should_pass_if_record_already_attached_to_the_same_case() throws Exception {
-        setUpCaseSearchByCcdId(okJson(mapper.writeValueAsString(exceptionRecord(CASE_ID))));
+        setUpCaseSearchByCcdId(okJson(mapper.writeValueAsString(exceptionRecord(null))));
         setUpCcdStartEvent(okJson(getResponseBody("ccd-start-event-for-case-worker_with_document.json")));
 
         Map<String, Object> caseData = getCaseData();

--- a/src/integrationTest/resources/ccd/callback/attach/request/valid-supplementary-evidence-with-ocr.json
+++ b/src/integrationTest/resources/ccd/callback/attach/request/valid-supplementary-evidence-with-ocr.json
@@ -20,7 +20,7 @@
         {
           "value": {
             "fileName": "fileName",
-            "controlNumber": "controlNumber",
+            "controlNumber": "654321",
             "type": "cherished",
             "url": {
               "document_url": "document_url",

--- a/src/integrationTest/resources/ccd/callback/attach/response/ccd-start-event-for-case-worker_with_document.json
+++ b/src/integrationTest/resources/ccd/callback/attach/response/ccd-start-event-for-case-worker_with_document.json
@@ -1,0 +1,55 @@
+{
+  "case_details": {
+    "id": 1539007368674134,
+    "jurisdiction": "BULKSCAN",
+    "case_type_id": "BULKSCAN_ExceptionRecord",
+    "created_date": "2018-01-01T12:34:56.123Z",
+    "last_modified": "2018-01-01T12:34:56.123Z",
+    "state": "",
+    "locked_by_user_id": null,
+    "security_level": 0,
+    "case_data": {
+      "poBox": "PO 12345",
+      "journeyClassification": "EXCEPTION",
+      "formType": "B123",
+      "deliveryDate": "2018-01-02T12:34:56.123Z",
+      "openingDate": "2018-01-03T12:34:56.123Z",
+      "scannedDocuments": [
+        {
+          "value": {
+            "fileName": "fileName",
+            "controlNumber": "654321",
+            "type": "cherished",
+            "url": {
+              "document_url": "document_url",
+              "document_binary_url": "document_binary_url",
+              "document_filename": "document_filename"
+            },
+            "subtype": "subtype",
+            "scannedDate": "2018-01-03T12:34:56.123Z",
+            "uuid": "uuid",
+            "deliveryDate": "2018-01-03T12:34:56.123Z"
+          }
+        }
+      ],
+      "scanOCRData": [
+        {
+          "value": {
+            "key": "item",
+            "value": "value"
+          }
+        },
+        {
+          "value": {
+            "key": "item2",
+            "value": "12345"
+          }
+        }
+      ]
+    },
+    "security_classification": "PUBLIC",
+    "callback_response_status": ""
+  },
+  "event_id": "NEW_EVENT_ID",
+  "token": "MY_NEW_TOKEN"
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -453,7 +453,7 @@ public class AttachCaseCallbackService {
                 } else {
                     log.warn(
                         "Attempt to attach an already attached exception record to same case, "
-                            + "Document control number(s)  are not matching, will update the case "
+                            + "Document control number(s) are not matching, will update the case "
                             + "Exception record ID: {}, attach to case: {}",
                         callBackEvent.exceptionRecordId,
                         targetCaseCcdRef

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -33,7 +33,6 @@ import static io.vavr.control.Validation.valid;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getDocuments;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.canBeAttachedToCase;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasAScannedRecord;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasAnId;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -452,13 +452,12 @@ public class AttachCaseCallbackService {
                 } else {
                     log.warn(
                         "There has been an attempt to attach an already attached exception record to same case, "
-                            + "Document control number(s) are not matching. Will update the case "
+                            + "Document control numbers are not matching. Will update the case "
                             + "Exception record ID: {}, attach to case: {}",
                         callBackEvent.exceptionRecordId,
                         targetCaseCcdRef
                     );
                 }
-
             } else {
                 log.warn(
                     "There has been an attempt to attach an already attached exception record to another case. "

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -8,6 +8,7 @@ import io.vavr.collection.Seq;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
 import io.vavr.control.Validation;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -459,9 +460,9 @@ public class AttachCaseCallbackService {
             exceptionRecordJurisdiction
         );
 
-        Object attachToCaseRef = fetchedExceptionRecord.getData().get(ATTACH_TO_CASE_REFERENCE);
+        String attachToCaseRef = (String)fetchedExceptionRecord.getData().get(ATTACH_TO_CASE_REFERENCE);
 
-        if (attachToCaseRef != null && !Strings.isNullOrEmpty(attachToCaseRef.toString())) {
+        if (StringUtils.isNotEmpty(attachToCaseRef)) {
             throw new AlreadyAttachedToCaseException("Exception record is already attached to case " + attachToCaseRef);
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -447,18 +447,6 @@ public class AttachCaseCallbackService {
             }
         }
 
-        //check the case even attachedToCase ref empty
-
-        if (isExceptionAlreadyAttached(callBackEvent, targetCaseCcdRef)) {
-            log.warn(
-                "There has been an attempt to attach an already attached exception record to same case. "
-                    + "Exception record ID: {}, attempt to attach to case: {}",
-                callBackEvent.exceptionRecordId,
-                targetCaseCcdRef
-            );
-            return Optional.empty();
-        }
-
         ServiceConfigItem serviceConfigItem = getServiceConfig(exceptionRecordDetails);
         ProcessResult processResult = ccdCaseUpdater.updateCase(
             callBackEvent.exceptionRecord,
@@ -477,24 +465,6 @@ public class AttachCaseCallbackService {
         } else {
             return Optional.empty();
         }
-    }
-
-    private boolean isExceptionAlreadyAttached(AttachToCaseEventData callBackEvent,
-                                               String targetCaseCcdRef) {
-        CaseDetails theCase = ccdApi.getCase(targetCaseCcdRef, callBackEvent.exceptionRecordJurisdiction);
-
-        List<String> caseDocList = getDocuments(theCase)
-            .stream()
-            .map(d -> d.controlNumber)
-            .collect(toList());
-
-        List<String> newExDocList = callBackEvent
-            .exceptionRecord
-            .scannedDocuments
-            .stream()
-            .map(d -> d.controlNumber).collect(toList());
-
-        return caseDocList.containsAll(newExDocList);
     }
 
     private Map<String, Object> buildCaseData(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -421,17 +421,17 @@ public class AttachCaseCallbackService {
         CaseDetails exceptionRecordDetails,
         boolean ignoreWarnings
     ) {
-        CaseDetails fetchedExceptionRecord = ccdApi.getCase(
+        CaseDetails attachToCase = ccdApi.getCase(
             callBackEvent.exceptionRecordId.toString(),
             callBackEvent.exceptionRecordJurisdiction
         );
 
-        String attachToCaseRef = (String) fetchedExceptionRecord.getData().get(ATTACH_TO_CASE_REFERENCE);
+        String attachToCaseRef = (String) attachToCase.getData().get(ATTACH_TO_CASE_REFERENCE);
 
         if (attachToCaseRef != null) {
             if (targetCaseCcdRef.equals(attachToCaseRef)) {
 
-                List<String> caseDocList = getDocuments(fetchedExceptionRecord)
+                List<String> caseDocList = getDocuments(attachToCase)
                     .stream()
                     .map(d -> d.controlNumber)
                     .collect(toList());

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -98,8 +98,8 @@ public class CcdCaseUpdater {
 
             if (isExceptionAlreadyAttached(existingCase, exceptionRecord)) {
                 log.warn(
-                    "Exception already attached to case. "
-                        + "Exception record ID: {}, attempt to attach to case: {}, Skipping Update",
+                    "Skipping Update as all documents from this exception record are already in the case. "
+                        + "Exception record ID: {}, attempt to attach to case: {} ",
                     exceptionRecord.id,
                     existingCase.getId()
                 );

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -208,9 +208,10 @@ public class CcdCaseUpdater {
         }
     }
 
-    private boolean isExceptionAlreadyAttached(CaseDetails existingCase,
-                                               ExceptionRecord exceptionRecord) {
-
+    private boolean isExceptionAlreadyAttached(
+        CaseDetails existingCase,
+        ExceptionRecord exceptionRecord
+    ) {
         List<String> caseDocList = getDocuments(existingCase)
             .stream()
             .map(d -> d.controlNumber)

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -14,7 +14,10 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.ServiceResponseParser;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.CaseUpdateClient;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.response.CaseUpdateDetails;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.response.SuccessfulUpdateResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentType;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentUrl;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response.ClientServiceErrorResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CallbackException;
@@ -30,6 +33,7 @@ import java.util.Map;
 import static java.time.LocalDateTime.now;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.ArgumentMatchers.any;
@@ -560,7 +564,19 @@ class CcdCaseUpdaterTest {
             "Form1",
             now(),
             now(),
-            emptyList(),
+            singletonList(new ScannedDocument(
+                DocumentType.FORM,
+                "D8",
+                new DocumentUrl(
+                    "http://locahost",
+                    "http://locahost/binary",
+                    "file1.pdf"
+                ),
+                "1234",
+                "file1.pdf",
+                now(),
+                now()
+            )),
             emptyList()
         );
     }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-951


### Change description ###

make Idempotent supplementary evidence with ocr updates.


revert some code back which was done in this PR:
https://github.com/hmcts/bulk-scan-orchestrator/pull/831

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
