### PR TITLE
Revert "Revert "Attaching Exception records with pending payments to the case (#855)" (#862)"

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
@@ -4,7 +4,6 @@ import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -141,7 +140,6 @@ class AttachExceptionRecordToExistingCaseTest {
         );
     }
 
-    @Disabled("Functionality not implemented yet")
     @Test
     public void should_not_attach_exception_record_with_pending_payments_when_classification_is_not_allowed()
         throws Exception {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordWithOcrToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordWithOcrToExistingCaseTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -76,8 +75,6 @@ class AttachExceptionRecordWithOcrToExistingCaseTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    @Disabled("Functionality not implemented yet")
     void should_not_attach_exception_record_with_pending_payments_when_classification_is_not_allowed()
         throws Exception {
         //given
@@ -99,9 +96,6 @@ class AttachExceptionRecordWithOcrToExistingCaseTest {
         // verify case is not updated
         CaseDetails updatedCase = ccdApi.getCase(caseId, existingCase.getJurisdiction());
         assertThat(getScannedDocuments(updatedCase)).isEmpty(); // no scanned documents
-
-        Map<String, String> address = (Map<String, String>) updatedCase.getData().get("address");
-        assertThat(address.get("country")).isNull();
     }
 
     private CaseDetails createExceptionRecord(String resourceName) throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
@@ -55,7 +55,9 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.doNothing;
@@ -65,6 +67,8 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.CASE_
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.CASE_TYPE_EXCEPTION_RECORD;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.config.Environment.JURISDICTION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.controllers.CcdCallbackController.USER_ID;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.AWAITING_PAYMENT_DCN_PROCESSING;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE_WITH_OCR;
 
 @AutoConfigureWireMock(port = 0)
@@ -580,7 +584,99 @@ class AttachExceptionRecordToExistingCaseTest {
                     RESPONSE_FIELD_ERRORS,
                     hasItem("The 'attach to case' event is not supported for supplementary evidence with OCR "
                         + "but not containing OCR data")
-        );
+                );
+    }
+
+    @Test
+    public void should_return_payments_error_when_config_does_not_allow_classification_with_pending_payments() {
+        CallbackRequest callbackRequest =
+            callbackRequestWith(
+                EVENT_ID_ATTACH_TO_CASE,
+                CLASSIFICATION_EXCEPTION, // not allowed to attach exception record with pending payments
+                "Yes", // awaiting payments DCN processing
+                false
+            );
+
+        given()
+            .body(callbackRequest)
+            .headers(userHeaders())
+            .post(CALLBACK_ATTACH_CASE_PATH)
+            .then()
+            .statusCode(200)
+            .body(
+                RESPONSE_FIELD_ERRORS,
+                hasItem("Cannot attach this exception record to a case because it has pending payments")
+            );
+    }
+
+    @Test
+    public void should_not_return_payments_error_when_config_allows_classification_with_pending_payments() {
+        CallbackRequest callbackRequest =
+            callbackRequestWith(
+                EVENT_ID_ATTACH_TO_CASE,
+                SUPPLEMENTARY_EVIDENCE_WITH_OCR.name(), // config allows to attach with pending payments
+                "Yes", // awaiting payments DCN processing
+                true
+            );
+
+        given()
+            .body(callbackRequest)
+            .headers(userHeaders())
+            .post(CALLBACK_ATTACH_CASE_PATH)
+            .then()
+            .statusCode(200)
+            .body(
+                RESPONSE_FIELD_ERRORS,
+                not(hasItem("Cannot attach this exception record to a case because it has pending payments"))
+            );
+    }
+
+    @Test
+    public void should_return_payments_error_when_config_does_not_allow_supplementary_evidence_with_pending_payments() {
+        CallbackRequest callbackRequest =
+            callbackRequestWith(
+                EVENT_ID_ATTACH_TO_CASE,
+                SUPPLEMENTARY_EVIDENCE.name(), // not allowed to attach exception record with pending payments
+                "Yes", // awaiting payments DCN processing
+                false
+            );
+
+        given()
+            .body(callbackRequest)
+            .headers(userHeaders())
+            .post(CALLBACK_ATTACH_CASE_PATH)
+            .then()
+            .statusCode(200)
+            .body(
+                RESPONSE_FIELD_ERRORS,
+                hasItem("Cannot attach this exception record to a case because it has pending payments")
+            );
+    }
+
+    @Test
+    public void should_succeed_when_classification_is_supplementary_evidence_with_processed_payments() {
+        CallbackRequest callbackRequest =
+            callbackRequestWith(
+                EVENT_ID_ATTACH_TO_CASE,
+                SUPPLEMENTARY_EVIDENCE.name(),
+                "No", // awaiting payments DCN processing
+                false
+            );
+
+        ValidatableResponse response =
+            given()
+                .body(callbackRequest)
+                .headers(userHeaders())
+                .post(CALLBACK_ATTACH_CASE_PATH)
+                .then()
+                .statusCode(200)
+                .body(
+                    RESPONSE_FIELD_ERRORS,
+                    empty()
+                );
+
+        verifySuccessResponse(response, callbackRequest);
+        verifyRequestedAttachingToCase();
     }
 
     @Test
