### PR TITLE
Revert 866 add publiclaw secrets

### DIFF
--- a/charts/bulk-scan-orchestrator/Chart.yaml
+++ b/charts/bulk-scan-orchestrator/Chart.yaml
@@ -1,7 +1,7 @@
 name: bulk-scan-orchestrator
 apiVersion: v1
 home: https://github.com/hmcts/bulk-scan-orchestrator
-version: 0.2.5
+version: 0.2.4
 description: HMCTS Bulk scan orchestrator service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/bulk-scan-orchestrator/Chart.yaml
+++ b/charts/bulk-scan-orchestrator/Chart.yaml
@@ -1,7 +1,7 @@
 name: bulk-scan-orchestrator
 apiVersion: v1
 home: https://github.com/hmcts/bulk-scan-orchestrator
-version: 0.2.4
+version: 0.2.6
 description: HMCTS Bulk scan orchestrator service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/bulk-scan-orchestrator/values.yaml
+++ b/charts/bulk-scan-orchestrator/values.yaml
@@ -31,8 +31,6 @@ java:
         - idam-users-div-password
         - idam-users-probate-username
         - idam-users-probate-password
-        - idam-users-publiclaw-username
-        - idam-users-publiclaw-password
         - idam-users-sscs-username
         - idam-users-sscs-password
         - envelopes-queue-listen-connection-string

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -143,3 +143,4 @@ hystrix:
 task:
   check-jurisdiction-log-in:
     check-validity-duration: PT5M # only ensure this often that no log-in attempt is rejected by IDAM
+

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -14,8 +14,6 @@ spring:
         idam-users-div-password: idam.users.divorce.password
         idam-users-probate-username: idam.users.probate.username
         idam-users-probate-password: idam.users.probate.password
-        idam-users-publiclaw-username: idam.users.publiclaw.username
-        idam-users-publiclaw-password: idam.users.publiclaw.password
         idam-users-sscs-username: idam.users.sscs.username
         idam-users-sscs-password: idam.users.sscs.password
         envelopes-queue-listen-connection-string: ENVELOPES_QUEUE_CONNECTION_STRING


### PR DESCRIPTION

### Change description ###

- `QueueProcessingReadinessChecker` tries to login for all jurisdictions and if login fails then it pauses the processing of queue through. Circuit breaker.

- As a result we are also getting heartbeat message failure alerts.

- There are currently 196 messages in envelopes queue in prod which are not processed due to envelopes queue being paused.

- Idam team has still not created the user in prod hence reverting as messages in the queue needs to be processed asap.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
