### PR TITLE
Remove Form type validation for Exception classification

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CreateCaseCallbackTest.java
@@ -28,10 +28,10 @@ import static com.google.common.io.Resources.toByteArray;
 import static io.restassured.RestAssured.given;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsMapWithSize.anEmptyMap;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
@@ -302,9 +302,10 @@ class CreateCaseCallbackTest {
     void should_respond_with_relevant_errors_when_create_case_callback_body_misses_content() {
         postWithBody(getRequestBody("invalid-empty-case-data.json"))
             .statusCode(OK.value())
-            .body("errors", containsInAnyOrder(
+            .body("errors", hasItems(
                 "Missing poBox",
                 "Missing journeyClassification",
+                "Missing Form Type",
                 "Missing deliveryDate",
                 "Missing openingDate"
             ));

--- a/src/integrationTest/resources/ccd/callback/create-case/request/valid-exception-without-form-type.json
+++ b/src/integrationTest/resources/ccd/callback/create-case/request/valid-exception-without-form-type.json
@@ -1,0 +1,36 @@
+{
+  "case_details": {
+    "id": 1539007368674134,
+    "jurisdiction": "BULKSCAN",
+    "case_type_id": "BULKSCAN_ExceptionRecord",
+    "created_date": "2018-01-01T12:34:56.123Z",
+    "last_modified": "2018-01-01T12:34:56.123Z",
+    "state": "",
+    "locked_by_user_id": null,
+    "security_level": 0,
+    "case_data": {
+      "poBox": "PO 12345",
+      "journeyClassification": "EXCEPTION",
+      "deliveryDate": "2018-01-02T12:34:56.123",
+      "openingDate": "2018-01-03T12:34:56.123Z",
+      "scanOCRData": [
+        {
+          "value": {
+            "key": "item",
+            "value": "value"
+          }
+        },
+        {
+          "value": {
+            "key": "item2",
+            "value": "12345"
+          }
+        }
+      ]
+    },
+    "security_classification": "PUBLIC",
+    "callback_response_status": ""
+  },
+  "event_id": "createNewCase",
+  "ignore_warning": false
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
@@ -4,7 +4,6 @@ import io.vavr.collection.Array;
 import io.vavr.collection.Seq;
 import io.vavr.control.Try;
 import io.vavr.control.Validation;
-import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentType;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentUrl;
@@ -161,9 +160,8 @@ public class ExceptionRecordValidator {
     @SuppressWarnings("unchecked")
     private ScannedDocument mapScannedDocument(Map<String, Object> document) {
         Map<String, String> ccdUrl = (Map<String, String>) document.get("url");
-        String documentType = (String) document.get("type");
         return new ScannedDocument(
-            StringUtils.isNotEmpty(documentType) ? DocumentType.valueOf(documentType.toUpperCase()) : null,
+            DocumentType.valueOf(((String) document.get("type")).toUpperCase()),
             (String) document.get("subtype"),
             new DocumentUrl(
                 ccdUrl.get("document_url"),

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
@@ -74,6 +74,7 @@ public class ExceptionRecordValidator {
         Validation<String, Classification> journeyClassificationValidation = hasJourneyClassification(caseDetails);
 
         Validation<String, String> formTypeValidation;
+        // Exception journey classification may not have form type so skipping validation for it
         if (journeyClassificationValidation.isValid() && journeyClassificationValidation.get().equals(EXCEPTION)) {
             formTypeValidation = Validation.valid(null);
         } else {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
@@ -77,8 +77,6 @@ public class ExceptionRecordValidator {
         // Exception journey classification may not have form type so skipping validation for it
         if (journeyClassificationValidation.isValid() && journeyClassificationValidation.get().equals(EXCEPTION)) {
             formTypeValidation = Validation.valid(formTypeValidation.getOrNull());
-        } else {
-            formTypeValidation = hasFormType(caseDetails);
         }
 
         Validation<String, LocalDateTime> deliveryDateValidation = hasDateField(caseDetails, "deliveryDate");

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
@@ -4,6 +4,7 @@ import io.vavr.collection.Array;
 import io.vavr.collection.Seq;
 import io.vavr.control.Try;
 import io.vavr.control.Validation;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentType;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentUrl;
@@ -160,8 +161,9 @@ public class ExceptionRecordValidator {
     @SuppressWarnings("unchecked")
     private ScannedDocument mapScannedDocument(Map<String, Object> document) {
         Map<String, String> ccdUrl = (Map<String, String>) document.get("url");
+        String documentType = (String) document.get("type");
         return new ScannedDocument(
-            DocumentType.valueOf(((String) document.get("type")).toUpperCase()),
+            StringUtils.isNotEmpty(documentType) ? DocumentType.valueOf(documentType.toUpperCase()) : null,
             (String) document.get("subtype"),
             new DocumentUrl(
                 ccdUrl.get("document_url"),

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
@@ -31,6 +31,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackVal
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasJourneyClassification;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasJurisdiction;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CallbackValidations.hasPoBox;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.EXCEPTION;
 
 @Component
 public class ExceptionRecordValidator {
@@ -70,8 +71,15 @@ public class ExceptionRecordValidator {
         Validation<String, String> caseTypeIdValidation = hasCaseTypeId(caseDetails);
         Validation<String, String> poBoxValidation = hasPoBox(caseDetails);
         Validation<String, String> jurisdictionValidation = hasJurisdiction(caseDetails);
-        Validation<String, String> formTypeValidation = hasFormType(caseDetails);
         Validation<String, Classification> journeyClassificationValidation = hasJourneyClassification(caseDetails);
+
+        Validation<String, String> formTypeValidation;
+        if (journeyClassificationValidation.isValid() && !journeyClassificationValidation.get().equals(EXCEPTION)) {
+            formTypeValidation = hasFormType(caseDetails);
+        } else {
+            formTypeValidation = Validation.valid(null);
+        }
+
         Validation<String, LocalDateTime> deliveryDateValidation = hasDateField(caseDetails, "deliveryDate");
         Validation<String, LocalDateTime> openingDateValidation = hasDateField(caseDetails, "openingDate");
         Validation<String, List<ScannedDocument>> scannedDocumentsValidation = getScannedDocuments(caseDetails);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
@@ -74,10 +74,10 @@ public class ExceptionRecordValidator {
         Validation<String, Classification> journeyClassificationValidation = hasJourneyClassification(caseDetails);
 
         Validation<String, String> formTypeValidation;
-        if (journeyClassificationValidation.isValid() && !journeyClassificationValidation.get().equals(EXCEPTION)) {
-            formTypeValidation = hasFormType(caseDetails);
-        } else {
+        if (journeyClassificationValidation.isValid() && journeyClassificationValidation.get().equals(EXCEPTION)) {
             formTypeValidation = Validation.valid(null);
+        } else {
+            formTypeValidation = hasFormType(caseDetails);
         }
 
         Validation<String, LocalDateTime> deliveryDateValidation = hasDateField(caseDetails, "deliveryDate");

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/callback/ExceptionRecordValidator.java
@@ -73,10 +73,10 @@ public class ExceptionRecordValidator {
         Validation<String, String> jurisdictionValidation = hasJurisdiction(caseDetails);
         Validation<String, Classification> journeyClassificationValidation = hasJourneyClassification(caseDetails);
 
-        Validation<String, String> formTypeValidation;
+        Validation<String, String> formTypeValidation =  hasFormType(caseDetails);
         // Exception journey classification may not have form type so skipping validation for it
         if (journeyClassificationValidation.isValid() && journeyClassificationValidation.get().equals(EXCEPTION)) {
-            formTypeValidation = Validation.valid(null);
+            formTypeValidation = Validation.valid(formTypeValidation.getOrNull());
         } else {
             formTypeValidation = hasFormType(caseDetails);
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1298


### Change description ###
Create case callback should not validate Form type for `Exception` classification


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
