### PR TITLE
Validate user ID in reclassification endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
@@ -89,7 +89,9 @@ public class CcdCallbackController {
         @RequestBody CcdCallbackRequest callbackRequest,
         @RequestHeader(value = USER_ID, required = false) String userId
     ) {
-        if (callbackRequest.getCaseDetails() == null) {
+        if (userId != null && userId.matches("^.*[\\n|\\r|\\t]+.*$")) {
+            throw new InvalidRequestException("User ID contains invalid characters");
+        } else if (callbackRequest.getCaseDetails() == null) {
             throw new InvalidRequestException("Case details are missing in callback data");
         } else if (callbackRequest.getCaseDetails().getData() == null) {
             throw new InvalidRequestException("Case data is missing in case details");

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackControllerReclassifyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackControllerReclassifyTest.java
@@ -84,14 +84,26 @@ public class CcdCallbackControllerReclassifyTest {
         callReclassifyEndpoint("malformed body").andExpect(status().isBadRequest());
     }
 
+    @Test
+    void should_return_400_response_when_user_id_contains_invalid_characters() throws Exception {
+        callReclassifyEndpoint(VALID_REQUEST_BODY, "user\tId\tWith\tInvalid\tCharacters")
+            .andExpect(status().isBadRequest())
+            .andExpect(content().json("{'message':'User ID contains invalid characters'}"));
+    }
+
     private static String jsonString(String singleQuotedString) {
         return singleQuotedString.replace("'", "\"");
     }
 
     private ResultActions callReclassifyEndpoint(String body) throws Exception {
+        return callReclassifyEndpoint(body, "userId1");
+    }
+
+    private ResultActions callReclassifyEndpoint(String body, String userId) throws Exception {
         return mvc.perform(
             post("/callback/reclassify-exception-record")
                 .content(body)
+                .header("user-id", userId)
                 .contentType(MediaType.APPLICATION_JSON)
         );
     }


### PR DESCRIPTION
### Change description ###

Validate user ID in reclassification endpoint in order to prevent attacks through its value (user ID is logged). This should fix currently broken build (due to sonarcloud).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
