### PR TITLE
Fix log entry to recognise case ID

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/envelopes/EnvelopeEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/envelopes/EnvelopeEventProcessor.java
@@ -185,13 +185,14 @@ public class EnvelopeEventProcessor {
 
     private void logMessageParsed(IMessage message, Envelope envelope) {
         log.info(
-            "Parsed message. ID: {}, Envelope ID: {}, File name: {}, Jurisdiction: {}, Classification: {}, Case: {}",
+            "Parsed message. ID: {}, Envelope ID: {}, File name: {}, Jurisdiction: {}, Classification: {}, {}: {}",
             message.getMessageId(),
             envelope.id,
             envelope.zipFileName,
             envelope.jurisdiction,
             envelope.classification,
-            envelope.caseRef
+            envelope.caseRef == null ? "Legacy Case" : "Case",
+            envelope.caseRef == null ? envelope.legacyCaseRef : envelope.caseRef
         );
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Report](https://tools.hmcts.net/jira/browse/BPS-960)

### Change description ###

While was adding reason into the existing query, also noticed there are quite a sum of legacy cases which are not included in the report. Although it is only ad-hoc but ideally would like to have such link in automatic way. The report linked ^ will automatically work for legacy cases too

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
