### PR TITLE
Add FeignExceptionLogger utility class

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseSearcher.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseSearcher.java
@@ -28,6 +28,7 @@ public class CaseSearcher {
         this.coreCaseDataApi = coreCaseDataApi;
     }
 
+    // only used in tests
     public Optional<CaseDetails> findExceptionRecord(String poBox) {
         return search(
             SampleData.JURSIDICTION,
@@ -36,6 +37,7 @@ public class CaseSearcher {
         ).stream().findFirst();
     }
 
+    // only used in tests. single source code call - only used in tests too
     public List<CaseDetails> search(
         String jurisdiction,
         String caseTypeId,

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCaseCreator.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCaseCreator.java
@@ -45,11 +45,13 @@ public class CcdCaseCreator {
         this.supplementaryEvidenceMapper = supplementaryEvidenceMapper;
     }
 
+    // only used in tests
     public CaseDetails createCase(List<Document> documents, Instant deliveryDate) {
         String legacyId = "legacy-id-" + (long) (Math.random() * 100_000_000d);
         return createCase(legacyId, documents, deliveryDate);
     }
 
+    // only used privately here. is this class serving any purpose?
     public CaseDetails createCase(String legacyId, List<Document> documents, Instant deliveryDate) {
         log.info("Creating new case");
         CcdAuthenticator authenticator = ccdAuthenticatorFactory.createForJurisdiction(JURISDICTION);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/FeignExceptionLogger.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/FeignExceptionLogger.java
@@ -13,7 +13,7 @@ public final class FeignExceptionLogger {
         logger.debug(
             "{}. CCD response: {}",
             introMessage,
-            exception.responseBody().map(b -> new String(b.array())).orElse(exception.getMessage())
+            exception.responseBody().map(b -> new String(b.array())).orElseGet(exception::getMessage)
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/FeignExceptionLogger.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/FeignExceptionLogger.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.logging;
+
+import feign.FeignException;
+import org.slf4j.Logger;
+
+public final class FeignExceptionLogger {
+
+    private FeignExceptionLogger() {
+        // empty utility class construct
+    }
+
+    public static void debugCcdException(Logger logger, FeignException exception, String introMessage) {
+        logger.debug(
+            "{}. CCD response: {}",
+            introMessage,
+            exception.responseBody().map(b -> new String(b.array())).orElse(exception.getMessage())
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -21,6 +21,7 @@ import javax.annotation.Nonnull;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.logging.FeignExceptionLogger.debugCcdException;
 
 /**
  * This class is intended to be a wrapper/adaptor/facade for the orchestrator -> CcdApi.
@@ -63,6 +64,7 @@ public class CcdApi {
             return feignCcdApi
                 .getCase(authenticator.getUserToken(), authenticator.getServiceToken(), caseRef);
         } catch (FeignException ex) {
+            debugCcdException(log, ex, "Failed to call 'getCase'");
             removeFromIdamCacheIfAuthProblem(ex.status(), jurisdiction);
             throw ex;
         }
@@ -81,6 +83,7 @@ public class CcdApi {
                 searchString
             );
         } catch (FeignException ex) {
+            debugCcdException(log, ex, "Failed to call 'searchCases'");
             removeFromIdamCacheIfAuthProblem(ex.status(), jurisdiction);
             throw ex;
         }
@@ -130,6 +133,7 @@ public class CcdApi {
 
             return response;
         } catch (FeignException e) {
+            debugCcdException(log, e, "Failed to call 'startAttachScannedDocs'");
             throw new CcdCallException(
                 format("Internal Error: start event call failed case: %s Error: %s", caseRef, e.status()), e
             );
@@ -228,6 +232,7 @@ public class CcdApi {
                 Event.builder().summary(eventSummary).id(event.getEventId()).build()
             );
         } catch (FeignException e) {
+            debugCcdException(log, e, "Failed to call 'attachCall' - `submitEventForCaseWorker`");
             throw new CcdCallException(
                 format("Internal Error: submitting attach file event failed case: %s Error: %s", caseRef, e.status()),
                 e
@@ -299,6 +304,7 @@ public class CcdApi {
                 eventTypeId
             );
         } catch (FeignException ex) {
+            debugCcdException(log, ex, "Failed to call 'startForCaseworker'");
             removeFromIdamCacheIfAuthProblem(ex.status(), jurisdiction);
             throw ex;
         }
@@ -329,6 +335,7 @@ public class CcdApi {
                 e
             );
         } catch (FeignException e) {
+            debugCcdException(log, e, "Failed to call 'startEventForCaseWorker'");
             removeFromIdamCacheIfAuthProblem(e.status(), jurisdiction);
             throw new CcdCallException(
                 String.format("Could not attach documents for case ref: %s Error: %s", caseRef, e.status()), e
@@ -353,6 +360,7 @@ public class CcdApi {
                 caseDataContent
             );
         } catch (FeignException ex) {
+            debugCcdException(log, ex, "Failed to call 'submitForCaseworker'");
             removeFromIdamCacheIfAuthProblem(ex.status(), jurisdiction);
             throw ex;
         }
@@ -385,6 +393,7 @@ public class CcdApi {
                 e
             );
         } catch (FeignException e) {
+            debugCcdException(log, e, "Failed to call 'submitEventForCaseWorker'");
             removeFromIdamCacheIfAuthProblem(e.status(), jurisdiction);
             throw new CcdCallException(
                 String.format("Could not attach documents for case ref: %s Error: %s", caseRef, e.status()), e

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -31,6 +31,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getDocuments;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.logging.FeignExceptionLogger.debugCcdException;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventIdValidator.EVENT_ID_ATTACH_SCANNED_DOCS_WITH_OCR;
 
 @Service
@@ -184,6 +185,7 @@ public class CcdCaseUpdater {
             ClientServiceErrorResponse errorResponse = new ClientServiceErrorResponse(singletonList(msg), emptyList());
             return new ProcessResult(errorResponse.warnings, errorResponse.errors);
         } catch (FeignException exception) {
+            debugCcdException(log, exception, "Failed to call 'updateCase'");
             log.error(
                 getErrorMessage(configItem.getService(), existingCaseId, exceptionRecord.id)
                     + "Service response: {}",
@@ -311,6 +313,8 @@ public class CcdCaseUpdater {
         } catch (FeignException.Conflict exception) {
             throw exception;
         } catch (FeignException exception) {
+            debugCcdException(log, exception, "Failed to call 'updateCaseInCcd'");
+            // should service response be removed?
             String msg = format("Service response: %s", exception.contentUTF8());
             log.error(
                 "Failed to update case for {} jurisdiction "

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
@@ -28,6 +28,7 @@ import javax.validation.ConstraintViolationException;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.logging.FeignExceptionLogger.debugCcdException;
 
 @Service
 public class CcdNewCaseCreator {
@@ -202,6 +203,7 @@ public class CcdNewCaseCreator {
                     .build()
             ).getId();
         } catch (FeignException exception) {
+            debugCcdException(log, exception, "Failed to call 'createNewCaseInCcd'");
             log.error(
                 "Failed to create new case for {} jurisdiction from exception record {}. Service response: {}",
                 exceptionRecord.poBoxJurisdiction,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/FeignExceptionLoggerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/logging/FeignExceptionLoggerTest.java
@@ -1,0 +1,74 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.logging;
+
+import feign.FeignException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.never;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.logging.FeignExceptionLogger.debugCcdException;
+
+@ExtendWith(MockitoExtension.class)
+class FeignExceptionLoggerTest {
+
+    @Mock
+    private Logger logger;
+
+    @Mock
+    private FeignException exception;
+
+    @Test
+    void should_pick_from_response_body_when_it_is_present() {
+        // given
+        given(exception.responseBody()).willReturn(Optional.of(ByteBuffer.wrap("response body".getBytes())));
+
+        // when
+        debugCcdException(logger, exception, "Intro");
+
+        // then
+        verify(exception, times(1)).responseBody();
+        verify(exception, never()).getMessage();
+
+        // and
+        var logParamCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(logger).debug(logParamCaptor.capture(), logParamCaptor.capture(), logParamCaptor.capture());
+
+        assertThat(logParamCaptor.getAllValues())
+            .hasSize(3)
+            .containsOnly("{}. CCD response: {}", "Intro", "response body");
+    }
+
+    @Test
+    void should_pick_exception_message_when_response_body_is_not_present() {
+        // given
+        given(exception.responseBody()).willReturn(Optional.empty());
+        given(exception.getMessage()).willReturn("error message");
+
+        // when
+        debugCcdException(logger, exception, "Intro");
+
+        // then
+        verify(exception, times(1)).responseBody();
+        verify(exception, times(1)).getMessage();
+
+        // and
+        var logParamCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(logger).debug(logParamCaptor.capture(), logParamCaptor.capture(), logParamCaptor.capture());
+
+        assertThat(logParamCaptor.getAllValues())
+            .hasSize(3)
+            .containsOnly("{}. CCD response: {}", "Intro", "error message");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Log the content of CCD error responses in non-production environments](https://tools.hmcts.net/jira/browse/BPS-697)

### Change description ###

Add debug logs in all relevant places where ccd api calls are made. Messages are up for discussion - just thought it should be super simple as we only want response body. The rest is pretty much logged thoroughly already

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
