### PR TITLE
Idempotency bugfix for case creation callback

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
@@ -55,7 +55,7 @@ public class CcdNewCaseCreator {
         this.exceptionRecordFinalizer = exceptionRecordFinalizer;
     }
 
-    @SuppressWarnings({"squid:S2139", "unchecked"}) // squid for exception handle + logging
+    @SuppressWarnings("squid:S2139") // squid for exception handle + logging
     public Either<ProcessResult, Long> createNewCase(
         ExceptionRecord exceptionRecord,
         ServiceConfigItem configItem,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
@@ -42,7 +42,8 @@ public class CcdNewCaseCreator {
 
     public CcdNewCaseCreator(
         TransformationClient transformationClient,
-        ServiceResponseParser serviceResponseParser, AuthTokenGenerator s2sTokenGenerator,
+        ServiceResponseParser serviceResponseParser,
+        AuthTokenGenerator s2sTokenGenerator,
         CoreCaseDataApi coreCaseDataApi
     ) {
         this.transformationClient = transformationClient;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CallbackE
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.ProcessResult;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 
@@ -40,19 +39,16 @@ public class CcdNewCaseCreator {
     private final ServiceResponseParser serviceResponseParser;
     private final AuthTokenGenerator s2sTokenGenerator;
     private final CoreCaseDataApi coreCaseDataApi;
-    private final ExceptionRecordFinalizer exceptionRecordFinalizer;
 
     public CcdNewCaseCreator(
         TransformationClient transformationClient,
         ServiceResponseParser serviceResponseParser, AuthTokenGenerator s2sTokenGenerator,
-        CoreCaseDataApi coreCaseDataApi,
-        ExceptionRecordFinalizer exceptionRecordFinalizer
+        CoreCaseDataApi coreCaseDataApi
     ) {
         this.transformationClient = transformationClient;
         this.serviceResponseParser = serviceResponseParser;
         this.s2sTokenGenerator = s2sTokenGenerator;
         this.coreCaseDataApi = coreCaseDataApi;
-        this.exceptionRecordFinalizer = exceptionRecordFinalizer;
     }
 
     @SuppressWarnings("squid:S2139") // squid for exception handle + logging
@@ -61,8 +57,7 @@ public class CcdNewCaseCreator {
         ServiceConfigItem configItem,
         boolean ignoreWarnings,
         String idamToken,
-        String userId,
-        CaseDetails exceptionRecordData
+        String userId
     ) {
         log.info(
             "Start creating new case for {} from exception record {}",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -185,8 +185,7 @@ public class CreateCaseCallbackService {
                         configItem,
                         ignoreWarnings,
                         idamToken,
-                        userId,
-                        exceptionRecordData
+                        userId
                     ));
 
                 Either<ProcessResult, ProcessResult> processedResult = result

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/CreateCaseResult.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * Data model representing objects used in drafting a response to a callback request.
+ */
+public class CreateCaseResult {
+
+    public final Long caseId;
+
+    public final List<String> warnings;
+
+    public final List<String> errors;
+
+    public CreateCaseResult(long caseId) {
+        this.caseId = caseId;
+        this.warnings = emptyList();
+        this.errors = emptyList();
+    }
+
+    public CreateCaseResult(List<String> warnings, List<String> errors) {
+        this.caseId = null;
+        this.warnings = warnings;
+        this.errors = errors;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
@@ -61,9 +61,6 @@ class CcdNewCaseCreatorTest {
     @Mock
     private CoreCaseDataApi coreCaseDataApi;
 
-    @Mock
-    private ExceptionRecordFinalizer exceptionRecordFinalizer;
-
     private CcdNewCaseCreator ccdNewCaseCreator;
 
     @Mock
@@ -75,8 +72,7 @@ class CcdNewCaseCreatorTest {
             transformationClient,
             serviceResponseParser,
             s2sTokenGenerator,
-            coreCaseDataApi,
-            exceptionRecordFinalizer
+            coreCaseDataApi
         );
     }
 
@@ -120,8 +116,7 @@ class CcdNewCaseCreatorTest {
                     configItem,
                     true,
                     IDAM_TOKEN,
-                    USER_ID,
-                    caseDetails
+                    USER_ID
                 );
 
         assertThat(result.isRight()).isTrue();
@@ -183,8 +178,7 @@ class CcdNewCaseCreatorTest {
                     configItem,
                     true,
                     IDAM_TOKEN,
-                    USER_ID,
-                    caseDetails
+                    USER_ID
                 );
 
         // then
@@ -222,8 +216,7 @@ class CcdNewCaseCreatorTest {
             configItem,
             true,
             IDAM_TOKEN,
-            USER_ID,
-            caseDetails
+            USER_ID
         );
 
         // then

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
-import io.vavr.control.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,7 +14,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.Transform
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.CaseCreationDetails;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.ProcessResult;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CreateCaseResult;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.YesNoFieldValues;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
@@ -109,7 +108,7 @@ class CcdNewCaseCreatorTest {
         CaseDetails caseDetails = getCaseDetails(basicCaseData());
 
         // when
-        Either<ProcessResult, Long> result =
+        CreateCaseResult result =
             ccdNewCaseCreator
                 .createNewCase(
                     exceptionRecord,
@@ -119,7 +118,7 @@ class CcdNewCaseCreatorTest {
                     USER_ID
                 );
 
-        assertThat(result.isRight()).isTrue();
+        assertThat(result.caseId).isEqualTo(newCaseId);
     }
 
     @Test
@@ -171,7 +170,7 @@ class CcdNewCaseCreatorTest {
         CaseDetails caseDetails = getCaseDetails(data);
 
         // when
-        Either<ProcessResult, Long> result =
+        CreateCaseResult result =
             ccdNewCaseCreator
                 .createNewCase(
                     exceptionRecord,
@@ -182,7 +181,7 @@ class CcdNewCaseCreatorTest {
                 );
 
         // then
-        assertThat(result.isRight()).isTrue();
+        assertThat(result.caseId).isEqualTo(newCaseId);
     }
 
     @Test
@@ -211,7 +210,7 @@ class CcdNewCaseCreatorTest {
         CaseDetails caseDetails = getCaseDetails(data);
 
         // when
-        Either<ProcessResult, Long> result = ccdNewCaseCreator.createNewCase(
+        CreateCaseResult result = ccdNewCaseCreator.createNewCase(
             exceptionRecord,
             configItem,
             true,
@@ -220,9 +219,8 @@ class CcdNewCaseCreatorTest {
         );
 
         // then
-        assertThat(result.isLeft()).isTrue();
-        assertThat(result.getLeft().getWarnings()).containsOnly("warning");
-        assertThat(result.getLeft().getErrors()).containsOnly("error");
+        assertThat(result.warnings).containsOnly("warning");
+        assertThat(result.errors).containsOnly("error");
     }
 
     private ExceptionRecord getExceptionRecord() {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.vavr.control.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +14,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ExceptionR
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.in.CcdCallbackRequest;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CallbackException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CreateCaseResult;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.ExceptionRecordValidator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.ProcessResult;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields;
@@ -589,7 +589,7 @@ class CreateCaseCallbackServiceTest {
             anyBoolean(),
             anyString(),
             anyString()
-        )).willReturn(Either.right(newCaseId));
+        )).willReturn(new CreateCaseResult(newCaseId));
 
         // when
         ProcessResult result =

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -588,8 +588,7 @@ class CreateCaseCallbackServiceTest {
             any(ServiceConfigItem.class),
             anyBoolean(),
             anyString(),
-            anyString(),
-            any(CaseDetails.class)
+            anyString()
         )).willReturn(Either.right(newCaseId));
 
         // when


### PR DESCRIPTION
### Change description ###

Payment should be called regardless case was found or newly created. Doing a bit of a re-work around the specific area and then moving the payment trigger there

Service Now: INC5029932

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes // payments will be called when case is found -> idempotent action is to proceed with payments
[x] No // it's kind of "expected behaviour" from us
```
