### PR TITLE
Fix logging the attachment of exception record to a case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -280,7 +280,7 @@ public class AttachCaseCallbackService {
         }
 
         log.info(
-            "Successfully attached exception record {} to case {}",
+            "Completed the process of attaching exception record to a case. ER ID: {}. Case ID: {}",
             callBackEvent.exceptionRecordId,
             callBackEvent.targetCaseRef
         );
@@ -403,9 +403,9 @@ public class AttachCaseCallbackService {
         );
 
         log.info(
-            "Successfully attach Exception Record with ID {} to case with id {}",
-            theCase.getId(),
-            exceptionRecordDetails.getId()
+            "Attached Exception Record to a case in CCD. ER ID: {}. Case ID: {}",
+            exceptionRecordDetails.getId(),
+            theCase.getId()
         );
 
         paymentsProcessor.updatePayments(exceptionRecordDetails, theCase.getId());


### PR DESCRIPTION
### Change description ###

Fix logging the attachment of exception record to a case. Also, remove some ambiguity - we had two log entries with the same content, but marking the completion of different things.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
