### PR TITLE
Payment queue retry config

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/QueueClientsConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/QueueClientsConfig.java
@@ -44,7 +44,7 @@ public class QueueClientsConfig {
         @Value("${azure.servicebus.payments.queue-name}") String queueName
     ) throws InterruptedException, ServiceBusException {
         ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(connectionString, queueName);
-        connectionStringBuilder.setOperationTimeout(Duration.ofSeconds(15));
+        connectionStringBuilder.setOperationTimeout(Duration.ofSeconds(5));
         return new QueueClient(connectionStringBuilder, ReceiveMode.PEEKLOCK);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/QueueClientsConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/QueueClientsConfig.java
@@ -11,6 +11,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
+import java.time.Duration;
+
 @Configuration
 @Profile("!nosb") // do not register handler for the nosb (test) profile
 public class QueueClientsConfig {
@@ -41,9 +43,8 @@ public class QueueClientsConfig {
         @Value("${azure.servicebus.payments.connection-string}") String connectionString,
         @Value("${azure.servicebus.payments.queue-name}") String queueName
     ) throws InterruptedException, ServiceBusException {
-        return new QueueClient(
-            new ConnectionStringBuilder(connectionString, queueName),
-            ReceiveMode.PEEKLOCK
-        );
+        ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(connectionString, queueName);
+        connectionStringBuilder.setOperationTimeout(Duration.ofSeconds(15));
+        return new QueueClient(connectionStringBuilder, ReceiveMode.PEEKLOCK);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/PaymentsPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/PaymentsPublisher.java
@@ -67,7 +67,7 @@ public class PaymentsPublisher implements IPaymentsPublisher {
         } catch (Exception ex) {
             if (retry) {
                 LOG.error(
-                        "Sending to payment queue got error, Message ID: {}, {}. Will retry....",
+                        "Sending to payment queue got error, Message ID: {}. Will retry....",
                         message.getMessageId(),
                         ex
                 );

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/PaymentsPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/PaymentsPublisher.java
@@ -66,6 +66,7 @@ public class PaymentsPublisher implements IPaymentsPublisher {
             queueClient.send(message);
         } catch (Exception ex) {
             if (retry) {
+                LOG.error("Send to payment queue got error, will retry....", ex);
                 doSend(message, false);
             } else {
                 throw ex;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/PaymentsPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/PaymentsPublisher.java
@@ -64,8 +64,8 @@ public class PaymentsPublisher implements IPaymentsPublisher {
     private void doSend(IMessage message, boolean retry) throws ServiceBusException, InterruptedException {
         try {
             queueClient.send(message);
-        } catch (ServiceBusException ex) {
-            if (retry && ex.getIsTransient()) {
+        } catch (Exception ex) {
+            if (retry) {
                 doSend(message, false);
             } else {
                 throw ex;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/PaymentsPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/domains/payments/PaymentsPublisher.java
@@ -66,7 +66,12 @@ public class PaymentsPublisher implements IPaymentsPublisher {
             queueClient.send(message);
         } catch (Exception ex) {
             if (retry) {
-                LOG.error("Send to payment queue got error, will retry....", ex);
+                LOG.error(
+                        "Sending to payment queue got error, Message ID: {}, {}. Will retry....",
+                        message.getMessageId(),
+                        ex
+                );
+
                 doSend(message, false);
             } else {
                 throw ex;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/PaymentsPublisherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/servicebus/PaymentsPublisherTest.java
@@ -163,22 +163,6 @@ class PaymentsPublisherTest {
 
     }
 
-    @Test
-    void sending_create_command_should_throw_exception_without_retry() throws Exception {
-        CreatePaymentsCommand cmd = getCreatePaymentsCommand(false);
-
-        ServiceBusException exceptionToThrow = new ServiceBusException(false, "test exception");
-        willThrow(exceptionToThrow).given(queueClient).send(any());
-
-        assertThatThrownBy(() -> paymentsPublisher.send(cmd))
-                .isInstanceOf(PaymentsPublishingException.class)
-                .hasMessageContaining("An error occurred when trying to publish message to payments queue.")
-                .hasCause(exceptionToThrow);
-
-        verify(queueClient, times(1)).send(any());
-
-    }
-
     private CreatePaymentsCommand getCreatePaymentsCommand(boolean isExceptionRecord) {
         return new CreatePaymentsCommand(
             "envelope-id",


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1075

### Change description ###

normally servicebus api provides default retry mechanism for transient exceptions.
servicebus exceptions are transient and we got timeout exception which is transient too 
but api did not retried as I understand. again from my investigations retries are bounded with 
operational timeout.  I tried to active retry mechanism in my local but I could not managed to run.
if you think we can active retry mechanism please go head, I am open for ideas.

for now, if we can reduce the timeout and retry manually and we can handle the most cases.

in the api:
default timeout =30 seconds



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
