### PR TITLE
Set default classification list in service config to empty

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/ServiceConfigItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/ServiceConfigItem.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toMap;
 
 public class ServiceConfigItem {
@@ -36,7 +37,7 @@ public class ServiceConfigItem {
 
     private boolean allowCreatingCaseBeforePaymentsAreProcessed = false;
 
-    private List<Classification> allowAttachingToCaseBeforePaymentsAreProcessedForClassifications;
+    private List<Classification> allowAttachingToCaseBeforePaymentsAreProcessedForClassifications = emptyList();
 
     private Map<String, List<String>> formTypeToSurnameOcrFieldMappings = new HashMap<>();
 
@@ -102,7 +103,7 @@ public class ServiceConfigItem {
     }
 
     public List<String> getSurnameOcrFieldNameList(String formType) {
-        return formTypeToSurnameOcrFieldMappings.getOrDefault(formType, Collections.emptyList());
+        return formTypeToSurnameOcrFieldMappings.getOrDefault(formType, emptyList());
     }
 
     public void setFormTypeToSurnameOcrFieldMappings(List<FormFieldMapping> formTypeToSurnameOcrFieldMappings) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/ServiceConfigItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/config/ServiceConfigItem.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
### Change description ###

Set default classification list in service config to empty. The list represents classifications for which it should be possible to attach exception record to a case when payment processing is not completed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
