### PR TITLE
Bump logging library 5.1.5 -> 5.1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,7 +203,7 @@ repositories {
 // it is important to specify logback classic and core packages explicitly as libraries like spring boot
 // enforces it's own (older) version which is not recommended.
 def versions = [
-  reformLogging     : '5.1.5',
+  reformLogging     : '5.1.6',
   springfoxSwagger  : '2.9.2',
   junit             : '5.6.2',
   junitPlatform     : '1.6.2',


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Log the content of CCD error responses in non-production environments](https://tools.hmcts.net/jira/browse/BPS-697)

### Change description ###

This version aligns with latest dependencies + allows to publish custom log levels to app insights which is the goal of the task.

Full release notes: https://github.com/hmcts/java-logging/releases/tag/5.1.6

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
