### PR TITLE
Use searchCaseReference as the target case reference when attaching an exception record

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
@@ -206,7 +206,7 @@ class AttachExceptionRecordToExistingCaseTest {
         // set searchCaseReference to the callback request data
         // and searchCaseReferenceType and attachToCaseReference doesn't exist
         invokeCallbackEndpointWithSearchCaseRefAndAttachToCaseRef(
-            String.valueOf(targetCase.getId()),
+            Long.toString(targetCase.getId()),
             exceptionRecord
         ).jsonPath()
             .getList("errors")

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
@@ -194,6 +194,39 @@ class AttachExceptionRecordToExistingCaseTest {
     }
 
     @Test
+    public void should_attach_exception_record_to_case_by_searchCaseReference_and_attachToCaseReference()
+        throws Exception {
+        //given
+        // set searchCaseReference as targetCase id
+        CaseDetails targetCase = ccdCaseCreator.createCase(emptyList(), Instant.now());
+
+        // set attachToCaseReference value with attachToCaseDetails id, which should be ignored
+        CaseDetails attachToCaseDetails = ccdCaseCreator.createCase(emptyList(), Instant.now());
+
+        CaseDetails exceptionRecord =
+            createExceptionRecord("envelopes/supplementary-evidence-envelope.json");
+
+        // when
+        // set searchCaseReference and attachToCaseReference to callback request
+        // and searchCaseReferenceType doesn't exist
+        invokeCallbackEndpointWithSearchCaseRefAndAttachToCaseRef(
+            targetCase,
+            attachToCaseDetails,
+            exceptionRecord
+        ).jsonPath()
+            .getList("errors")
+            .isEmpty();
+
+        //then
+        await("Exception record is attached to the case with searchCaseReference")
+            .atMost(60, TimeUnit.SECONDS)
+            .pollDelay(2, TimeUnit.SECONDS)
+            .until(() -> isExceptionRecordAttachedToTheCase(targetCase, 1));
+
+        verifyExistingCaseIsUpdatedWithExceptionRecordData(targetCase, exceptionRecord, 1);
+    }
+
+    @Test
     public void should_attach_exception_record_to_case_by_search_case_reference_and_payment() throws Exception {
         //given
         CaseDetails caseDetails = ccdCaseCreator.createCase(emptyList(), Instant.now());
@@ -290,6 +323,39 @@ class AttachExceptionRecordToExistingCaseTest {
 
         CaseDetails exceptionRecordWithSearchFields =
             exceptionRecord.toBuilder().data(exceptionRecordDataWithSearchFields).build();
+
+        CallbackRequest callbackRequest = CallbackRequest
+            .builder()
+            .eventId("attachToExistingCase")
+            .caseDetails(exceptionRecordWithSearchFields)
+            .build();
+
+        CcdAuthenticator ccdAuthenticator = ccdAuthenticatorFactory.createForJurisdiction("BULKSCAN");
+
+        return RestAssured
+            .given()
+            .relaxedHTTPSValidation()
+            .baseUri(testUrl)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header(SyntheticHeaders.SYNTHETIC_TEST_SOURCE, "Bulk Scan Orchestrator Functional test")
+            .header(AUTHORIZATION, ccdAuthenticator.getUserToken())
+            .header(CcdCallbackController.USER_ID, ccdAuthenticator.getUserDetails().getId())
+            .body(callbackRequest)
+            .when()
+            .post("/callback/attach_case?ignore-warning=true");
+    }
+
+    private Response invokeCallbackEndpointWithSearchCaseRefAndAttachToCaseRef(
+        CaseDetails searchCaseRefCaseDetails,
+        CaseDetails attachToCaseDetails,
+        CaseDetails exceptionRecord
+    ) {
+        Map<String, Object> exceptionRecordData = new HashMap<>(exceptionRecord.getData());
+        exceptionRecordData.put("attachToCaseReference", String.valueOf(attachToCaseDetails.getId()));
+        exceptionRecordData.put("searchCaseReference", String.valueOf(searchCaseRefCaseDetails.getId()));
+
+        CaseDetails exceptionRecordWithSearchFields =
+            exceptionRecord.toBuilder().data(exceptionRecordData).build();
 
         CallbackRequest callbackRequest = CallbackRequest
             .builder()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
@@ -206,7 +206,7 @@ class AttachExceptionRecordToExistingCaseTest {
         // set searchCaseReference to the callback request data
         // and searchCaseReferenceType and attachToCaseReference doesn't exist
         invokeCallbackEndpointWithSearchCaseRefAndAttachToCaseRef(
-            targetCase,
+            String.valueOf(targetCase.getId()),
             exceptionRecord
         ).jsonPath()
             .getList("errors")
@@ -341,11 +341,11 @@ class AttachExceptionRecordToExistingCaseTest {
     }
 
     private Response invokeCallbackEndpointWithSearchCaseRefAndAttachToCaseRef(
-        CaseDetails searchCaseRefCaseDetails,
+        String searchCaseReference,
         CaseDetails exceptionRecord
     ) {
         Map<String, Object> exceptionRecordData = new HashMap<>(exceptionRecord.getData());
-        exceptionRecordData.put("searchCaseReference", String.valueOf(searchCaseRefCaseDetails.getId()));
+        exceptionRecordData.put("searchCaseReference", searchCaseReference);
 
         CaseDetails exceptionRecordWithSearchFields =
             exceptionRecord.toBuilder().data(exceptionRecordData).build();
@@ -368,7 +368,7 @@ class AttachExceptionRecordToExistingCaseTest {
             .header(CcdCallbackController.USER_ID, ccdAuthenticator.getUserDetails().getId())
             .body(callbackRequest)
             .when()
-            .post("/callback/attach_case?ignore-warning=true");
+            .post("/callback/attach_case?ignore-warning=false");
     }
 
     private Map<String, Object> exceptionRecordDataWithSearchFields(

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
@@ -194,24 +194,19 @@ class AttachExceptionRecordToExistingCaseTest {
     }
 
     @Test
-    public void should_attach_exception_record_to_case_by_searchCaseReference_and_attachToCaseReference()
+    public void should_attach_exception_record_to_case_by_search_case_reference()
         throws Exception {
         //given
-        // set searchCaseReference as targetCase id
         CaseDetails targetCase = ccdCaseCreator.createCase(emptyList(), Instant.now());
-
-        // set attachToCaseReference value with attachToCaseDetails id, which should be ignored
-        CaseDetails attachToCaseDetails = ccdCaseCreator.createCase(emptyList(), Instant.now());
 
         CaseDetails exceptionRecord =
             createExceptionRecord("envelopes/supplementary-evidence-envelope.json");
 
         // when
-        // set searchCaseReference and attachToCaseReference to callback request
-        // and searchCaseReferenceType doesn't exist
+        // set searchCaseReference to the callback request data
+        // and searchCaseReferenceType and attachToCaseReference doesn't exist
         invokeCallbackEndpointWithSearchCaseRefAndAttachToCaseRef(
             targetCase,
-            attachToCaseDetails,
             exceptionRecord
         ).jsonPath()
             .getList("errors")
@@ -347,11 +342,9 @@ class AttachExceptionRecordToExistingCaseTest {
 
     private Response invokeCallbackEndpointWithSearchCaseRefAndAttachToCaseRef(
         CaseDetails searchCaseRefCaseDetails,
-        CaseDetails attachToCaseDetails,
         CaseDetails exceptionRecord
     ) {
         Map<String, Object> exceptionRecordData = new HashMap<>(exceptionRecord.getData());
-        exceptionRecordData.put("attachToCaseReference", String.valueOf(attachToCaseDetails.getId()));
         exceptionRecordData.put("searchCaseReference", String.valueOf(searchCaseRefCaseDetails.getId()));
 
         CaseDetails exceptionRecordWithSearchFields =

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
@@ -128,6 +128,43 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
         verify(exactly(0), submittedScannedRecords());
     }
 
+    @Test
+    void should_callback_with_search_case_reference_when_attaching_without_search_case_reference_type() {
+        CallbackRequest callbackRequest = exceptionRecordCallbackRequest(
+            null,
+            null,
+            CASE_REF,
+            CASE_TYPE_EXCEPTION_RECORD
+        );
+
+        ValidatableResponse response =
+            given()
+                .body(callbackRequest)
+                .headers(userHeaders())
+                .post(CALLBACK_ATTACH_CASE_PATH)
+                .then()
+                .statusCode(200);
+
+        verifySuccessResponse(response, callbackRequest);
+        verifyRequestedAttachingToCase();
+    }
+
+    @Test
+    void should_callback_with_search_case_reference_when_attach_to_case_reference_also_exists() {
+        CallbackRequest callbackRequest = attachToCaseRequest("12345678", null, CASE_REF, EXISTING_DOC);
+
+        ValidatableResponse response = given()
+            .body(callbackRequest)
+            .headers(userHeaders())
+            .post(CALLBACK_ATTACH_CASE_PATH)
+            .then()
+            .statusCode(200);
+
+        verifySuccessResponse(response, callbackRequest);
+        verify(exactly(0), startEventRequest());
+        verify(exactly(0), submittedScannedRecords());
+    }
+
     @DisplayName("Should fail with the correct error when submit api call fails")
     @Test
     void should_fail_with_the_correct_error_when_submit_api_call_fails() {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
@@ -149,22 +149,6 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
         verifyRequestedAttachingToCase();
     }
 
-    @Test
-    void should_callback_with_search_case_reference_when_attach_to_case_reference_also_exists() {
-        CallbackRequest callbackRequest = attachToCaseRequest("12345678", null, CASE_REF, EXISTING_DOC);
-
-        ValidatableResponse response = given()
-            .body(callbackRequest)
-            .headers(userHeaders())
-            .post(CALLBACK_ATTACH_CASE_PATH)
-            .then()
-            .statusCode(200);
-
-        verifySuccessResponse(response, callbackRequest);
-        verify(exactly(0), startEventRequest());
-        verify(exactly(0), submittedScannedRecords());
-    }
-
     @DisplayName("Should fail with the correct error when submit api call fails")
     @Test
     void should_fail_with_the_correct_error_when_submit_api_call_fails() {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -38,13 +38,13 @@ import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.canBeAttachedToCase;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasAScannedRecord;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasAnId;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasAttachToCaseReference;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasIdamToken;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasJourneyClassificationForAttachToCase;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasJurisdiction;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasSearchCaseReference;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasSearchCaseReferenceType;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasServiceNameInCaseTypeId;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasTargetCaseReference;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasUserId;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.validatePayments;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.Documents.concatDocuments;
@@ -145,7 +145,7 @@ public class AttachCaseCallbackService {
 
         Validation<String, String> caseReferenceValidation = useSearchCaseReference
             ? hasSearchCaseReference(exceptionRecord)
-            : hasAttachToCaseReference(exceptionRecord);
+            : hasTargetCaseReference(exceptionRecord);
 
         Validation<String, String> jurisdictionValidation = hasJurisdiction(exceptionRecord);
         Validation<String, String> serviceNameInCaseTypeIdValidation = hasServiceNameInCaseTypeId(exceptionRecord);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidations.java
@@ -103,12 +103,12 @@ public final class CallbackValidations {
 
     @Nonnull
     static Validation<String, String> hasSearchCaseReference(CaseDetails theCase) {
-        return caseRefValidator.validateSearchCaseReference(theCase);
+        return caseRefValidator.validateSearchCaseReferenceWithSearchType(theCase);
     }
 
     @Nonnull
-    static Validation<String, String> hasAttachToCaseReference(CaseDetails theCase) {
-        return caseRefValidator.validateAttachToCaseReference(theCase);
+    static Validation<String, String> hasTargetCaseReference(CaseDetails theCase) {
+        return caseRefValidator.validateTargetCaseReference(theCase);
     }
 
     @Nonnull

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseReferenceValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseReferenceValidator.java
@@ -33,7 +33,14 @@ class CaseReferenceValidator {
     }
 
     @Nonnull
-    Validation<String, String> validateSearchCaseReference(CaseDetails theCase) {
+    Validation<String, String> validateTargetCaseReference(CaseDetails theCase) {
+        return getCaseRef(theCase, SEARCH_CASE_REFERENCE)
+            .map(this::validateCcdCaseRef)
+            .orElse(validateAttachToCaseReference(theCase));
+    }
+
+    @Nonnull
+    Validation<String, String> validateSearchCaseReferenceWithSearchType(CaseDetails theCase) {
         Validation<String, String> caseReferenceTypeValidation = validateCaseReferenceType(theCase);
 
         if (caseReferenceTypeValidation.isValid()) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackServiceTest.java
@@ -34,9 +34,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidationsTest.JOURNEY_CLASSIFICATION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.EVENT_ID_ATTACH_TO_CASE;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.ATTACH_TO_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.OCR_DATA;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SCANNED_DOCUMENTS;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SEARCH_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE_WITH_OCR;
 
 @ExtendWith(MockitoExtension.class)
@@ -84,7 +84,7 @@ class AttachCaseCallbackServiceTest {
         .data(
             ImmutableMap.of(
             JOURNEY_CLASSIFICATION, SUPPLEMENTARY_EVIDENCE_WITH_OCR.name(),
-            ATTACH_TO_CASE_REFERENCE, EXISTING_CASE_ID,
+            SEARCH_CASE_REFERENCE, EXISTING_CASE_ID,
             OCR_DATA, asList(ImmutableMap.of("firstName", "John")),
             SCANNED_DOCUMENTS, ImmutableList.of(EXISTING_DOC)
         ))

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
@@ -27,6 +27,13 @@ class TestCaseBuilder {
         return createCaseWith(b -> b.data(data));
     }
 
+    static CaseDetails caseWithTargetReference(Object attachToCaseReference, Object searchCaseReference) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("attachToCaseReference", attachToCaseReference);
+        data.put("searchCaseReference", searchCaseReference);
+        return createCaseWith(b -> b.data(data));
+    }
+
     static CaseDetails caseWithSearchCaseReferenceType(Object searchCaseReferenceType) {
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("searchCaseReferenceType", searchCaseReferenceType);
@@ -34,14 +41,16 @@ class TestCaseBuilder {
     }
 
     static CaseDetails caseWithCcdSearchCaseReference(Object searchCaseReference) {
-        return caseWithSearchCaseReference("ccdCaseReference", searchCaseReference);
+        return caseWithSearchCaseRefTypeAndCaseRef("ccdCaseReference", searchCaseReference);
     }
 
     static CaseDetails caseWithExternalSearchCaseReference(Object searchCaseReference) {
-        return caseWithSearchCaseReference("externalCaseReference", searchCaseReference);
+        return caseWithSearchCaseRefTypeAndCaseRef("externalCaseReference", searchCaseReference);
     }
 
-    static CaseDetails caseWithSearchCaseReference(Object searchCaseReferenceType, Object searchCaseReference) {
+    static CaseDetails caseWithSearchCaseRefTypeAndCaseRef(
+        Object searchCaseReferenceType, Object searchCaseReference
+    ) {
         Map<String, Object> caseData = new HashMap<>();
         caseData.put("searchCaseReference", searchCaseReference);
         caseData.put("searchCaseReferenceType", searchCaseReferenceType);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1275


### Change description ###
- When attaching an Exception Record to an existing case, 
   - Validate `searchCaseReference` value in the callback request as the target case reference.
   - Validate  `attachToCaseReference` value when `searchCaseReference`  value doesn't exist (so 
   that the current functionality will not be broken)

- Added a functional test to verify if `searchCaseReference` takes priority when both  `searchCaseReference` and `attachToCaseReference` have values in the callback request.

**Next steps:**
- update Exception record definitions to include searchCaseReference field
- Update callback service to attach the Exception Record to `searchCaseReference` and 
remove validation on `attachToCaseReference`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
