### PR TITLE
Use service case type id in the startEvent call for the attachScannedDocsWithOcr event

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
@@ -194,7 +194,6 @@ class AttachExceptionRecordWithOcrTest {
         String invalidCaseId = "1234";
         setUpCaseSearchByCcdId(okJson(mapper.writeValueAsString(exceptionRecord(null))));
         setUpClientUpdate(getResponseBody("client-update-ok-no-warnings.json"));
-        setUpCcdStartEvent(badRequest(), invalidCaseId);
 
         // request with invalid case reference
         byte[] requestBody = getRequestBodyWithAttachToCaseRef(
@@ -203,7 +202,7 @@ class AttachExceptionRecordWithOcrTest {
 
         postWithBody(requestBody)
             .statusCode(OK.value())
-            .body(RESPONSE_FIELD_ERRORS, hasItem("Invalid case ID: " + invalidCaseId));
+            .body(RESPONSE_FIELD_ERRORS, hasItem("Could not find case: " + invalidCaseId));
     }
 
     @DisplayName("Should return with the correct error message when start event fails with case not found response")
@@ -221,7 +220,7 @@ class AttachExceptionRecordWithOcrTest {
 
         postWithBody(requestBody)
             .statusCode(OK.value())
-            .body(RESPONSE_FIELD_ERRORS, hasItem("No case found for case ID: " + caseReference));
+            .body(RESPONSE_FIELD_ERRORS, hasItem("Could not find case: " + caseReference));
     }
 
     @DisplayName("Should fail correctly if ccd is down")

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
@@ -28,7 +28,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.badRequestEntity;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
-import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
@@ -187,12 +186,11 @@ class AttachExceptionRecordWithOcrTest {
         postWithBody(requestBody).statusCode(INTERNAL_SERVER_ERROR.value());
     }
 
-    @DisplayName("Should return with the correct error message when start event fails for invalid case reference")
+    @DisplayName("Should return with the correct error message when service case reference is invalid")
     @Test
     void should_return_correct_error_for_the_invalid_case_id() throws Exception {
-        String invalidCaseId = "1234";
+        String invalidCaseId = "10a67";
         setUpCaseSearchByCcdId(okJson(mapper.writeValueAsString(exceptionRecord(null))));
-        setUpClientUpdate(getResponseBody("client-update-ok-no-warnings.json"));
 
         // request with invalid case reference
         byte[] requestBody = getRequestBodyWithAttachToCaseRef(
@@ -201,25 +199,23 @@ class AttachExceptionRecordWithOcrTest {
 
         postWithBody(requestBody)
             .statusCode(OK.value())
-            .body(RESPONSE_FIELD_ERRORS, hasItem("Could not find case: " + invalidCaseId));
+            .body(RESPONSE_FIELD_ERRORS, hasItem(String.format("Invalid case reference: '%s'", invalidCaseId)));
     }
 
-    @DisplayName("Should return with the correct error message when start event fails with case not found response")
+    @DisplayName("Should return with the correct error message when service case doesn't exist")
     @Test
     void should_return_correct_error_when_no_case_found_for_the_case_id() throws Exception {
-        String caseReference = "1234123412341234";
+        String targetCaseReference = "1234123412341234";
         setUpCaseSearchByCcdId(okJson(mapper.writeValueAsString(exceptionRecord(null))));
-        setUpClientUpdate(getResponseBody("client-update-ok-no-warnings.json"));
-        setUpCcdStartEvent(notFound(), caseReference);
 
         // request with case id which does not exist
         byte[] requestBody = getRequestBodyWithAttachToCaseRef(
-            "valid-supplementary-evidence-with-ocr.json", caseReference
+            "valid-supplementary-evidence-with-ocr.json", targetCaseReference
         );
 
         postWithBody(requestBody)
             .statusCode(OK.value())
-            .body(RESPONSE_FIELD_ERRORS, hasItem("Could not find case: " + caseReference));
+            .body(RESPONSE_FIELD_ERRORS, hasItem("Could not find case: " + targetCaseReference));
     }
 
     @DisplayName("Should fail correctly if ccd is down")

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
@@ -189,7 +189,7 @@ class AttachExceptionRecordWithOcrTest {
     @DisplayName("Should return with the correct error message when service case reference is invalid")
     @Test
     void should_return_correct_error_for_the_invalid_case_id() throws Exception {
-        String invalidCaseId = "10a67";
+        String invalidCaseId = "abc";
         setUpCaseSearchByCcdId(okJson(mapper.writeValueAsString(exceptionRecord(null))));
 
         // request with invalid case reference

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
 import static com.github.tomakehurst.wiremock.client.WireMock.badRequestEntity;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -447,6 +447,8 @@ public class AttachCaseCallbackService {
             callBackEvent.exceptionRecordId
         );
 
+        CaseDetails targetCase = ccdApi.getCase(targetCaseCcdRef, callBackEvent.exceptionRecordJurisdiction);
+
         ServiceConfigItem serviceConfigItem = getServiceConfig(exceptionRecordDetails);
         ProcessResult processResult = ccdCaseUpdater.updateCase(
             callBackEvent.exceptionRecord,
@@ -454,7 +456,8 @@ public class AttachCaseCallbackService {
             ignoreWarnings,
             callBackEvent.idamToken,
             callBackEvent.userId,
-            targetCaseCcdRef
+            targetCaseCcdRef,
+            targetCase.getCaseTypeId()
         );
 
         if (!processResult.getErrors().isEmpty() || !processResult.getWarnings().isEmpty()) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -63,7 +63,8 @@ public class CcdCaseUpdater {
         boolean ignoreWarnings,
         String idamToken,
         String userId,
-        String existingCaseId
+        String existingCaseId,
+        String existingCaseTypeId
     ) {
         log.info(
             "Start updating case for service {} with case Id {} from exception record {}",
@@ -80,7 +81,7 @@ public class CcdCaseUpdater {
                 s2sToken,
                 userId,
                 exceptionRecord.poBoxJurisdiction,
-                exceptionRecord.caseTypeId,
+                existingCaseTypeId,
                 existingCaseId,
                 EVENT_ID_ATTACH_SCANNED_DOCS_WITH_OCR
             );

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -261,7 +261,7 @@ class CcdCaseUpdaterTest {
             .willReturn(noWarningsUpdateResponse);
         initMockData();
         prepareMockForSubmissionEventForCaseWorker().willThrow(
-            new FeignException.BadRequest("Msg", mock(Request.class), "Body".getBytes())
+                new FeignException.BadRequest("Msg", mock(Request.class), "Body".getBytes())
         );
 
         // when
@@ -295,7 +295,7 @@ class CcdCaseUpdaterTest {
         initMockData();
         prepareMockForSubmissionEventForCaseWorker()
             .willThrow(
-                new FeignException.UnprocessableEntity("Msg", mock(Request.class), "Body".getBytes())
+                    new FeignException.UnprocessableEntity("Msg", mock(Request.class),  "Body".getBytes())
             );
 
         // when
@@ -363,15 +363,15 @@ class CcdCaseUpdaterTest {
 
         // when
         Throwable exception = catchThrowable(() ->
-            ccdCaseUpdater.updateCase(
-                exceptionRecord,
-                configItem,
-                true,
-                "idamToken",
-                "userId",
-                EXISTING_CASE_ID,
-                EXISTING_CASE_TYPE_ID
-            )
+                ccdCaseUpdater.updateCase(
+                    exceptionRecord,
+                    configItem,
+                    true,
+                    "idamToken",
+                    "userId",
+                    EXISTING_CASE_ID,
+                    EXISTING_CASE_TYPE_ID
+                )
         );
 
         // then
@@ -478,7 +478,7 @@ class CcdCaseUpdaterTest {
             anyString(),
             anyString()
         ))
-            .willThrow(new FeignException.MethodNotAllowed("Msg", mock(Request.class), "Body".getBytes()));
+            .willThrow(new FeignException.MethodNotAllowed("Msg", mock(Request.class),  "Body".getBytes()));
 
         // when
         CallbackException callbackException = catchThrowableOfType(() ->
@@ -548,7 +548,7 @@ class CcdCaseUpdaterTest {
             anyString()
         ))
             .willThrow(
-                new FeignException.NotFound("case not found", mock(Request.class), "Body".getBytes())
+                    new FeignException.NotFound("case not found",  mock(Request.class), "Body".getBytes())
             );
 
         // when
@@ -579,7 +579,7 @@ class CcdCaseUpdaterTest {
             anyString(),
             anyString()
         ))
-            .willThrow(new FeignException.BadRequest("invalid", mock(Request.class), "Body".getBytes()));
+            .willThrow(new FeignException.BadRequest("invalid", mock(Request.class),  "Body".getBytes()));
 
         // when
         ProcessResult res = ccdCaseUpdater.updateCase(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -55,6 +55,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.doma
 class CcdCaseUpdaterTest {
 
     private static final String EXISTING_CASE_ID = "existing_case_id";
+    private static final String EXISTING_CASE_TYPE_ID = "existing_case_type";
 
     private CcdCaseUpdater ccdCaseUpdater;
 
@@ -133,7 +134,8 @@ class CcdCaseUpdaterTest {
             true,
             "idamToken",
             "userId",
-            EXISTING_CASE_ID
+            EXISTING_CASE_ID,
+            EXISTING_CASE_TYPE_ID
         );
 
         // then
@@ -160,7 +162,8 @@ class CcdCaseUpdaterTest {
             true,
             "idamToken",
             "userId",
-            EXISTING_CASE_ID
+            EXISTING_CASE_ID,
+            EXISTING_CASE_TYPE_ID
         );
 
         // then
@@ -184,7 +187,8 @@ class CcdCaseUpdaterTest {
             false,
             "idamToken",
             "userId",
-            EXISTING_CASE_ID
+            EXISTING_CASE_ID,
+            EXISTING_CASE_TYPE_ID
         );
 
         // then
@@ -211,7 +215,8 @@ class CcdCaseUpdaterTest {
             false,
             "idamToken",
             "userId",
-            EXISTING_CASE_ID
+            EXISTING_CASE_ID,
+            EXISTING_CASE_TYPE_ID
         );
 
         // then
@@ -237,7 +242,8 @@ class CcdCaseUpdaterTest {
             true,
             "idamToken",
             "userId",
-            EXISTING_CASE_ID
+            EXISTING_CASE_ID,
+            EXISTING_CASE_TYPE_ID
         );
 
         // then
@@ -255,7 +261,7 @@ class CcdCaseUpdaterTest {
             .willReturn(noWarningsUpdateResponse);
         initMockData();
         prepareMockForSubmissionEventForCaseWorker().willThrow(
-                new FeignException.BadRequest("Msg", mock(Request.class), "Body".getBytes())
+            new FeignException.BadRequest("Msg", mock(Request.class), "Body".getBytes())
         );
 
         // when
@@ -266,7 +272,8 @@ class CcdCaseUpdaterTest {
                     true,
                     "idamToken",
                     "userId",
-                    EXISTING_CASE_ID
+                    EXISTING_CASE_ID,
+                    EXISTING_CASE_TYPE_ID
                 ),
             CallbackException.class
         );
@@ -288,7 +295,7 @@ class CcdCaseUpdaterTest {
         initMockData();
         prepareMockForSubmissionEventForCaseWorker()
             .willThrow(
-                    new FeignException.UnprocessableEntity("Msg", mock(Request.class),  "Body".getBytes())
+                new FeignException.UnprocessableEntity("Msg", mock(Request.class), "Body".getBytes())
             );
 
         // when
@@ -298,7 +305,8 @@ class CcdCaseUpdaterTest {
             true,
             "idamToken",
             "userId",
-            EXISTING_CASE_ID
+            EXISTING_CASE_ID,
+            EXISTING_CASE_TYPE_ID
         );
 
         // then
@@ -320,14 +328,15 @@ class CcdCaseUpdaterTest {
 
         // when
         CallbackException exception = catchThrowableOfType(() ->
-            ccdCaseUpdater.updateCase(
-                exceptionRecord,
-                configItem,
-                true,
-                "idamToken",
-                "userId",
-                EXISTING_CASE_ID
-            ),
+                ccdCaseUpdater.updateCase(
+                    exceptionRecord,
+                    configItem,
+                    true,
+                    "idamToken",
+                    "userId",
+                    EXISTING_CASE_ID,
+                    EXISTING_CASE_TYPE_ID
+                ),
             CallbackException.class
         );
 
@@ -354,14 +363,15 @@ class CcdCaseUpdaterTest {
 
         // when
         Throwable exception = catchThrowable(() ->
-                ccdCaseUpdater.updateCase(
-                    exceptionRecord,
-                    configItem,
-                    true,
-                    "idamToken",
-                    "userId",
-                    EXISTING_CASE_ID
-                )
+            ccdCaseUpdater.updateCase(
+                exceptionRecord,
+                configItem,
+                true,
+                "idamToken",
+                "userId",
+                EXISTING_CASE_ID,
+                EXISTING_CASE_TYPE_ID
+            )
         );
 
         // then
@@ -399,7 +409,8 @@ class CcdCaseUpdaterTest {
                     true,
                     "idamToken",
                     "userId",
-                    EXISTING_CASE_ID
+                    EXISTING_CASE_ID,
+                    EXISTING_CASE_TYPE_ID
                 ),
             CallbackException.class
         );
@@ -446,7 +457,8 @@ class CcdCaseUpdaterTest {
             true,
             "idamToken",
             "userId",
-            EXISTING_CASE_ID
+            EXISTING_CASE_ID,
+            EXISTING_CASE_TYPE_ID
         );
 
         // then
@@ -466,7 +478,7 @@ class CcdCaseUpdaterTest {
             anyString(),
             anyString()
         ))
-            .willThrow(new FeignException.MethodNotAllowed("Msg", mock(Request.class),  "Body".getBytes()));
+            .willThrow(new FeignException.MethodNotAllowed("Msg", mock(Request.class), "Body".getBytes()));
 
         // when
         CallbackException callbackException = catchThrowableOfType(() ->
@@ -476,7 +488,8 @@ class CcdCaseUpdaterTest {
                     true,
                     "idamToken",
                     "userId",
-                    EXISTING_CASE_ID
+                    EXISTING_CASE_ID,
+                    EXISTING_CASE_TYPE_ID
                 ),
             CallbackException.class
         );
@@ -510,7 +523,8 @@ class CcdCaseUpdaterTest {
                     true,
                     "idamToken",
                     "userId",
-                    EXISTING_CASE_ID
+                    EXISTING_CASE_ID,
+                    EXISTING_CASE_TYPE_ID
                 ),
             CallbackException.class
         );
@@ -534,7 +548,7 @@ class CcdCaseUpdaterTest {
             anyString()
         ))
             .willThrow(
-                    new FeignException.NotFound("case not found",  mock(Request.class), "Body".getBytes())
+                new FeignException.NotFound("case not found", mock(Request.class), "Body".getBytes())
             );
 
         // when
@@ -544,7 +558,8 @@ class CcdCaseUpdaterTest {
             true,
             "idamToken",
             "userId",
-            "1234123412341234"
+            "1234123412341234",
+            EXISTING_CASE_TYPE_ID
         );
 
         // then
@@ -564,7 +579,7 @@ class CcdCaseUpdaterTest {
             anyString(),
             anyString()
         ))
-            .willThrow(new FeignException.BadRequest("invalid", mock(Request.class),  "Body".getBytes()));
+            .willThrow(new FeignException.BadRequest("invalid", mock(Request.class), "Body".getBytes()));
 
         // when
         ProcessResult res = ccdCaseUpdater.updateCase(
@@ -573,7 +588,8 @@ class CcdCaseUpdaterTest {
             true,
             "idamToken",
             "userId",
-            "1234"
+            "1234",
+            EXISTING_CASE_TYPE_ID
         );
 
         // then


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1180


### Change description ###
Retrieve the service case before starting the "attachScannedDocsWithOcr" event so that the service case type id can be fetched and used in the startEvent call.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
