### PR TITLE
Review CCD Auth Factory class

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrievalTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrievalTest.java
@@ -60,7 +60,7 @@ class CaseRetrievalTest {
         new CcdAuthenticator(
             () -> "service_token",
             new UserDetails("12", "forname", "", null, null),
-            () -> "ey_token"
+            "ey_token"
         );
 
     @BeforeEach

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticator.java
@@ -8,20 +8,20 @@ public class CcdAuthenticator {
 
     private final UserDetails userDetails;
     private final Supplier<String> serviceTokenSupplier;
-    private final Supplier<String> userTokenSupplier;
+    private final String userToken;
 
     public CcdAuthenticator(
         Supplier<String> serviceTokenSupplier,
         UserDetails userDetails,
-        Supplier<String> userTokenSupplier
+        String userToken
     ) {
         this.serviceTokenSupplier = serviceTokenSupplier;
         this.userDetails = userDetails;
-        this.userTokenSupplier = userTokenSupplier;
+        this.userToken = userToken;
     }
 
     public String getUserToken() {
-        return this.userTokenSupplier.get();
+        return this.userToken;
     }
 
     public String getServiceToken() {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticatorFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticatorFactory.java
@@ -28,7 +28,7 @@ public class CcdAuthenticatorFactory {
         return new CcdAuthenticator(
             s2sTokenGenerator::generate,
             idamCredentials.userDetails,
-            () -> idamCredentials.accessToken
+            idamCredentials.accessToken
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticatorFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticatorFactory.java
@@ -1,14 +1,11 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.JurisdictionToUserMapping;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.cache.CachedIdamCredential;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.cache.IdamCachedClient;
 
 @Service
-@EnableConfigurationProperties(JurisdictionToUserMapping.class)
 public class CcdAuthenticatorFactory {
 
     private final AuthTokenGenerator s2sTokenGenerator;

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -54,7 +54,7 @@ public class SampleData {
     public static final CcdAuthenticator AUTH_DETAILS = new CcdAuthenticator(
         () -> SERVICE_TOKEN,
         USER_DETAILS,
-        () -> USER_TOKEN
+        USER_TOKEN
     );
 
     public static final CaseDetails THE_CASE = CaseDetails.builder()


### PR DESCRIPTION
### Change description ###

- There's no need to add runnable interface for access token. plus it's cached but not related to functional interface usage here
- Looks like config properties are long gone - not used in this class

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
