### PR TITLE
Introduce validating rest template

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ValidatableRestTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ValidatableRestTemplate.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
+
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
+
+@Component
+public class ValidatableRestTemplate {
+
+    private final RestTemplate restTemplate;
+    private final Validator validator;
+
+    public ValidatableRestTemplate(RestTemplate restTemplate, Validator validator) {
+        this.restTemplate = restTemplate;
+        this.validator = validator;
+    }
+
+    public <T> T post(String url, @Nullable Object request, Class<T> responseType) {
+        T response = restTemplate.postForObject(url, request, responseType);
+
+        Set<ConstraintViolation<T>> violations = validator.validate(response);
+
+        if (violations.isEmpty()) {
+            return response;
+        }
+
+        throw new ConstraintViolationException(violations);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ValidatableRestTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ValidatableRestTemplateTest.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestTemplate;
+
+import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ValidatableRestTemplateTest {
+
+    private static final Validator validator = Validation
+        .buildDefaultValidatorFactory()
+        .getValidator();
+    private static final String URL = "/url";
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    private ValidatableRestTemplate validatableRestTemplate;
+
+    @BeforeEach
+    void setUp() {
+        validatableRestTemplate = new ValidatableRestTemplate(restTemplate, validator);
+    }
+
+    @Test
+    void should_return_valid_model() {
+        given(restTemplate.postForObject(URL, null, Model.class)).willReturn(new Model(new Object()));
+
+        assertThatCode(() -> validatableRestTemplate.post(URL, null, Model.class))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_throw_exception_when_model_is_invalid() {
+        given(restTemplate.postForObject(URL, null, Model.class)).willReturn(new Model(null));
+
+        assertThatCode(() -> validatableRestTemplate.post(URL, null, Model.class))
+            .isInstanceOf(ConstraintViolationException.class)
+            .hasMessage("object: must not be null");
+    }
+
+    @Valid
+    private static class Model {
+
+        @NotNull
+        public final Object object;
+
+        private Model(Object object) {
+            this.object = object;
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Improve handling of transformation response for create case](https://tools.hmcts.net/jira/browse/BPS-1073)

### Change description ###

First out of 2 PRs: `ValidatableRestTemplate` ready to be used in custom clients. Which is transformation client as the ticket refers.

The following PR is self-explanatory given this is introduced into codebase

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
