### PR TITLE
Add more info to the "duplicate documents" scenario

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordTestBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordTestBase.java
@@ -83,7 +83,7 @@ public class AttachExceptionRecordTestBase {
     private static final String EVENT_TOKEN = "theToken";
 
     private static final String EXCEPTION_RECORD_FILENAME = "record.pdf";
-    private static final String EXCEPTION_RECORD_DOCUMENT_NUMBER = "654321";
+    static final String EXCEPTION_RECORD_DOCUMENT_NUMBER = "654321";
 
     private static final String SERVICE_AUTHORIZATION_HEADER = "ServiceAuthorization";
     private static final String RESPONSE_FIELD_DATA = "data";

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
@@ -183,8 +183,10 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
             .then()
             .statusCode(200)
             .body(RESPONSE_FIELD_ERRORS, hasItem(String.format(
-                "Document(s) with control number [%s] are already attached to case reference: %s",
+                "Document(s) with control number(s) [%s] are already attached to case.\n"
+                    + " Document(s) with control numbers(s) [%s] missing in the target case. Case reference: %s",
                 DOCUMENT_NUMBER,
+                EXCEPTION_RECORD_DOCUMENT_NUMBER,
                 CASE_REF
             )));
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/util/ExceptionRecordAttachDocumentConnectives.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/util/ExceptionRecordAttachDocumentConnectives.java
@@ -22,7 +22,7 @@ public class ExceptionRecordAttachDocumentConnectives {
         this.toBeAttachedToTargetCase = toBeAttachedToTargetCase;
     }
 
-    public boolean hasDuplicates() {
+    public boolean hasDuplicatesAndMissing() {
         return !existingInTargetCase.isEmpty() && !toBeAttachedToTargetCase.isEmpty();
     }
 
@@ -32,5 +32,9 @@ public class ExceptionRecordAttachDocumentConnectives {
 
     public Set<String> getExistingInTargetCase() {
         return existingInTargetCase;
+    }
+
+    public Set<String> getToBeAttachedToTargetCase() {
+        return toBeAttachedToTargetCase;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -393,13 +393,15 @@ public class AttachCaseCallbackService {
             targetCaseDocuments
         );
 
-        if (erDocumentConnectives.hasDuplicates()) {
+        if (erDocumentConnectives.hasDuplicatesAndMissing()) {
             // This is done so exception record does not change state if there is a document error
             throw new DuplicateDocsException(
-                // todo include empty
                 String.format(
-                    "Document(s) with control number %s are already attached to case reference: %s",
+                    "Document(s) with control number(s) %s are already attached to case.\n"
+                        + " Document(s) with control numbers(s) %s missing in the target case."
+                        + " Case reference: %s",
                     erDocumentConnectives.getExistingInTargetCase(),
+                    erDocumentConnectives.getToBeAttachedToTargetCase(),
                     targetCaseCcdRef
                 )
             );

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
@@ -65,7 +65,7 @@ class DocumentsTest {
         );
 
         if (duplicates.isEmpty()) {
-            assertThat(erDocumentConnectives.hasDuplicates()).isFalse();
+            assertThat(erDocumentConnectives.hasDuplicatesAndMissing()).isFalse();
         } else {
             assertThat(erDocumentConnectives.getExistingInTargetCase()).isEqualTo(asStringSet(duplicates));
         }


### PR DESCRIPTION
### Change description ###

Gathering more information on edge case which suppose to be removed/resolved. At the moment, logically there should not be a fault but for some reason - it is experienced. Without extra information I cannot confirm case worker is right. And it was meant to be added anyway. Once our QA confirms the workflow further development can be conducted.

NOTE. This is not changing current and previous functionality (before idempotency) per say. Just including extra information to new flow for adoption of idempotency

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
