### PR TITLE
Add new method for retrieving docs to attach

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/Documents.java
@@ -9,12 +9,14 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.validation.constraints.NotNull;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 public final class Documents {
@@ -40,6 +42,23 @@ public final class Documents {
                 existingCaseDocumentIds
             )
         );
+    }
+
+    static List<Map<String, Object>> removeAlreadyAttachedDocuments(
+        List<Map<String, Object>> exceptionRecordDocuments,
+        List<Map<String, Object>> targetCaseDocuments,
+        String exceptionRecordCcdRef
+    ) {
+        Set<String> dcnsOfCaseDocumentsFromThisExceptionRecord = targetCaseDocuments
+            .stream()
+            .filter(doc -> Objects.equals(getExceptionRecordReference(doc), exceptionRecordCcdRef))
+            .map(Documents::getDocumentId)
+            .collect(toSet());
+
+        return exceptionRecordDocuments
+            .stream()
+            .filter(doc -> !dcnsOfCaseDocumentsFromThisExceptionRecord.contains(getDocumentId(doc)))
+            .collect(toList());
     }
 
     @NotNull

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
@@ -31,7 +31,7 @@ class DocumentsTest {
     private static final String DOCUMENT_NUMBER = "id";
 
     @Test
-    void should_remove_all_documents_from_exception_record_because_all_of_them_are_already_in_target_case() {
+    void should_remove_all_documents_from_exception_record_when_all_of_them_are_already_in_target_case() {
         // given
         String exceptionRecordReference = "REF";
         List<Map<String, Object>> exceptionRecordDocuments = singletonList(
@@ -56,7 +56,7 @@ class DocumentsTest {
     }
 
     @Test
-    void should_remove_overlapping_documents_from_exception_record_because_they_are_already_in_target_case() {
+    void should_remove_overlapping_documents_from_exception_record_when_they_are_already_in_target_case() {
         // given
         String exceptionRecordReference = "REF";
         List<Map<String, Object>> exceptionRecordDocuments = ImmutableList.of(
@@ -94,7 +94,7 @@ class DocumentsTest {
     }
 
     @Test
-    void should_leave_all_documents_in_exception_record_because_there_is_nothing_matching_in_target_case() {
+    void should_leave_all_documents_in_exception_record_when_there_is_nothing_matching_in_target_case() {
         // given
         List<Map<String, Object>> exceptionRecordDocuments = ImmutableList.of(
             singletonMap("value", singletonMap("controlNumber", "e-123")),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/DocumentsTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.DisplayName;
@@ -18,13 +19,104 @@ import javax.validation.constraints.NotNull;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.getScannedDocuments;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.removeAlreadyAttachedDocuments;
 
 class DocumentsTest {
     private static final String SCANNED_DOCUMENTS = "scannedDocuments";
     private static final String DOCUMENT_NUMBER = "id";
+
+    @Test
+    void should_remove_all_documents_from_exception_record_because_all_of_them_are_already_in_target_case() {
+        // given
+        String exceptionRecordReference = "REF";
+        List<Map<String, Object>> exceptionRecordDocuments = singletonList(
+            singletonMap("value", singletonMap("controlNumber", "e-123"))
+        );
+        List<Map<String, Object>> targetCaseDocuments = singletonList(
+            singletonMap("value", ImmutableMap.of(
+                "controlNumber", "e-123",
+                "exceptionRecordReference", exceptionRecordReference
+            ))
+        );
+
+        // when
+        List<Map<String, Object>> actualDocumentsToAttach = removeAlreadyAttachedDocuments(
+            exceptionRecordDocuments,
+            targetCaseDocuments,
+            exceptionRecordReference
+        );
+
+        // then
+        assertThat(actualDocumentsToAttach).asList().isEmpty();
+    }
+
+    @Test
+    void should_remove_overlapping_documents_from_exception_record_because_they_are_already_in_target_case() {
+        // given
+        String exceptionRecordReference = "REF";
+        List<Map<String, Object>> exceptionRecordDocuments = ImmutableList.of(
+            singletonMap("value", singletonMap("controlNumber", "e-123")),
+            singletonMap("value", singletonMap("controlNumber", "e-321"))
+        );
+        List<Map<String, Object>> targetCaseDocuments = singletonList(
+            singletonMap("value", ImmutableMap.of(
+                "controlNumber", "e-123",
+                "exceptionRecordReference", exceptionRecordReference
+            ))
+        );
+
+        // when
+        List<Map<String, Object>> actualDocumentsToAttach = removeAlreadyAttachedDocuments(
+            exceptionRecordDocuments,
+            targetCaseDocuments,
+            exceptionRecordReference
+        );
+
+        // then
+        assertThat(actualDocumentsToAttach)
+            .asList()
+            .hasSize(1)
+            .first()
+            .isInstanceOfSatisfying(actualDocumentsToAttach.get(0).getClass(), document ->
+                assertThat(document)
+                    .hasFieldOrProperty("value")
+                    .extracting("value")
+                    .isInstanceOfSatisfying(document.getClass(), actualDocument ->
+                        assertThat(actualDocument)
+                            .hasFieldOrPropertyWithValue("controlNumber", "e-321")
+                    )
+            );
+    }
+
+    @Test
+    void should_leave_all_documents_in_exception_record_because_there_is_nothing_matching_in_target_case() {
+        // given
+        List<Map<String, Object>> exceptionRecordDocuments = ImmutableList.of(
+            singletonMap("value", singletonMap("controlNumber", "e-123")),
+            singletonMap("value", singletonMap("controlNumber", "e-321"))
+        );
+        List<Map<String, Object>> targetCaseDocuments = singletonList(
+            singletonMap("value", ImmutableMap.of(
+                "controlNumber", "e-123",
+                "exceptionRecordReference", "REF-1"
+            ))
+        );
+
+        // when
+        List<Map<String, Object>> actualDocumentsToAttach = removeAlreadyAttachedDocuments(
+            exceptionRecordDocuments,
+            targetCaseDocuments,
+            "REF-2"
+        );
+
+        // then
+        assertThat(actualDocumentsToAttach).asList().hasSize(2);
+    }
 
     @Test
     void should_return_document_control_number_when_one_is_present() {


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Handle missing and duplicate documents for attaching exception record with supplementary evidence](https://tools.hmcts.net/jira/browse/BPS-1095)

### Change description ###

One more helper PR which introduces new method to get documents to be attached to target case. Combining this and the one before (#968) we will be ready to amend the current process of attaching documents for supplementary evidence

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
