### PR TITLE
add userdetail cache

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClient.java
@@ -57,6 +57,10 @@ public class IdamCachedClient {
         accessTokenCache.invalidate(jurisdiction);
     }
 
+    public void cleanUpAccessTokenCache() {
+        accessTokenCache.cleanUp();
+    }
+
     private CachedIdamToken retrieveToken(String jurisdiction) {
         log.info("Retrieve access token for jurisdiction: {} from IDAM", jurisdiction);
         Credential user = users.getUser(jurisdiction);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClient.java
@@ -5,11 +5,13 @@ import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.Credential;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.JurisdictionToUserMapping;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
 @Service
 public class IdamCachedClient {
@@ -18,6 +20,7 @@ public class IdamCachedClient {
     public static final String EXPIRES_IN = "expires_in";
 
     private static Cache<String, CachedIdamToken> accessTokenCache;
+    private static Cache<String, UserDetails> userDetailsCache;
 
     private final IdamClient idamClient;
     private final JurisdictionToUserMapping users;
@@ -31,6 +34,11 @@ public class IdamCachedClient {
         this.users = users;
         this.accessTokenCache = Caffeine.newBuilder()
             .expireAfter(accessTokenCacheExpiry)
+            .removalListener(this::onCachedIdamTokenRemoval)
+            .build();
+
+        this.userDetailsCache =  Caffeine.newBuilder()
+            .maximumSize(200)
             .build();
     }
 
@@ -68,6 +76,22 @@ public class IdamCachedClient {
         }
 
         return expires.asLong();
+    }
+
+    private void onCachedIdamTokenRemoval(
+        String jurisdiction,
+        CachedIdamToken cachedIdamToken,
+        RemovalCause cause
+    ) {
+        userDetailsCache.invalidate(cachedIdamToken.accessToken);
+    }
+
+    public UserDetails getUserDetails(String accessToken) {
+        return this.userDetailsCache.get(accessToken, this::retrieveUserDetails);
+    }
+
+    private UserDetails retrieveUserDetails(String accessToken) {
+        return idamClient.getUserDetails(accessToken);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClient.java
@@ -58,7 +58,7 @@ public class IdamCachedClient {
     }
 
     private CachedIdamToken retrieveToken(String jurisdiction) {
-        log.info("Retrieve access token for jurisdiction: {} ", jurisdiction);
+        log.info("Retrieve access token for jurisdiction: {} from IDAM", jurisdiction);
         Credential user = users.getUser(jurisdiction);
         String tokenWithBearer = idamClient.authenticateUser(
             user.getUsername(),
@@ -102,7 +102,7 @@ public class IdamCachedClient {
     }
 
     private UserDetails retrieveUserDetails(String accessToken) {
-        log.info("Retrieve user details");
+        log.info("Retrieve user details from IDAM");
         return idamClient.getUserDetails(accessToken);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClientTest.java
@@ -241,20 +241,19 @@ class IdamCachedClientTest {
         given(idamClient.authenticateUser(USERNAME, PASSWORD)).willReturn(JWT, JWT2);
 
         UserDetails expectedUserDetails1 =  new UserDetails("12","q@a.com","","",null);
+        UserDetails expectedUserDetails2 = USER_DETAILS;
 
-        given(idamClient.getUserDetails(JWT)).willReturn(expectedUserDetails1, USER_DETAILS);
+        given(idamClient.getUserDetails(JWT)).willReturn(expectedUserDetails1, expectedUserDetails2);
 
-        String token1 =
-            idamCachedClient.getAccessToken(jurisdiction1);
-        UserDetails userDetails = idamCachedClient
-            .getUserDetails(token1);
+        String token1 = idamCachedClient.getAccessToken(jurisdiction1);
+        UserDetails userDetailsBefore = idamCachedClient.getUserDetails(token1);
 
         idamCachedClient.removeAccessTokenFromCache(jurisdiction1);
 
-        assertThat(userDetails).isEqualTo(expectedUserDetails1);
+        assertThat(userDetailsBefore).isEqualTo(expectedUserDetails1);
 
-        UserDetails userDetails2 = idamCachedClient.getUserDetails(token1);
-        assertThat(userDetails2).usingRecursiveComparison().isEqualTo(USER_DETAILS);
+        UserDetails userDetailsBeforeInvalidating = idamCachedClient.getUserDetails(token1);
+        assertThat(userDetailsBeforeInvalidating).usingRecursiveComparison().isEqualTo(expectedUserDetails2);
         verify(idamClient, times(2)).getUserDetails(any());
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClientTest.java
@@ -210,21 +210,17 @@ class IdamCachedClientTest {
 
     @Test
     public void should_get_userDetail_when_no_error() {
-
         given(idamClient.getUserDetails(JWT)).willReturn(USER_DETAILS);
 
         UserDetails userDetails1 =
             idamCachedClient.getUserDetails(JWT);
 
         assertThat(userDetails1).usingRecursiveComparison().isEqualTo(USER_DETAILS);
-
         verify(idamClient).getUserDetails(any());
-
     }
 
     @Test
     public void should_retrieve_userDetail_from_cache_when_value_in_cache() {
-
         given(idamClient.getUserDetails(JWT)).willReturn(USER_DETAILS);
 
         UserDetails userDetails1 =
@@ -234,14 +230,11 @@ class IdamCachedClientTest {
 
         assertThat(userDetails1).usingRecursiveComparison().isEqualTo(USER_DETAILS);
         assertThat(userDetails2).usingRecursiveComparison().isEqualTo(userDetails1);
-
         verify(idamClient).getUserDetails(any());
-
     }
 
     @Test
     public void should_invalidate_userDetail_when_cached_token_removed_from_cache() {
-
         String jurisdiction1 = "divorce";
 
         given(users.getUser(jurisdiction1)).willReturn(new Credential(USERNAME, PASSWORD));

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClientTest.java
@@ -9,7 +9,9 @@ import uk.gov.hmcts.reform.authorisation.exceptions.InvalidTokenException;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.Credential;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.JurisdictionToUserMapping;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +52,14 @@ class IdamCachedClientTest {
     private static final String USERNAME = "userxxx";
 
     private static final String PASSWORD = "passs123";
+
+    private static final UserDetails USER_DETAILS = new UserDetails(
+        "12",
+        "q@a.com",
+        "name_x",
+        "surname_y",
+        Arrays.asList("role1, role2", "role3")
+    );
 
     @BeforeEach
     private void setUp() {
@@ -195,5 +205,64 @@ class IdamCachedClientTest {
         assertThat(token1).isNotEqualTo(token2);
         verify(users, times(2)).getUser(any());
         verify(idamClient, times(2)).authenticateUser(any(), any());
+    }
+
+
+    @Test
+    public void should_get_userDetail_when_no_error() {
+
+        given(idamClient.getUserDetails(JWT)).willReturn(USER_DETAILS);
+
+        UserDetails userDetails1 =
+            idamCachedClient.getUserDetails(JWT);
+
+        assertThat(userDetails1).usingRecursiveComparison().isEqualTo(USER_DETAILS);
+
+        verify(idamClient).getUserDetails(any());
+
+    }
+
+    @Test
+    public void should_retrieve_userDetail_from_cache_when_value_in_cache() {
+
+        given(idamClient.getUserDetails(JWT)).willReturn(USER_DETAILS);
+
+        UserDetails userDetails1 =
+            idamCachedClient.getUserDetails(JWT);
+        UserDetails userDetails2 =
+            idamCachedClient.getUserDetails(JWT);
+
+        assertThat(userDetails1).usingRecursiveComparison().isEqualTo(USER_DETAILS);
+        assertThat(userDetails2).usingRecursiveComparison().isEqualTo(userDetails1);
+
+        verify(idamClient).getUserDetails(any());
+
+    }
+
+    @Test
+    public void should_invalidate_userDetail_when_cached_token_removed_from_cache() {
+
+        String jurisdiction1 = "divorce";
+
+        given(users.getUser(jurisdiction1)).willReturn(new Credential(USERNAME, PASSWORD));
+        given(idamClient.authenticateUser(USERNAME, PASSWORD)).willReturn(JWT, JWT2);
+
+        UserDetails expectedUserDetails1 =  new UserDetails("12","q@a.com","","",null);
+
+        given(idamClient.getUserDetails(JWT)).willReturn(expectedUserDetails1, USER_DETAILS);
+
+        String token1 =
+            idamCachedClient.getAccessToken(jurisdiction1);
+        UserDetails userDetails = idamCachedClient
+            .getUserDetails(token1);
+
+        idamCachedClient.removeAccessTokenFromCache(jurisdiction1);
+
+        assertThat(userDetails).isEqualTo(expectedUserDetails1);
+
+        UserDetails userDetails2 = idamCachedClient.getUserDetails(token1);
+        assertThat(userDetails2).usingRecursiveComparison().isEqualTo(USER_DETAILS);
+        verify(idamClient, times(2)).getUserDetails(any());
+
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClientTest.java
@@ -247,13 +247,13 @@ class IdamCachedClientTest {
 
         String token1 = idamCachedClient.getAccessToken(jurisdiction1);
         UserDetails userDetailsBefore = idamCachedClient.getUserDetails(token1);
-
-        idamCachedClient.removeAccessTokenFromCache(jurisdiction1);
-
         assertThat(userDetailsBefore).isEqualTo(expectedUserDetails1);
 
-        UserDetails userDetailsBeforeInvalidating = idamCachedClient.getUserDetails(token1);
-        assertThat(userDetailsBeforeInvalidating).usingRecursiveComparison().isEqualTo(expectedUserDetails2);
+        idamCachedClient.removeAccessTokenFromCache(jurisdiction1);
+        idamCachedClient.cleanUpAccessTokenCache();
+
+        UserDetails userDetailsAfterInvalidating = idamCachedClient.getUserDetails(token1);
+        assertThat(userDetailsAfterInvalidating).usingRecursiveComparison().isEqualTo(expectedUserDetails2);
         verify(idamClient, times(2)).getUserDetails(any());
 
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1122

### Change description ###

Part 3: add userdetails cache
to remove a user detail from cache whenever token invalidated or expired removalListener used.
maxsize of userdetails 200 hardcoded next pr I will make it configurable.
caffeine manage the eviction if  max size set:
 * As the cache size grows close to the maximum, the cache evicts entries that are less likely to
   * be used again. For example, the cache may evict an entry because it hasn't been used recently
   * or very often.
but in our case it should not happen as it should remove from user cache whenever token removed from cache.


Part2 last pr: https://github.com/hmcts/bulk-scan-orchestrator/pull/942


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