@@ -893,7 +989,47 @@ class AttachExceptionRecordToExistingCaseTest {
             .build();
     }
 
+    private CallbackRequest callbackRequestWith(
+        String eventId,
+        String classification,
+        String awaitingPaymentDcnProcessing,
+        boolean includeOcr
+    ) {
+        return CallbackRequest
+            .builder()
+            .caseDetails(exceptionRecordWith(classification, awaitingPaymentDcnProcessing, includeOcr))
+            .eventId(eventId)
+            .build();
+    }
+
+    private CaseDetails exceptionRecordWith(
+        String classification,
+        String awaitingPaymentDcnProcessing,
+        boolean includeOcr
+    ) {
+        Map<String, Object> caseData = exceptionRecordData(classification, includeOcr);
+        caseData.put(AWAITING_PAYMENT_DCN_PROCESSING, awaitingPaymentDcnProcessing);
+
+        return CaseDetails.builder()
+            .jurisdiction(JURISDICTION)
+            .id(EXCEPTION_RECORD_ID)
+            .caseTypeId(CASE_TYPE_EXCEPTION_RECORD)
+            .data(caseData)
+            .build();
+    }
+
     private CaseDetails exceptionRecordWith(String classification, boolean includeOcr) {
+        Map<String, Object> caseData = exceptionRecordData(classification, includeOcr);
+
+        return CaseDetails.builder()
+            .jurisdiction(JURISDICTION)
+            .id(EXCEPTION_RECORD_ID)
+            .caseTypeId(CASE_TYPE_EXCEPTION_RECORD)
+            .data(caseData)
+            .build();
+    }
+
+    private Map<String, Object> exceptionRecordData(String classification, boolean includeOcr) {
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("journeyClassification", classification);
 
@@ -907,13 +1043,7 @@ class AttachExceptionRecordToExistingCaseTest {
 
         caseData.put("scannedDocuments", ImmutableList.of(EXCEPTION_RECORD_DOC));
         caseData.put("attachToCaseReference", CASE_REF);
-
-        return CaseDetails.builder()
-            .jurisdiction(JURISDICTION)
-            .id(EXCEPTION_RECORD_ID)
-            .caseTypeId(CASE_TYPE_EXCEPTION_RECORD)
-            .data(caseData)
-            .build();
+        return caseData;
     }
 
     private static Map<String, Object> document(String filename, String documentNumber) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -45,6 +45,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackVal
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasSearchCaseReferenceType;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasServiceNameInCaseTypeId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasUserId;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.validatePayments;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.checkForDuplicatesOrElse;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.concatDocuments;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.getDocumentNumbers;
@@ -150,6 +151,16 @@ public class AttachCaseCallbackService {
         Validation<String, Classification> classificationValidation =
             hasJourneyClassificationForAttachToCase(exceptionRecord);
 
+        final Validation<String, Void> paymentsValidation;
+        if (classificationValidation.isValid() && serviceNameInCaseTypeIdValidation.isValid()) {
+            ServiceConfigItem serviceConfig = serviceConfigProvider.getConfig(
+                serviceNameInCaseTypeIdValidation.get()
+            );
+            paymentsValidation = validatePayments(exceptionRecord, classificationValidation.get(), serviceConfig);
+        } else {
+            paymentsValidation = Validation.valid(null);
+        }
+
         final Validation<Seq<String>, ExceptionRecord> exceptionRecordValidation;
         if (classificationValidation.isValid() && classificationValidation.get() == SUPPLEMENTARY_EVIDENCE_WITH_OCR) {
             exceptionRecordValidation = exceptionRecordValidator.getValidation(exceptionRecord);
@@ -168,7 +179,8 @@ public class AttachCaseCallbackService {
             scannedRecordValidation,
             idamTokenValidation,
             userIdValidation,
-            classificationValidation
+            classificationValidation,
+            paymentsValidation
         );
 
         Seq<String> errors = getValidationErrors(validations);
@@ -462,7 +474,7 @@ public class AttachCaseCallbackService {
             exceptionRecordJurisdiction
         );
 
-        String attachToCaseRef = (String)fetchedExceptionRecord.getData().get(ATTACH_TO_CASE_REFERENCE);
+        String attachToCaseRef = (String) fetchedExceptionRecord.getData().get(ATTACH_TO_CASE_REFERENCE);
 
         if (StringUtils.isNotEmpty(attachToCaseRef)) {
             throw new AlreadyAttachedToCaseException("Exception record is already attached to case " + attachToCaseRef);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -5,6 +5,7 @@ import io.vavr.control.Validation;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
@@ -22,6 +23,7 @@ import static io.vavr.control.Validation.invalid;
 import static io.vavr.control.Validation.valid;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.YesNoFieldValues.YES;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.EXCEPTION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.NEW_APPLICATION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE;
@@ -198,10 +200,35 @@ public final class CallbackValidations {
             .map(c -> (String) c);
     }
 
+    private static Optional<String> getAwaitingPaymentDcnProcessing(CaseDetails theCase) {
+        return Optional.ofNullable(theCase)
+            .map(CaseDetails::getData)
+            .map(data -> data.get("awaitingPaymentDCNProcessing"))
+            .map(c -> (String) c);
+    }
+
     static boolean hasOcr(CaseDetails theCase) {
         return getOcrData(theCase)
             .map(CollectionUtils::isNotEmpty)
             .orElse(false);
+    }
+
+    static Validation<String, Void> validatePayments(
+        CaseDetails theCase,
+        Classification classification,
+        ServiceConfigItem config
+    ) {
+        Optional<String> awaitingPaymentsOptional = getAwaitingPaymentDcnProcessing(theCase);
+
+        if (awaitingPaymentsOptional.isPresent()
+            && awaitingPaymentsOptional.get().equals(YES) // payments processing pending
+            && !config.getAllowAttachingToCaseBeforePaymentsAreProcessedForClassifications() // check if config allows
+            .contains(classification)
+        ) {
+            return invalid("Cannot attach this exception record to a case because it has pending payments");
+        } else {
+            return valid(null);
+        }
     }
 
     public static Validation<String, String> hasPoBox(CaseDetails theCase) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/definition/ExceptionRecordFields.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/definition/ExceptionRecordFields.java
@@ -17,6 +17,7 @@ public final class ExceptionRecordFields {
     public static final String ENVELOPE_ID = "envelopeId";
     public static final String PO_BOX_JURISDICTION = "poBoxJurisdiction";
     public static final String AWAITING_PAYMENT_DCN_PROCESSING = "awaitingPaymentDCNProcessing";
+    public static final String JOURNEY_CLASSIFICATION = "journeyClassification";
     public static final String OCR_DATA = "scanOCRData";
 
     private ExceptionRecordFields() {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.AWAITING_PAYMENT_DCN_PROCESSING;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.JOURNEY_CLASSIFICATION;
+
 class TestCaseBuilder {
     private TestCaseBuilder() {
     }
@@ -44,6 +47,16 @@ class TestCaseBuilder {
         caseData.put("searchCaseReferenceType", searchCaseReferenceType);
 
         return createCaseWith(b -> b.data(caseData));
+    }
+
+    static CaseDetails caseWithAwaitingPaymentsAndClassification(
+        Object awaitingPaymentsProcessing,
+        Object classification
+    ) {
+        Map<String, Object> data = new HashMap<>();
+        data.put(AWAITING_PAYMENT_DCN_PROCESSING, awaitingPaymentsProcessing);
+        data.put(JOURNEY_CLASSIFICATION, classification);
+        return createCaseWith(b -> b.data(data));
     }
 
     static CaseDetails caseWithDocument(List<Map<String, Object>> caseReference) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1025

### Change description ###
Reverted #862 
The additional change to #855 is:
Service config is retrieved from `ServiceConfigProvider` and doesn't check for `updateUrl` config . 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
