### PR TITLE
Publish service bus dependency telemetry

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/AppInsights.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/AppInsights.java
@@ -2,13 +2,24 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.logging;
 
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.telemetry.Duration;
+import com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry;
+import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
+import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
+import com.microsoft.applicationinsights.web.internal.ThreadContext;
+import com.microsoft.applicationinsights.web.internal.correlation.TelemetryCorrelationUtils;
 import com.microsoft.azure.servicebus.IMessage;
 import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 @Component
 public class AppInsights {
 
     static final String DEAD_LETTER_EVENT = "DeadLetter";
+
+    static final String SERVICE_BUS_DEPENDENCY_TYPE = "ServiceBus";
 
     private final TelemetryClient telemetryClient;
 
@@ -29,5 +40,34 @@ public class AppInsights {
                 "deliveryCount", (double) (message.getDeliveryCount() + 1) // starts from 0
             )
         );
+    }
+
+    // dependencies
+
+    public void trackServiceBusMessage(String dependencyName, String commandName, Instant start, boolean success) {
+        // dependency definition
+        RemoteDependencyTelemetry dependencyTelemetry = new RemoteDependencyTelemetry(
+            dependencyName,
+            commandName,
+            new Duration(ChronoUnit.MILLIS.between(start, Instant.now())),
+            success
+        );
+        dependencyTelemetry.setType(SERVICE_BUS_DEPENDENCY_TYPE);
+
+        // tracing support
+        RequestTelemetryContext context = ThreadContext.getRequestTelemetryContext();
+
+        if (context != null) {
+            RequestTelemetry requestTelemetry = context.getHttpRequestTelemetry();
+            dependencyTelemetry.setId(TelemetryCorrelationUtils.generateChildDependencyId());
+            dependencyTelemetry.getContext().getOperation().setId(
+                requestTelemetry.getContext().getOperation().getId()
+            );
+            dependencyTelemetry.getContext().getOperation().setParentId(
+                requestTelemetry.getId()
+            );
+        }
+
+        telemetryClient.trackDependency(dependencyTelemetry);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/DependencyCommand.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/DependencyCommand.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.logging;
+
+public final class DependencyCommand {
+
+    public static final String QUEUE_MESSAGE_RECEIVED = "Received";
+
+    private DependencyCommand() {
+        // empty utility class construct
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/DependencyName.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/DependencyName.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.logging;
+
+public final class DependencyName {
+
+    public static final String ENVELOPE_QUEUE = "Envelope QUEUE";
+
+    private DependencyName() {
+        // empty utility class construct
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/AppInsightsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/AppInsightsTest.java
@@ -2,15 +2,28 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.logging;
 
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry;
+import com.microsoft.applicationinsights.web.internal.RequestTelemetryContext;
+import com.microsoft.applicationinsights.web.internal.ThreadContext;
 import com.microsoft.azure.servicebus.IMessage;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Instant;
+
+import static java.time.Instant.now;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.logging.DependencyCommand.QUEUE_MESSAGE_RECEIVED;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.logging.DependencyName.ENVELOPE_QUEUE;
 
 @ExtendWith(MockitoExtension.class)
 class AppInsightsTest {
@@ -22,6 +35,13 @@ class AppInsightsTest {
     private TelemetryClient telemetryClient;
 
     private AppInsights appInsights;
+
+    @BeforeAll
+    static void setUpRequestContext() {
+        ThreadContext.setRequestTelemetryContext(
+            new RequestTelemetryContext(now().toEpochMilli(), null)
+        );
+    }
 
     @BeforeEach
     void setUp() {
@@ -53,5 +73,28 @@ class AppInsightsTest {
                 "deliveryCount", (double) (deliveryCount + 1)
             )
         );
+    }
+
+    @Test
+    void should_record_service_bus_message_activity() {
+        // given
+        Instant finished = now();
+        ArgumentCaptor<RemoteDependencyTelemetry> dependencyCaptor =
+            ArgumentCaptor.forClass(RemoteDependencyTelemetry.class);
+
+        // when
+        appInsights.trackServiceBusMessage(ENVELOPE_QUEUE, QUEUE_MESSAGE_RECEIVED, finished, true);
+        appInsights.trackServiceBusMessage(ENVELOPE_QUEUE, QUEUE_MESSAGE_RECEIVED, finished, false);
+
+        // then
+        verify(telemetryClient, times(2)).trackDependency(dependencyCaptor.capture());
+        assertThat(dependencyCaptor.getAllValues())
+            .extracting(dependency ->
+                tuple(dependency.getType(), dependency.getName(), dependency.getCommandName(), dependency.getSuccess())
+            )
+            .containsExactlyInAnyOrder(
+                tuple(AppInsights.SERVICE_BUS_DEPENDENCY_TYPE, ENVELOPE_QUEUE, QUEUE_MESSAGE_RECEIVED, true),
+                tuple(AppInsights.SERVICE_BUS_DEPENDENCY_TYPE, ENVELOPE_QUEUE, QUEUE_MESSAGE_RECEIVED, false)
+            );
     }
 }


### PR DESCRIPTION
### Change description ###

Introducing another remote dependency (and bubble in app insights application map!) called `ServiceBus`. It'll contain different dependencies named `Envelope QUEUE`, `Notification QUEUE` and so on.

This will link `bulk-scan` product components even more tightly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
