### PR TITLE
Fix a log message about attaching supplementary evidence to case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -63,7 +63,7 @@ class AttachDocsToSupplementaryEvidence {
                     EVENT_TYPE_ID
                 );
 
-                log.info("Started event in CCD to attach exception record to case. {}", loggingContext);
+                log.info("Started event in CCD to attach supplementary evidence to case. {}", loggingContext);
 
                 ccdApi.submitEventForAttachScannedDocs(
                     authenticator,


### PR DESCRIPTION
### Change description ###

Fix a log message about attaching supplementary evidence to case. It mentioned exception record, which doesn't play any role in this scenario.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
