### PR TITLE
Review CCD Api usage: AUTO event for SUPPLEMENTARY_EVIDENCE

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrievalTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrievalTest.java
@@ -260,34 +260,21 @@ class CaseRetrievalTest {
 
         // when
         assertThatThrownBy(
-            () -> ccdApi.startEventForAttachScannedDocs(CCD_AUTHENTICATOR, JURISDICTION, "77", "2", "eventId"))
-            .isInstanceOf(CcdCallException.class)
-            .hasMessageContaining("Could not attach documents for case ref: 2 Error: " + status);
-        Mockito.verify(authenticatorFactory).removeFromCache(JURISDICTION);
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {401, 403})
-    public void submitEventForAttachScannedDocs_should_throw_CcdCallException_when_auth_error(int status) {
-        // given
-        givenThat(
-            post("/caseworkers/12/jurisdictions/BULKSCAN/case-types/23/cases/98/events?ignore-warning=true")
-            .willReturn(aResponse().withStatus(status))
-        );
-
-        // when
-        assertThatThrownBy(
-            () -> ccdApi.submitEventForAttachScannedDocs(
+            () -> ccdApi.attachScannedDocs(
                 CCD_AUTHENTICATOR,
                 JURISDICTION,
-                "23",
-                "98",
-                CaseDataContent.builder().eventToken("eventtoken").build()
+                "77",
+                "2",
+                "eventId",
+                startEvent -> CaseDataContent.builder().eventToken("eventtoken").build(),
+                "log context"
             )
         )
+            // then
             .isInstanceOf(CcdCallException.class)
-            .hasMessageContaining("Could not attach documents for case ref: 98 Error: " + status);
-        //then
+            .hasMessageContaining("Could not attach documents for case ref: 2 Error: " + status);
+
+        // and
         Mockito.verify(authenticatorFactory).removeFromCache(JURISDICTION);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrievalTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrievalTest.java
@@ -253,7 +253,7 @@ class CaseRetrievalTest {
 
     @ParameterizedTest
     @ValueSource(ints = {401, 403})
-    public void startEventForAttachScannedDocs_should_throw_ccdCallException_when_auth_error(int status) {
+    public void attachScannedDocs_should_throw_ccdCallException_when_auth_error(int status) {
         // given
         givenThat(get("/caseworkers/12/jurisdictions/BULKSCAN/case-types/77/cases/2/event-triggers/eventId/token")
             .willReturn(aResponse().withStatus(status)));

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -347,7 +347,7 @@ public class CcdApi {
                 e
             );
         } catch (FeignException e) {
-            debugCcdException(log, e, "Failed to call 'eventForCaseWorker'");
+            debugCcdException(log, e, "Failed to call 'attachScannedDocs'");
             removeFromIdamCacheIfAuthProblem(e.status(), jurisdiction);
 
             throw new CcdCallException(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -55,22 +55,14 @@ class AttachDocsToSupplementaryEvidence {
             try {
                 CcdAuthenticator authenticator = ccdApi.authenticateJurisdiction(envelope.jurisdiction);
 
-                StartEventResponse startEventResp = ccdApi.startEventForAttachScannedDocs(
+                ccdApi.attachScannedDocs(
                     authenticator,
                     envelope.jurisdiction,
                     existingCase.getCaseTypeId(),
-                    existingCase.getId().toString(),
-                    EVENT_TYPE_ID
-                );
-
-                log.info("Started event in CCD to attach supplementary evidence to case. {}", loggingContext);
-
-                ccdApi.submitEventForAttachScannedDocs(
-                    authenticator,
-                    envelope.jurisdiction,
-                    existingCase.getCaseTypeId(),
-                    existingCase.getId().toString(),
-                    buildCaseDataContent(envelope, startEventResp)
+                    Long.toString(existingCase.getId()),
+                    EVENT_TYPE_ID,
+                    startEventResponse -> buildCaseDataContent(envelope, startEventResponse),
+                    loggingContext
                 );
 
                 log.info("Attached documents from envelope to case. {}", loggingContext);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidence.java
@@ -67,7 +67,7 @@ class AttachDocsToSupplementaryEvidence {
 
                 log.info("Attached documents from envelope to case. {}", loggingContext);
             } catch (UnableToAttachDocumentsException e) {
-                log.error("Failed to attach documents from envelope to case. {}", loggingContext);
+                log.error("Failed to attach documents from envelope to case. {}", loggingContext, e);
                 return false;
             }
         }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/AttachDocsToSupplementaryEvidenceTest.java
@@ -114,6 +114,6 @@ class AttachDocsToSupplementaryEvidenceTest {
         attacher.attach(envelope, existingCase);
 
         // then
-        verify(ccdApi, never()).startEvent(any(), any(), any(), any());
+        verify(ccdApi, never()).attachScannedDocs(any(), any(), any(), any(), any(), any(), any());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Orchestrator: refactor CcdCaseUpdater and its surroundings](https://tools.hmcts.net/jira/browse/BPS-1074)

### Change description ###

What has been done so far: review all possible scenarios orchestrator has involvement with ccd feign client which is key element in this service.

Goal: if possible, reduce calls, reduce split of those calls, identify what can be unified and reduced.

Most of those calls are fairly "simple":

- start event
- log some success
- build data to submit event
- submit event

There are some customised exception handling so cannot completely unify everything but solution may appear clearer once all such behavioural usage is reviewed/re-jigged.

Here is the first one, simple enough to apply: same actions were applied for both start and submit events. Just unifying them in one go making event class clear enough what it needs doing

Summary:

```markdown
BEFORE:

- ccdApi.authenticateJurisdiction(envelope.jurisdiction)
- ccdApi.startEventForAttachScannedDocs:
  - feignCcdApi.startEventForCaseWorker
  - exception:
    - 404 -> throw new UnableToAttachDocumentsException
    - otherwise: removeFromIdamCacheIfAuthProblem(e.status(), jurisdiction) + throw new CcdCallException
- ccdApi.submitEventForAttachScannedDocs:
  - feignCcdApi.submitEventForCaseWorker
  - exception:
    - 404 -> throw new UnableToAttachDocumentsException
    - otherwise: removeFromIdamCacheIfAuthProblem(e.status(), jurisdiction) + throw new CcdCallException
- catch (UnableToAttachDocumentsException e)? return false

AFTER:

- ccdApi.authenticateJurisdiction(envelope.jurisdiction)
- ccdApi.attachScannedDocs:
  - feignCcdApi.startEventForCaseWorker
  - feignCcdApi.submitEventForCaseWorker
  - exception:
    - 404 -> throw new UnableToAttachDocumentsException
    - otherwise: removeFromIdamCacheIfAuthProblem(e.status(), jurisdiction) + throw new CcdCallException
- catch (UnableToAttachDocumentsException e)? return false
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
