### PR TITLE
Increase timeout for case creation assertion in the functional test

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
@@ -95,7 +95,6 @@ class CreateCaseTest {
 
         await("Case is ingested")
             .atMost(30, TimeUnit.SECONDS)
-            .pollDelay(2, TimeUnit.SECONDS)
             .pollInterval(1, TimeUnit.SECONDS)
             .until(() -> caseIngested(bulkScanCaseReference));
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
@@ -94,7 +94,7 @@ class CreateCaseTest {
         assertThat(bulkScanCaseReference.equals(String.valueOf(exceptionRecord.getId())));
 
         await("Case is ingested")
-            .atMost(30, TimeUnit.SECONDS)
+            .atMost(10, TimeUnit.SECONDS)
             .pollInterval(1, TimeUnit.SECONDS)
             .until(() -> caseIngested(bulkScanCaseReference));
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
@@ -94,8 +94,9 @@ class CreateCaseTest {
         assertThat(bulkScanCaseReference.equals(String.valueOf(exceptionRecord.getId())));
 
         await("Case is ingested")
-            .atMost(2, TimeUnit.SECONDS)
-            .pollDelay(1, TimeUnit.SECONDS)
+            .atMost(30, TimeUnit.SECONDS)
+            .pollDelay(2, TimeUnit.SECONDS)
+            .pollInterval(1, TimeUnit.SECONDS)
             .until(() -> caseIngested(bulkScanCaseReference));
 
         // when


### PR DESCRIPTION
### Change description ###
Create case idempotency functional test is frequently failing due to the short timeout.
Increased timeout to 30 seconds.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
