### PR TITLE
Improve logging for attaching supplementary evidence

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -48,9 +48,9 @@ class AttachDocsToSupplementaryEvidence {
             existingCase.getState()
         );
         if (mapper.getDocsToAdd(getDocuments(existingCase), envelope.documents).isEmpty()) {
-            log.warn("Envelope has no new documents. CCD Case not updated. " + loggingContext);
+            log.warn("Envelope has no new documents. CCD Case not updated. {}", loggingContext);
         } else {
-            log.info("Attaching supplementary evidence. " + loggingContext);
+            log.info("Attaching supplementary evidence. {}", loggingContext);
 
             try {
                 CcdAuthenticator authenticator = ccdApi.authenticateJurisdiction(envelope.jurisdiction);
@@ -63,7 +63,7 @@ class AttachDocsToSupplementaryEvidence {
                     EVENT_TYPE_ID
                 );
 
-                log.info("Started event in CCD to attach exception record to case. " + loggingContext);
+                log.info("Started event in CCD to attach exception record to case. {}", loggingContext);
 
                 ccdApi.submitEventForAttachScannedDocs(
                     authenticator,
@@ -73,13 +73,9 @@ class AttachDocsToSupplementaryEvidence {
                     buildCaseDataContent(envelope, startEventResp)
                 );
 
-                log.info(
-                    "Attached documents from envelope to case. " + loggingContext
-                );
+                log.info("Attached documents from envelope to case. {}", loggingContext);
             } catch (UnableToAttachDocumentsException e) {
-                log.error(
-                    "Failed to attach documents from envelope to case. " + loggingContext
-                );
+                log.error("Failed to attach documents from envelope to case. {}", loggingContext);
                 return false;
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -40,15 +40,17 @@ class AttachDocsToSupplementaryEvidence {
      * @return true when attaching documents to existing case is successful, otherwise false
      */
     public boolean attach(Envelope envelope, CaseDetails existingCase) {
+        String loggingContext = String.format(
+            "Envelope ID: %s. File name: %s. Case ref: %s. Case state: %s",
+            envelope.id,
+            envelope.zipFileName,
+            existingCase.getId(),
+            existingCase.getState()
+        );
         if (mapper.getDocsToAdd(getDocuments(existingCase), envelope.documents).isEmpty()) {
-            log.warn("Envelope {} has no new documents. CCD Case {} not updated", envelope.id, existingCase.getId());
+            log.warn("Envelope has no new documents. CCD Case not updated. " + loggingContext);
         } else {
-            log.info(
-                "Attaching supplementary evidence. Envelope: {}. Case: {}. Case type: {}",
-                envelope.id,
-                existingCase.getId(),
-                existingCase.getCaseTypeId()
-            );
+            log.info("Attaching supplementary evidence. " + loggingContext);
 
             try {
                 CcdAuthenticator authenticator = ccdApi.authenticateJurisdiction(envelope.jurisdiction);
@@ -61,14 +63,7 @@ class AttachDocsToSupplementaryEvidence {
                     EVENT_TYPE_ID
                 );
 
-                log.info(
-                    "Started event in CCD to attach exception record to case. "
-                        + "Envelope ID: {}. File name: {}. Case ref: {}. Case state: {}",
-                    envelope.id,
-                    envelope.zipFileName,
-                    existingCase.getId(),
-                    existingCase.getState()
-                );
+                log.info("Started event in CCD to attach exception record to case. " + loggingContext);
 
                 ccdApi.submitEventForAttachScannedDocs(
                     authenticator,
@@ -79,16 +74,11 @@ class AttachDocsToSupplementaryEvidence {
                 );
 
                 log.info(
-                    "Attached documents from envelope to case. Case ID: {}, envelope ID: {}",
-                    existingCase.getId(),
-                    envelope.id
+                    "Attached documents from envelope to case. " + loggingContext
                 );
             } catch (UnableToAttachDocumentsException e) {
                 log.error(
-                    "Failed to attach documents from envelope to case. Case Type: {}, Case ID: {}, envelope ID: {}",
-                    existingCase.getCaseTypeId(),
-                    existingCase.getId(),
-                    envelope.id
+                    "Failed to attach documents from envelope to case. " + loggingContext
                 );
                 return false;
             }


### PR DESCRIPTION
Some logs included zip file name and some did not (just envelope ID), making it harder to check the history of given file.

Updated the logs so that we can see all the steps just by knowing the file name.