### PR TITLE
use cache write instead of removal listener

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClient.java
@@ -4,8 +4,10 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.CacheWriter;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -37,10 +39,30 @@ public class IdamCachedClient {
         this.users = users;
         this.accessTokenCache = Caffeine.newBuilder()
             .expireAfter(accessTokenCacheExpiry)
-            .removalListener(this::onCachedIdamTokenRemoval)
+            .writer(new CacheWriter<String, CachedIdamToken>() {
+                @Override
+                public void write(@NonNull String key, @NonNull CachedIdamToken value) {
+                    throw new UnsupportedOperationException("Cache put() or replace() not supported.");
+                }
+
+                @Override
+                public void delete(
+                    @NonNull String jurisdiction,
+                    @NonNull CachedIdamToken cachedIdamToken,
+                    @NonNull RemovalCause cause
+                ) {
+                    log.info(
+                        "Invalidate user details,"
+                            + "Access token deleted for jurisdiction: {}, cause: {} ",
+                        jurisdiction,
+                        cause
+                    );
+                    userDetailsCache.invalidate(cachedIdamToken.accessToken);
+                }
+            })
             .build();
 
-        this.userDetailsCache =  Caffeine.newBuilder()
+        this.userDetailsCache = Caffeine.newBuilder()
             .maximumSize(200)
             .build();
     }
@@ -55,10 +77,6 @@ public class IdamCachedClient {
     public void removeAccessTokenFromCache(String jurisdiction) {
         log.info("Remove access token from cache for jurisdiction: {} ", jurisdiction);
         accessTokenCache.invalidate(jurisdiction);
-    }
-
-    public void cleanUpAccessTokenCache() {
-        accessTokenCache.cleanUp();
     }
 
     private CachedIdamToken retrieveToken(String jurisdiction) {
@@ -86,18 +104,6 @@ public class IdamCachedClient {
         }
 
         return expires.asLong();
-    }
-
-    private void onCachedIdamTokenRemoval(
-        String jurisdiction,
-        CachedIdamToken cachedIdamToken,
-        RemovalCause cause
-    ) {
-        log.info("On access token removal invalidate user details. "
-                + "Access token removed for jurisdiction: {}, cause: {} ",
-            jurisdiction,
-            cause);
-        userDetailsCache.invalidate(cachedIdamToken.accessToken);
     }
 
     public UserDetails getUserDetails(String accessToken) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClient.java
@@ -51,9 +51,7 @@ public class IdamCachedClient {
                     @NonNull CachedIdamToken cachedIdamToken,
                     @NonNull RemovalCause cause
                 ) {
-                    log.info(
-                        "Invalidate user details,"
-                            + "Access token deleted for jurisdiction: {}, cause: {} ",
+                    log.info("Access token deleted for jurisdiction: {}, cause: {}, Invalidate user details.",
                         jurisdiction,
                         cause
                     );

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClientTest.java
@@ -250,7 +250,6 @@ class IdamCachedClientTest {
         assertThat(userDetailsBefore).isEqualTo(expectedUserDetails1);
 
         idamCachedClient.removeAccessTokenFromCache(jurisdiction1);
-        idamCachedClient.cleanUpAccessTokenCache();
 
         UserDetails userDetailsAfterInvalidating = idamCachedClient.getUserDetails(token1);
         assertThat(userDetailsAfterInvalidating).usingRecursiveComparison().isEqualTo(expectedUserDetails2);


### PR DESCRIPTION


### JIRA link (if applicable) ###



### Change description ###

sometimes invalidate test  is failing as removal listener is working asynchronously.
replace listener with cachewriter which is synchronously runs on removal.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
