### PR TITLE
Introduce ER document connectives for duplicates

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/util/ExceptionRecordAttachDocumentConnectives.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/util/ExceptionRecordAttachDocumentConnectives.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.util;
+
+import java.util.Set;
+
+public class ExceptionRecordAttachDocumentConnectives {
+
+    /**
+     * Exception Record documents already present in target case.
+     */
+    private Set<String> duplicates;
+
+    public ExceptionRecordAttachDocumentConnectives(
+        Set<String> duplicates
+    ) {
+        this.duplicates = duplicates;
+    }
+
+    public boolean hasDuplicates() {
+        return !duplicates.isEmpty();
+    }
+
+    public Set<String> getDuplicates() {
+        return duplicates;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.util.ExceptionRecordAttachDocumentConnectives;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CallbackException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.ExceptionRecordValidator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.ProcessResult;
@@ -28,7 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static io.vavr.control.Validation.valid;
 import static java.util.Collections.singletonList;
@@ -46,7 +46,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackVal
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasServiceNameInCaseTypeId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasUserId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.validatePayments;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.checkForDuplicatesOrElse;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.calculateDocumentConnectives;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.concatDocuments;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.getDocumentNumbers;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.getScannedDocuments;
@@ -388,12 +388,21 @@ public class AttachCaseCallbackService {
         CaseDetails theCase = ccdApi.getCase(targetCaseCcdRef, callBackEvent.exceptionRecordJurisdiction);
         List<Map<String, Object>> targetCaseDocuments = getScannedDocuments(theCase);
 
-        //This is done so exception record does not change state if there is a document error
-        checkForDuplicatesOrElse(
+        ExceptionRecordAttachDocumentConnectives erDocumentConnectives = calculateDocumentConnectives(
             callBackEvent.exceptionRecordDocuments,
-            targetCaseDocuments,
-            ids -> throwDuplicateError(targetCaseCcdRef, ids)
+            targetCaseDocuments
         );
+
+        if (erDocumentConnectives.hasDuplicates()) {
+            // This is done so exception record does not change state if there is a document error
+            throw new DuplicateDocsException(
+                String.format(
+                    "Document(s) with control number %s are already attached to case reference: %s",
+                    erDocumentConnectives.getDuplicates(),
+                    targetCaseCcdRef
+                )
+            );
+        }
 
         List<Map<String, Object>> newCaseDocuments = attachExceptionRecordReference(
             callBackEvent.exceptionRecordDocuments,
@@ -500,16 +509,6 @@ public class AttachCaseCallbackService {
                 return ImmutableMap.<String, Object>of("value", copiedDocumentContent);
             })
             .collect(toList());
-    }
-
-    private void throwDuplicateError(String caseRef, Set<String> duplicateIds) {
-        throw new DuplicateDocsException(
-            String.format(
-                "Document(s) with control number %s are already attached to case reference: %s",
-                duplicateIds,
-                caseRef
-            )
-        );
     }
 
     private String createEventSummary(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
@@ -4,13 +4,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.util.ExceptionRecordAttachDocumentConnectives;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.validation.constraints.NotNull;
 
@@ -23,21 +23,19 @@ public final class Documents {
     private Documents() {
     }
 
-    private static Set<String> findDuplicates(List<Map<String, Object>> exceptionDocuments,
-                                              List<Map<String, Object>> existingDocuments) {
-        return Sets.intersection(
-            getDocumentIdSet(existingDocuments),
-            getDocumentIdSet(exceptionDocuments)
-        );
-    }
+    static ExceptionRecordAttachDocumentConnectives calculateDocumentConnectives(
+        List<Map<String, Object>> exceptionDocuments,
+        List<Map<String, Object>> existingDocuments
+    ) {
+        Set<String> exceptionRecordDocumentIds = getDocumentIdSet(exceptionDocuments);
+        Set<String> existingCaseDocumentIds = getDocumentIdSet(existingDocuments);
 
-    static void checkForDuplicatesOrElse(List<Map<String, Object>> exceptionDocuments,
-                                         List<Map<String, Object>> existingDocuments,
-                                         Consumer<Set<String>> duplicatesExist) {
-        Set<String> ids = findDuplicates(exceptionDocuments, existingDocuments);
-        if (!ids.isEmpty()) {
-            duplicatesExist.accept(ids);
-        }
+        return new ExceptionRecordAttachDocumentConnectives(
+            Sets.intersection(
+                exceptionRecordDocumentIds,
+                existingCaseDocumentIds
+            )
+        );
     }
 
     @NotNull

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
@@ -5,13 +5,13 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.util.ExceptionRecordAttachDocumentConnectives;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
 
@@ -59,13 +59,15 @@ class DocumentsTest {
     void findDuplicatesTest(CaseDetails theCase,
                             List<Map<String, Object>> exceptionRecords,
                             Set<Integer> duplicates) {
-        AtomicReference<Set<String>> result = new AtomicReference<>();
-        Documents.checkForDuplicatesOrElse(exceptionRecords, getScannedDocuments(theCase), result::set);
+        ExceptionRecordAttachDocumentConnectives erDocumentConnectives = Documents.calculateDocumentConnectives(
+            exceptionRecords,
+            getScannedDocuments(theCase)
+        );
 
         if (duplicates.isEmpty()) {
-            assertThat(result.get()).isNull();
+            assertThat(erDocumentConnectives.hasDuplicates()).isFalse();
         } else {
-            assertThat(result.get()).isEqualTo(asStringSet(duplicates));
+            assertThat(erDocumentConnectives.getDuplicates()).isEqualTo(asStringSet(duplicates));
         }
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Send payment message to the queue regardless of CCD action](https://tools.hmcts.net/jira/browse/BPS-1062)

### Change description ###

In order to send payments message disregarding documents where attached or not, need to rework the duplicate check first. Introducing helper which will contain other logical set comparison to determine whether there are duplicates amond missing or duplicates entirely which means everything is attached and just need to publish payment message

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
