### PR TITLE
Fix build - Make queue name configurable per environment

### DIFF
--- a/charts/bulk-scan-orchestrator/Chart.yaml
+++ b/charts/bulk-scan-orchestrator/Chart.yaml
@@ -1,7 +1,7 @@
 name: bulk-scan-orchestrator
 apiVersion: v1
 home: https://github.com/hmcts/bulk-scan-orchestrator
-version: 0.3.0
+version: 0.3.1
 description: HMCTS Bulk scan orchestrator service
 maintainers:
   - name: HMCTS BSP Team

--- a/charts/bulk-scan-orchestrator/values.aat.template.yaml
+++ b/charts/bulk-scan-orchestrator/values.aat.template.yaml
@@ -1,4 +1,8 @@
 java:
+  environment:
+    ENVELOPES_QUEUE_NAME: "envelopes-staging"
+    PROCESSED_ENVELOPES_QUEUE_NAME: "processed-envelopes-staging"
+    PAYMENTS_QUEUE_NAME: "payments-staging"
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}

--- a/charts/bulk-scan-orchestrator/values.yaml
+++ b/charts/bulk-scan-orchestrator/values.yaml
@@ -21,6 +21,9 @@ java:
     DELETE_ENVELOPES_DLQ_MESSAGES_ENABLED: "true"
     DELETE_ENVELOPES_DLQ_MESSAGES_CRON: "0 * * * * *"
     DELETE_ENVELOPES_DLQ_MESSAGES_TTL: "10s"
+    ENVELOPES_QUEUE_NAME: "envelopes"
+    PROCESSED_ENVELOPES_QUEUE_NAME: "processed-envelopes"
+    PAYMENTS_QUEUE_NAME: "payments"
   keyVaults:
     bulk-scan:
       resourceGroup: bulk-scan

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,14 +21,14 @@ azure:
   servicebus:
     envelopes:
       connection-string: ${ENVELOPES_QUEUE_CONNECTION_STRING}
-      queue-name: envelopes
+      queue-name: ${ENVELOPES_QUEUE_NAME}
       max-delivery-count: ${ENVELOPES_QUEUE_MAX_DELIVERY_COUNT}
     processed-envelopes:
       connection-string: ${PROCESSED_ENVELOPES_QUEUE_CONNECTION_STRING}
-      queue-name: processed-envelopes
+      queue-name: ${PROCESSED_ENVELOPES_QUEUE_NAME}
     payments:
       connection-string: ${PAYMENTS_QUEUE_CONNECTION_STRING}
-      queue-name: payments
+      queue-name: ${PAYMENTS_QUEUE_NAME}
       manual-retry-count: 2
 
 core_case_data:

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -26,3 +26,4 @@ spring:
         payments-staging-queue-send-connection-string: PAYMENTS_QUEUE_CONNECTION_STRING
         envelopes-queue-max-delivery-count: ENVELOPES_QUEUE_MAX_DELIVERY_COUNT
         app-insights-instrumentation-key: azure.application-insights.instrumentation-key
+


### PR DESCRIPTION

### Change description ###

- Queue name cannot be hardcoded anymore as we use different queue for staging.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
