### PR TITLE
Extend the set of valid event IDs for attaching exception records to cases

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidator.java
@@ -2,18 +2,28 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
 import io.vavr.control.Validation;
 
+import java.util.List;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 
 import static io.vavr.control.Validation.invalid;
 import static io.vavr.control.Validation.valid;
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
 
 public final class EventIdValidator {
 
     public static final String EVENT_ID_ATTACH_TO_CASE = "attachToExistingCase";
+    public static final String EVENT_ID_EXTEND_CAVEAT_CASE = "extendCaveatCase";
+    public static final String EVENT_ID_EXTEND_BULK_SCAN_CASE = "extendBulkScanCase";
     public static final String EVENT_ID_CREATE_NEW_CASE = "createNewCase";
     public static final String EVENT_ID_ATTACH_SCANNED_DOCS_WITH_OCR = "attachScannedDocsWithOcr";
+
+    public static final List<String> ATTACH_TO_CASE_EVENT_IDS = asList(
+        EVENT_ID_ATTACH_TO_CASE,
+        EVENT_ID_EXTEND_CAVEAT_CASE,
+        EVENT_ID_EXTEND_BULK_SCAN_CASE
+    );
 
     private EventIdValidator() {
         // utility class constructor
@@ -21,7 +31,7 @@ public final class EventIdValidator {
 
     @Nonnull
     static Validation<String, Void> isAttachToCaseEvent(String eventId) {
-        return hasValidEventId(EVENT_ID_ATTACH_TO_CASE::equals, eventId);
+        return hasValidEventId(ATTACH_TO_CASE_EVENT_IDS::contains, eventId);
     }
 
     @Nonnull

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidator.java
@@ -19,7 +19,7 @@ public final class EventIdValidator {
     public static final String EVENT_ID_CREATE_NEW_CASE = "createNewCase";
     public static final String EVENT_ID_ATTACH_SCANNED_DOCS_WITH_OCR = "attachScannedDocsWithOcr";
 
-    public static final List<String> ATTACH_TO_CASE_EVENT_IDS = asList(
+    private static final List<String> ATTACH_TO_CASE_EVENT_IDS = asList(
         EVENT_ID_ATTACH_TO_CASE,
         EVENT_ID_EXTEND_CAVEAT_CASE,
         EVENT_ID_EXTEND_BULK_SCAN_CASE

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventIdValidatorTest.java
@@ -13,7 +13,9 @@ class EventIdValidatorTest {
         return new Object[][]{
             {"Invalid 'Attach to Case' event id", "invalid_event_id", false},
             {"Invalid 'Attach to Case' event id", "AttachToExistingCase", false},
-            {"Valid 'Attach to Case' event id", "attachToExistingCase", true}
+            {"Valid 'Attach to Case' event id", "attachToExistingCase", true},
+            {"Valid 'Attach to Case' event id", "extendCaveatCase", true},
+            {"Valid 'Attach to Case' event id", "extendBulkScanCase", true}
         };
     }
 


### PR DESCRIPTION
### Change description ###

Extend the set of valid event IDs for attaching exception records to cases, by the new ones:
- extendCaveatCase
- extendBulkScanCase

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
