### PR TITLE
Review wiremock configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,6 @@ dependencies {
   testCompile group: 'com.typesafe', name: 'config', version: '1.4.0'
   testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.2.4'
   testCompile group: 'org.assertj', name: 'assertj-core', version: '3.14.0'
-  testCompile group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '2.0.2.RELEASE'
   testCompile group: 'org.awaitility', name: 'awaitility', version: '4.0.2'
   testCompile group: 'io.rest-assured', name: 'rest-assured'
 
@@ -233,6 +232,10 @@ dependencies {
 
   integrationTestCompile sourceSets.main.runtimeClasspath
   integrationTestCompile sourceSets.test.runtimeClasspath
+  integrationTestCompile group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '2.0.2.RELEASE', {
+    exclude group: 'com.github.tomakehurst', module: 'wiremock-standalone'
+  }
+  integrationTestCompile group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.25.1'
 
   functionalTestCompile sourceSets.main.runtimeClasspath
   functionalTestCompile sourceSets.test.runtimeClasspath

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -55,80 +55,30 @@
     <cve>CVE-2019-16869</cve>
   </suppress>
 
-  <!-- this is for the TEST jar wiremock-standalone -->
   <suppress>
     <notes><![CDATA[
        file name: spring-cloud-contract-wiremock-2.0.2.jar.
        This is only used for TESTING purposes.
    ]]></notes>
     <filePath regex="true">.*spring-cloud-contract-wiremock-2\.0\.2\.RELEASE\.jar</filePath>
-    <cpe>cpe:/a:wiremock:wiremock:2.0.2.release</cpe>
+    <cve>CVE-2018-9116</cve>
+    <cve>CVE-2018-9117</cve>
   </suppress>
 
-  <suppress>
+  <suppress until="2020-03-31">
     <notes><![CDATA[
-   file name: wiremock-standalone-2.18.0.jar (shaded: com.fasterxml.jackson.core:jackson-databind:2.8.11)
+   file name: wiremock-2.25.1.jar: handlebars-v4.0.4.js
+    This is only used for TESTING purposes.
    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-    <vulnerabilityName>CVE-2019-17267</vulnerabilityName>
-  </suppress>
-
-  <suppress>
-    <notes><![CDATA[
-       file name: wiremock-standalone-2..0.jar.
-       This is only used for TESTING purposes.
-   ]]></notes>
-    <filePath regex="true">.*wiremock-standalone-.*\.jar.*</filePath>
-    <cpe>cpe:/a:eclipse:jetty</cpe>
-    <cpe>cpe:/a:jetty:jetty</cpe>
-    <cpe>cpe:/a:google:guava</cpe>
-    <cpe>cpe:/a:fasterxml:jackson</cpe>
-    <!-- Following are separately enlisted as there is no way suppress `pkg:..` signature -->
-    <!-- guava -->
-    <cve>CVE-2018-10237</cve>
-    <!-- jackson-databind -->
-    <cve>CVE-2018-5968</cve>
-    <cve>CVE-2018-7489</cve>
-    <cve>CVE-2018-11307</cve>
-    <cve>CVE-2018-12022</cve>
-    <cve>CVE-2018-12023</cve>
-    <cve>CVE-2018-14718</cve>
-    <cve>CVE-2018-14719</cve>
-    <cve>CVE-2018-14720</cve>
-    <cve>CVE-2018-14721</cve>
-    <cve>CVE-2018-19360</cve>
-    <cve>CVE-2018-19361</cve>
-    <cve>CVE-2018-19362</cve>
-    <cve>CVE-2018-1000873</cve>
-    <cve>CVE-2019-12086</cve>
-    <cve>CVE-2019-12384</cve>
-    <cve>CVE-2019-12814</cve>
-    <!-- jetty -->
-    <cve>CVE-2017-7656</cve>
-    <cve>CVE-2017-7657</cve>
-    <cve>CVE-2017-7658</cve>
-    <cve>CVE-2017-9735</cve>
-    <cve>CVE-2018-12536</cve>
-    <cve>CVE-2019-10241</cve>
-    <cve>CVE-2019-10247</cve>
-    <!-- jquery -->
-    <cve>CVE-2012-6708</cve>
-    <cve>CVE-2015-9251</cve>
-    <cve>CVE-2019-11358</cve>
-    <!--jackson databind-->
-    <cve>CVE-2019-14379</cve>
-    <cve>CVE-2019-14439</cve>
-    <cve>CVE-2019-14540</cve>
-    <cve>CVE-2019-16335</cve>
-    <cve>CVE-2019-16942</cve>
-    <cve>CVE-2019-16943</cve>
-    <cve>CVE-2019-17531</cve>
-  </suppress>
-
-  <suppress>
-    <notes><![CDATA[ file name: wiremock-standalone-2.18.0.jar: handlebars-4.0.5.js ]]></notes>
-    <packageUrl regex="true">^pkg:javascript/handlebars\.js@.*$</packageUrl>
+    <packageUrl regex="true">^pkg:javascript/handlebars\.js@4\.0\.4.*$</packageUrl>
     <vulnerabilityName>A prototype pollution vulnerability in handlebars is exploitable if an attacker can control the template</vulnerabilityName>
+    <vulnerabilityName>Disallow calling helperMissing and blockHelperMissing directly</vulnerabilityName>
+    <vulnerabilityName>Prototype pollution</vulnerabilityName>
   </suppress>
 
+  <suppress until="2020-03-31">
+    <notes><![CDATA[No fix available. Not used by server - comes with wiremock-jre8 used only in integration tests]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty-(alpn-conscrypt-server|alpn-server|alpn-conscrypt-client|alpn-client|webapp|servlet|security|server|servlets|http|continuation|xml|util)@9\.4\.22\.v20191022.*$</packageUrl>
+    <cve>CVE-2019-17632</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

Was briefly looking into #835 and new version started to report couple of vulnerabilities for wiremock. Then saw it has standalone dependency and lot's of suppressions. All rest of our projects already excluded that and wired in just wiremock.

Perhaps this will even help out to bump this dependency, at last. Let's see how long pipeline is going as locally IDE took ages and CLI failed. Could be clash in java versions I am using

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
