### PR TITLE
Add validator for attaching scanned docs to target case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/AttachScannedDocumentsValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/AttachScannedDocumentsValidator.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static java.util.stream.Collectors.toSet;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -106,13 +106,13 @@ public final class AttachScannedDocumentsValidator {
     }
 
     private static Set<String> findDocumentsIntersection(
-        Function<Map<String, Object>, Boolean> filterOnTargetCaseDocuments,
+        Predicate<Map<String, Object>> filterOnTargetCaseDocuments,
         List<Map<String, Object>> exceptionRecordDocuments,
         List<Map<String, Object>> targetCaseDocuments
     ) {
         Set<String> dcnsOfCaseDocumentsFromOtherSources = targetCaseDocuments
             .stream()
-            .filter(filterOnTargetCaseDocuments::apply)
+            .filter(filterOnTargetCaseDocuments)
             .map(Documents::getDocumentId)
             .collect(toSet());
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/AttachScannedDocumentsValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/AttachScannedDocumentsValidator.java
@@ -1,0 +1,126 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback;
+
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.DuplicateDocsException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toSet;
+import static org.slf4j.LoggerFactory.getLogger;
+
+public final class AttachScannedDocumentsValidator {
+
+    private static final Logger log = getLogger(AttachScannedDocumentsValidator.class);
+
+    private AttachScannedDocumentsValidator() {
+        // utility class constructor
+    }
+
+    public static void verifyExceptionRecordAddsNoDuplicates(
+        List<Map<String, Object>> targetCaseDocuments,
+        List<Map<String, Object>> exceptionRecordDocuments,
+        String exceptionRecordCcdRef,
+        String targetCaseCcdRef
+    ) {
+        logIfDocumentsAreAlreadyAttachedToCaseFromER(
+            targetCaseDocuments,
+            exceptionRecordDocuments,
+            exceptionRecordCcdRef,
+            targetCaseCcdRef
+        );
+
+        Set<String> clashingDocumentDcns = getDcnsOfClashingDocuments(
+            exceptionRecordCcdRef,
+            exceptionRecordDocuments,
+            targetCaseDocuments
+        );
+
+        if (!clashingDocumentDcns.isEmpty()) {
+            // avoiding 120 line length rule
+            String message = String.format(
+                "Documents with following control numbers are already present in the case %s and cannot be added: %s",
+                targetCaseCcdRef,
+                String.join(", ", clashingDocumentDcns)
+            );
+
+            throw new DuplicateDocsException(message);
+        }
+    }
+
+    private static void logIfDocumentsAreAlreadyAttachedToCaseFromER(
+        List<Map<String, Object>> targetCaseDocuments,
+        List<Map<String, Object>> exceptionRecordDocuments,
+        String exceptionRecordCcdRef,
+        String targetCaseCcdRef
+    ) {
+        Set<String> alreadyAttachedDocumentDcns = getDcnsOfDocumentsAlreadyAttachedToCaseFromER(
+            exceptionRecordCcdRef,
+            exceptionRecordDocuments,
+            targetCaseDocuments
+        );
+
+        if (alreadyAttachedDocumentDcns.size() == exceptionRecordDocuments.size()) {
+            log.warn(
+                "All documents from exception record {} have already been attached to case {}",
+                exceptionRecordCcdRef,
+                targetCaseCcdRef
+            );
+        } else if (!alreadyAttachedDocumentDcns.isEmpty()) {
+            log.warn(
+                "Following documents have already been added from exception record {} to case {}: {}",
+                exceptionRecordCcdRef,
+                targetCaseCcdRef,
+                alreadyAttachedDocumentDcns
+            );
+        }
+    }
+
+    private static Set<String> getDcnsOfDocumentsAlreadyAttachedToCaseFromER(
+        String exceptionRecordId,
+        List<Map<String, Object>> exceptionRecordDocuments,
+        List<Map<String, Object>> targetCaseDocuments
+    ) {
+        return findDocumentsIntersection(
+            doc -> Objects.equals(Documents.getExceptionRecordReference(doc), exceptionRecordId),
+            exceptionRecordDocuments,
+            targetCaseDocuments
+        );
+    }
+
+    private static Set<String> getDcnsOfClashingDocuments(
+        String exceptionRecordId,
+        List<Map<String, Object>> exceptionRecordDocuments,
+        List<Map<String, Object>> targetCaseDocuments
+    ) {
+        return findDocumentsIntersection(
+            doc -> !Objects.equals(Documents.getExceptionRecordReference(doc), exceptionRecordId),
+            exceptionRecordDocuments,
+            targetCaseDocuments
+        );
+    }
+
+    private static Set<String> findDocumentsIntersection(
+        Function<Map<String, Object>, Boolean> filterOnTargetCaseDocuments,
+        List<Map<String, Object>> exceptionRecordDocuments,
+        List<Map<String, Object>> targetCaseDocuments
+    ) {
+        Set<String> dcnsOfCaseDocumentsFromOtherSources = targetCaseDocuments
+            .stream()
+            .filter(filterOnTargetCaseDocuments::apply)
+            .map(Documents::getDocumentId)
+            .collect(toSet());
+
+        Set<String> dcnsOfExceptionRecordDocuments = exceptionRecordDocuments
+            .stream()
+            .map(Documents::getDocumentId)
+            .collect(toSet());
+
+        return Sets.intersection(dcnsOfCaseDocumentsFromOtherSources, dcnsOfExceptionRecordDocuments);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/AttachScannedDocumentsValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/AttachScannedDocumentsValidator.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback;
 
 import com.google.common.collect.Sets;
 import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.DuplicateDocsException;
 
@@ -14,15 +15,16 @@ import java.util.function.Predicate;
 import static java.util.stream.Collectors.toSet;
 import static org.slf4j.LoggerFactory.getLogger;
 
-public final class AttachScannedDocumentsValidator {
+@Component
+public class AttachScannedDocumentsValidator {
 
     private static final Logger log = getLogger(AttachScannedDocumentsValidator.class);
 
-    private AttachScannedDocumentsValidator() {
-        // utility class constructor
+    public AttachScannedDocumentsValidator() {
+        // empty construct
     }
 
-    public static void verifyExceptionRecordAddsNoDuplicates(
+    public void verifyExceptionRecordAddsNoDuplicates(
         List<Map<String, Object>> targetCaseDocuments,
         List<Map<String, Object>> exceptionRecordDocuments,
         String exceptionRecordCcdRef,
@@ -53,7 +55,7 @@ public final class AttachScannedDocumentsValidator {
         }
     }
 
-    private static void logIfDocumentsAreAlreadyAttachedToCaseFromER(
+    private void logIfDocumentsAreAlreadyAttachedToCaseFromER(
         List<Map<String, Object>> targetCaseDocuments,
         List<Map<String, Object>> exceptionRecordDocuments,
         String exceptionRecordCcdRef,
@@ -81,7 +83,7 @@ public final class AttachScannedDocumentsValidator {
         }
     }
 
-    private static Set<String> getDcnsOfDocumentsAlreadyAttachedToCaseFromER(
+    private Set<String> getDcnsOfDocumentsAlreadyAttachedToCaseFromER(
         String exceptionRecordId,
         List<Map<String, Object>> exceptionRecordDocuments,
         List<Map<String, Object>> targetCaseDocuments
@@ -93,7 +95,7 @@ public final class AttachScannedDocumentsValidator {
         );
     }
 
-    private static Set<String> getDcnsOfClashingDocuments(
+    private Set<String> getDcnsOfClashingDocuments(
         String exceptionRecordId,
         List<Map<String, Object>> exceptionRecordDocuments,
         List<Map<String, Object>> targetCaseDocuments
@@ -105,7 +107,7 @@ public final class AttachScannedDocumentsValidator {
         );
     }
 
-    private static Set<String> findDocumentsIntersection(
+    private Set<String> findDocumentsIntersection(
         Predicate<Map<String, Object>> filterOnTargetCaseDocuments,
         List<Map<String, Object>> exceptionRecordDocuments,
         List<Map<String, Object>> targetCaseDocuments

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/AttachScannedDocumentsValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/AttachScannedDocumentsValidatorTest.java
@@ -10,9 +10,10 @@ import java.util.Map;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.AttachScannedDocumentsValidator.verifyExceptionRecordAddsNoDuplicates;
 
 class AttachScannedDocumentsValidatorTest {
+
+    private static final AttachScannedDocumentsValidator VALIDATOR = new AttachScannedDocumentsValidator();
 
     @Test
     void should_do_nothing_when_all_documents_are_already_attached() {
@@ -29,7 +30,7 @@ class AttachScannedDocumentsValidatorTest {
         );
 
         // when, then
-        assertThatCode(() -> verifyExceptionRecordAddsNoDuplicates(
+        assertThatCode(() -> VALIDATOR.verifyExceptionRecordAddsNoDuplicates(
             targetCaseDocuments,
             exceptionRecordDocuments,
             exceptionRecordReference,
@@ -48,7 +49,7 @@ class AttachScannedDocumentsValidatorTest {
         );
 
         // when, then
-        assertThatCode(() -> verifyExceptionRecordAddsNoDuplicates(
+        assertThatCode(() -> VALIDATOR.verifyExceptionRecordAddsNoDuplicates(
             targetCaseDocuments,
             exceptionRecordDocuments,
             "exception-ref",
@@ -67,7 +68,7 @@ class AttachScannedDocumentsValidatorTest {
         );
 
         // when, then
-        assertThatCode(() -> verifyExceptionRecordAddsNoDuplicates(
+        assertThatCode(() -> VALIDATOR.verifyExceptionRecordAddsNoDuplicates(
             targetCaseDocuments,
             exceptionRecordDocuments,
             "exception-ref",

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/AttachScannedDocumentsValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/AttachScannedDocumentsValidatorTest.java
@@ -1,0 +1,77 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.DuplicateDocsException;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.AttachScannedDocumentsValidator.verifyExceptionRecordAddsNoDuplicates;
+
+class AttachScannedDocumentsValidatorTest {
+
+    @Test
+    void should_do_nothing_when_all_documents_are_already_attached() {
+        // given
+        String exceptionRecordReference = "REF";
+        List<Map<String, Object>> exceptionRecordDocuments = singletonList(
+            singletonMap("value", singletonMap("controlNumber", "e-123"))
+        );
+        List<Map<String, Object>> targetCaseDocuments = singletonList(
+            singletonMap("value", ImmutableMap.of(
+                "controlNumber", "e-123",
+                "exceptionRecordReference", exceptionRecordReference
+            ))
+        );
+
+        // when, then
+        assertThatCode(() -> verifyExceptionRecordAddsNoDuplicates(
+            targetCaseDocuments,
+            exceptionRecordDocuments,
+            exceptionRecordReference,
+            "target-ref"
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_do_nothing_when_no_documents_are_attached() {
+        // given
+        List<Map<String, Object>> exceptionRecordDocuments = singletonList(
+            singletonMap("value", singletonMap("controlNumber", "e-123"))
+        );
+        List<Map<String, Object>> targetCaseDocuments = singletonList(
+            singletonMap("value", singletonMap("controlNumber", "c-123"))
+        );
+
+        // when, then
+        assertThatCode(() -> verifyExceptionRecordAddsNoDuplicates(
+            targetCaseDocuments,
+            exceptionRecordDocuments,
+            "exception-ref",
+            "target-ref"
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_throw_exception_when_document_is_already_present_in_target_case() {
+        // given
+        List<Map<String, Object>> exceptionRecordDocuments = singletonList(
+            singletonMap("value", singletonMap("controlNumber", "e-123"))
+        );
+        List<Map<String, Object>> targetCaseDocuments = singletonList(
+            singletonMap("value", singletonMap("controlNumber", "e-123"))
+        );
+
+        // when, then
+        assertThatCode(() -> verifyExceptionRecordAddsNoDuplicates(
+            targetCaseDocuments,
+            exceptionRecordDocuments,
+            "exception-ref",
+            "target-ref"
+        )).isInstanceOf(DuplicateDocsException.class);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Handle missing and duplicate documents for attaching exception record with supplementary evidence](https://tools.hmcts.net/jira/browse/BPS-1095)

### Change description ###

More detailed validation for scanned documents. Only throw exception when documents are truly attached without expected exception record reference. Otherwise - all good

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
