### PR TITLE
Upgrade to java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN wget -P /tmp https://github.com/microsoft/ApplicationInsights-Java/releases/
 
 # Application image
 
-FROM hmctspublic.azurecr.io/base/java:openjdk-8-distroless-1.4
+FROM hmctspublic.azurecr.io/base/java:openjdk-11-distroless-1.4
 
 COPY --from=downloader /tmp/applicationinsights-agent-${APP_INSIGHTS_AGENT_VERSION}.jar /opt/app/
 COPY lib/AI-Agent.xml /opt/app/

--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ def versions = [
   junitPlatform     : '1.6.0',
 ]
 
-ext["rest-assured.version"] = '4.2.0'
+ext["rest-assured.version"] = '4.3.0'
 
 dependencyManagement {
   dependencies {
@@ -191,6 +191,13 @@ dependencyManagement {
     // align with jupiter version
     dependencySet(group: 'org.mockito', version: '3.3.3') {
       entry 'mockito-core'
+    }
+    // force junit5 deps to use groovy v3 which fixes reflective call errors for java 11
+    // rest assured 4.2 -> 4.3 jumps to groovy v3. junit v5.6 still on v2.5
+    dependencySet(group: 'org.codehaus.groovy', version: '3.0.2') {
+      entry 'groovy'
+      entry 'groovy-json'
+      entry 'groovy-xml'
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,10 @@ plugins {
 }
 
 group = 'uk.gov.hmcts.reform'
-version = '0.0.1'
+version = '0.1.0' // all the time it was 0.0.1. 0.1.0 marks migration to java 11
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 
 sourceSets {
   contractTest {


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Upgrade bulk scan orchestrator to Java 11](https://tools.hmcts.net/jira/browse/BPS-1272)

### Change description ###

The possibility to bump rest assured has been opened. Testing it out together with this PR as dependency is only for smoke/fun testing - not source code itself.

As mentioned in #1005 changes here are not dependent on that PR but there is a tiny mention about groovy warning and where from it originates

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes - different docker image
[x] No - java11 compiler/jvm locally worked on java8 requirements anyway
```
