### PR TITLE
Catch more edge cases

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
@@ -198,7 +198,13 @@ class CreateCaseCallbackTest {
         postWithBody(getRequestBody("valid-exception.json"))
             .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
             // 1539007368674134 is from valid-exception.json
-            .body("message", equalTo("Failed to create new case for exception record with Id 1539007368674134"));
+            .body(
+                "message",
+                equalTo(
+                    "Failed to receive transformed exception record from "
+                        + "bulkscan client for exception record 1539007368674134"
+                )
+            );
     }
 
     @ParameterizedTest

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClient.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
@@ -12,8 +10,6 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.res
 
 @Component
 public class TransformationClient {
-
-    private static final Logger log = LoggerFactory.getLogger(TransformationClient.class);
 
     private final RestTemplate restTemplate;
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -200,13 +200,14 @@ public class CcdCaseUpdater {
                 ),
                 exception
             );
-        // I/O related exception received from case update client
+        // exceptions received from case update client
         } catch (RestClientException exception) {
             String message = getErrorMessage(configItem.getService(), existingCaseId, exceptionRecord.id);
 
             log.error(message, exception);
 
             throw new CallbackException(message, exception);
+        // rest of exceptions we did not handle appropriately. so far not such case
         } catch (Exception exception) {
             throw new CallbackException(
                 getErrorMessage(configItem.getService(), existingCaseId, exceptionRecord.id),

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException.UnprocessableEntity;
+import org.springframework.web.client.RestClientException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.ServiceResponseParser;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.CaseUpdateClient;
@@ -199,6 +200,13 @@ public class CcdCaseUpdater {
                 ),
                 exception
             );
+        // I/O related exception received from case update client
+        } catch (RestClientException exception) {
+            String message = getErrorMessage(configItem.getService(), existingCaseId, exceptionRecord.id);
+
+            log.error(message, exception);
+
+            throw new CallbackException(message, exception);
         } catch (Exception exception) {
             throw new CallbackException(
                 getErrorMessage(configItem.getService(), existingCaseId, exceptionRecord.id),

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException.BadRequest;
 import org.springframework.web.client.HttpClientErrorException.UnprocessableEntity;
+import org.springframework.web.client.RestClientException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.ServiceResponseParser;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ExceptionRecord;
@@ -137,6 +138,17 @@ public class CcdNewCaseCreator {
             );
 
             throw new CallbackException("Payment references cannot be processed. Please try again later", exception);
+        // I/O related exception received from transformation client
+        } catch (RestClientException exception) {
+            String message = format(
+                "Failed to receive transformed exception record from %s client for exception record %s",
+                configItem.getService(),
+                exceptionRecord.id
+            );
+
+            log.error(message, exception);
+
+            throw new CallbackException(message, exception);
         } catch (Exception exception) {
             // log happens individually to cover transformation/ccd cases
             throw new CallbackException(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
@@ -138,7 +138,7 @@ public class CcdNewCaseCreator {
             );
 
             throw new CallbackException("Payment references cannot be processed. Please try again later", exception);
-        // I/O related exception received from transformation client
+        // exceptions received from transformation client
         } catch (RestClientException exception) {
             String message = format(
                 "Failed to receive transformed exception record from %s client for exception record %s",
@@ -149,8 +149,8 @@ public class CcdNewCaseCreator {
             log.error(message, exception);
 
             throw new CallbackException(message, exception);
+        // rest of exceptions received from ccd and logged separately
         } catch (Exception exception) {
-            // log happens individually to cover transformation/ccd cases
             throw new CallbackException(
                 format("Failed to create new case for exception record with Id %s", exceptionRecord.id),
                 exception

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.ServiceResponseParser;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ExceptionRecord;
@@ -250,6 +251,54 @@ class CcdNewCaseCreatorTest {
         assertThat(result.getExceptionRecordData()).isEmpty();
         assertThat(result.getWarnings()).containsOnly("warning");
         assertThat(result.getErrors()).containsOnly("error");
+
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+    }
+
+    @Test
+    void should_throw_CallbackException_when_transformation_client_throws_RestClientException() {
+        // given
+        when(s2sTokenGenerator.generate()).thenReturn(randomUUID().toString());
+        doThrow(new RestClientException("I/O error"))
+            .when(transformationClient)
+            .transformExceptionRecord(anyString(), any(ExceptionRecord.class), anyString());
+
+        ServiceConfigItem configItem = getConfigItem();
+        ExceptionRecord exceptionRecord = getExceptionRecord();
+
+        Map<String, Object> data = new HashMap<>();
+        // putting 6 via `ImmutableMap` is available from Java 9
+        data.put("poBox", "12345");
+        data.put("journeyClassification", EXCEPTION.name());
+        data.put("formType", "Form1");
+        data.put("deliveryDate", "2019-09-06T15:30:03.000Z");
+        data.put("openingDate", "2019-09-06T15:30:04.000Z");
+        data.put("scannedDocuments", TestCaseBuilder.document("https://url", "some doc"));
+        data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("some key", "some value"));
+
+        CaseDetails caseDetails = getCaseDetails(data);
+
+        // when
+        CallbackException exception = catchThrowableOfType(() ->
+            ccdNewCaseCreator.createNewCase(
+                exceptionRecord,
+                configItem,
+                true,
+                IDAM_TOKEN,
+                USER_ID,
+                caseDetails
+            ),
+            CallbackException.class
+        );
+
+        // then
+        assertThat(exception)
+            .hasCauseInstanceOf(RestClientException.class)
+            .hasMessage(
+                "Failed to receive transformed exception record from %s client for exception record %s",
+                configItem.getService(),
+                exceptionRecord.id
+            );
 
         verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Improve the handling of client service responses](https://tools.hmcts.net/jira/browse/BPS-992)

### Change description ###

Case update and Transformation clients are using `RestTemplate` which can throw `RestClientException`s due to some I/O errors. Also noticed in exception alert fairly frequently happening from payments. Should review such edge case on payment processor as well

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
