### PR TITLE
process envelopes with supported jurisdictions only

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandler.java
@@ -39,7 +39,7 @@ public class EnvelopeHandler {
 
     public void handleEnvelope(Envelope envelope) {
         // check if envelope jurisdiction is configured
-        isJurisdictionConfigured(envelope);
+        checkJurisdictionConfigured(envelope);
 
         switch (envelope.classification) {
             case SUPPLEMENTARY_EVIDENCE:
@@ -74,7 +74,7 @@ public class EnvelopeHandler {
         }
     }
 
-    private void isJurisdictionConfigured(Envelope envelope) {
+    private void checkJurisdictionConfigured(Envelope envelope) {
         if (!supportedJurisdictions.contains(envelope.jurisdiction)) {
             log.info(
                 "Jurisdiction is not supported for envelope {} file {} Jurisdiction {}",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/UnsupportedJurisdictionException.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/UnsupportedJurisdictionException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
+
+public class UnsupportedJurisdictionException extends RuntimeException {
+
+    public UnsupportedJurisdictionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -144,3 +144,4 @@ task:
   check-jurisdiction-log-in:
     check-validity-duration: PT5M # only ensure this often that no log-in attempt is rejected by IDAM
 
+supported-jurisdictions: SSCS,BULKSCAN,DIVORCE,PROBATE,FINREM,CMC

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandlerTest.java
@@ -13,6 +13,9 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.Optional;
 
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -44,7 +47,8 @@ class EnvelopeHandlerTest {
             attachDocsToSupplementaryEvidence,
             createExceptionRecord,
             caseFinder,
-            paymentsProcessor
+            paymentsProcessor,
+            singletonList(JURSIDICTION) // only BULKSCAN jurisdiction is supported
         );
     }
 
@@ -147,5 +151,18 @@ class EnvelopeHandlerTest {
         verify(createExceptionRecord).tryCreateFrom(envelope);
         verify(paymentsProcessor).createPayments(envelope, CASE_ID, true);
     }
+
+    @Test
+    void should_throw_exception_when_jurisdiction_is_not_configured() {
+        // given
+        Envelope envelope = envelope(SUPPLEMENTARY_EVIDENCE, "UNSUPPORTED_JURISDICTION", CASE_REF);
+
+        // when
+        Throwable exception = catchThrowable(() -> envelopeHandler.handleEnvelope(envelope));
+
+        // then
+        assertThat(exception).isInstanceOf(UnsupportedJurisdictionException.class);
+    }
+
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1050


### Change description ###
- Added config for supported jurisdictions. This will be moved to AKS config in https://github.com/hmcts/bulk-scan-orchestrator/pull/866 
- Process envelopes with the configured jurisdictions

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
