### PR TITLE
Updated config with correct case for SSCS1PE  surname mapping

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -87,7 +87,7 @@ service-config:
           ocrFields:
             - person2_last_name
             - person1_last_name
-        - formType: sscs1pe
+        - formType: SSCS1PE
           ocrFields:
             - person2_last_name
             - person1_last_name


### PR DESCRIPTION

### Change description ###

- Processor only modifies the subtype case for SSCS1 and not for any other form type.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
