### PR TITLE
Update connective to check missing docs

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
@@ -183,10 +183,8 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
             .then()
             .statusCode(200)
             .body(RESPONSE_FIELD_ERRORS, hasItem(String.format(
-                "Document(s) with control number(s) [%s] are already attached to case.\n"
-                    + " Document(s) with control numbers(s) [%s] missing in the target case. Case reference: %s",
+                "Document(s) with control number(s) [%s] are already attached to case. Case reference: %s",
                 DOCUMENT_NUMBER,
-                EXCEPTION_RECORD_DOCUMENT_NUMBER,
                 CASE_REF
             )));
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/util/ExceptionRecordAttachDocumentConnectives.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/ccd/util/ExceptionRecordAttachDocumentConnectives.java
@@ -10,31 +10,27 @@ public class ExceptionRecordAttachDocumentConnectives {
     private Set<String> existingInTargetCase;
 
     /**
-     * Exception Record documents which are still missing in target case.
+     * Number of Exception Record documents.
      */
-    private Set<String> toBeAttachedToTargetCase;
+    private int exceptionRecordDocSize;
 
     public ExceptionRecordAttachDocumentConnectives(
         Set<String> existingInTargetCase,
-        Set<String> toBeAttachedToTargetCase
+        int exceptionRecordDocSize
     ) {
         this.existingInTargetCase = existingInTargetCase;
-        this.toBeAttachedToTargetCase = toBeAttachedToTargetCase;
+        this.exceptionRecordDocSize = exceptionRecordDocSize;
     }
 
     public boolean hasDuplicatesAndMissing() {
-        return !existingInTargetCase.isEmpty() && !toBeAttachedToTargetCase.isEmpty();
+        return !existingInTargetCase.isEmpty() && exceptionRecordDocSize != existingInTargetCase.size();
     }
 
     public boolean hasMissing() {
-        return existingInTargetCase.isEmpty() && !toBeAttachedToTargetCase.isEmpty();
+        return existingInTargetCase.isEmpty() && exceptionRecordDocSize > 0;
     }
 
     public Set<String> getExistingInTargetCase() {
         return existingInTargetCase;
-    }
-
-    public Set<String> getToBeAttachedToTargetCase() {
-        return toBeAttachedToTargetCase;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -397,11 +397,8 @@ public class AttachCaseCallbackService {
             // This is done so exception record does not change state if there is a document error
             throw new DuplicateDocsException(
                 String.format(
-                    "Document(s) with control number(s) %s are already attached to case.\n"
-                        + " Document(s) with control numbers(s) %s missing in the target case."
-                        + " Case reference: %s",
+                    "Document(s) with control number(s) %s are already attached to case. Case reference: %s",
                     erDocumentConnectives.getExistingInTargetCase(),
-                    erDocumentConnectives.getToBeAttachedToTargetCase(),
                     targetCaseCcdRef
                 )
             );

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
@@ -35,10 +35,7 @@ public final class Documents {
                 exceptionRecordDocumentIds,
                 existingCaseDocumentIds
             ),
-            Sets.difference(
-                exceptionRecordDocumentIds,
-                existingCaseDocumentIds
-            )
+            exceptionRecordDocumentIds.size()
         );
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Send payment message to the queue regardless of CCD action](https://tools.hmcts.net/jira/browse/BPS-1062)

### Change description ###

Not using `Sets.difference` and simply verifying missing factor with size of current documents in exception record against intersection which was there before.

Another option why I did not experience previous message is service was not deployed to aat environment. Nevertheless, this approach simplifies decision making

Will have to make sure it has been deployed to verify outcome. If still fails - go uncertain path and just delete the exception throw :(

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
