### PR TITLE
Unify ccdApi method calls for new exception

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrievalTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrievalTest.java
@@ -245,9 +245,19 @@ class CaseRetrievalTest {
             .willReturn(aResponse().withStatus(status)));
 
         // when
-        assertThatThrownBy(() -> ccdApi.startEvent(CCD_AUTHENTICATOR, JURISDICTION, "99", "eventId"))
+        assertThatThrownBy(() -> ccdApi.createExceptionRecord(
+            CCD_AUTHENTICATOR,
+            JURISDICTION,
+            "99",
+            "eventId",
+            startEventResponse -> CaseDataContent.builder().eventToken("eventtoken").build(),
+            "log context"
+        ))
+            // then
             .isInstanceOf(FeignException.class)
             .hasMessageContaining(errorMessage);
+
+        // and
         Mockito.verify(authenticatorFactory).removeFromCache(JURISDICTION);
     }
 
@@ -288,28 +298,6 @@ class CaseRetrievalTest {
             .isInstanceOf(CcdCallException.class)
             .hasMessageContaining("Could not attach documents for case ref: 98 Error: " + status);
         //then
-        Mockito.verify(authenticatorFactory).removeFromCache(JURISDICTION);
-    }
-
-    @ParameterizedTest
-    @CsvSource({"401,401 Unauthorized", "403,403 Forbidden"})
-    public void submitEvent_should_throw_FeignException_when_auth_error(int status, String errorMessage) {
-        // given
-        givenThat(
-            post("/caseworkers/12/jurisdictions/BULKSCAN/case-types/casetypeid/cases?ignore-warning=true")
-                .willReturn(aResponse().withStatus(status))
-        );
-
-        // when
-        assertThatThrownBy(() -> ccdApi.submitEvent(
-            CCD_AUTHENTICATOR,
-            JURISDICTION,
-            "casetypeid",
-            CaseDataContent.builder().eventToken("eventtoken").build()
-            )
-        )
-            .isInstanceOf(FeignException.class)
-            .hasMessageContaining(errorMessage);
         Mockito.verify(authenticatorFactory).removeFromCache(JURISDICTION);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/ExceptionRecordCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/ExceptionRecordCreatorTest.java
@@ -9,15 +9,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.mappers.ExceptionRecordMapper;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdApi;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CcdAuthenticator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 
+import java.util.UUID;
+import java.util.function.Function;
+
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -36,6 +41,8 @@ public class ExceptionRecordCreatorTest {
 
     private static final Long CASE_DETAILS_ID = 234L;
 
+    private static final String EVENT_TOKEN = UUID.randomUUID().toString();
+
     private CreateExceptionRecord exceptionRecordCreator;
 
     @BeforeEach
@@ -49,18 +56,27 @@ public class ExceptionRecordCreatorTest {
     @Test
     public void should_create_exception_record_when_none_exists_for_the_envelope() {
         // given
-        setupCcdApi();
-
         given(ccdApi.getExceptionRecordRefsByEnvelopeId(any(), any())).willReturn(emptyList());
         Envelope envelope = envelope(1);
         ExceptionRecord expectedExceptionRecord = mock(ExceptionRecord.class);
         given(exceptionRecordMapper.mapEnvelope(envelope)).willReturn(expectedExceptionRecord);
+        given(ccdApi.authenticateJurisdiction(envelope.jurisdiction)).willReturn(mock(CcdAuthenticator.class));
+
+        // and
+        var caseDetails = mock(CaseDetails.class);
+        given(ccdApi.createExceptionRecord(any(), anyString(), anyString(), anyString(), any(), anyString()))
+            .willReturn(caseDetails);
+        given(caseDetails.getId()).willReturn(CASE_DETAILS_ID);
+
+        // and
+        StartEventResponse startEventResponse = mock(StartEventResponse.class);
+        given(startEventResponse.getToken()).willReturn(EVENT_TOKEN);
 
         // when
         Long ccdRef = exceptionRecordCreator.tryCreateFrom(envelope);
 
         assertThat(ccdRef).isSameAs(CASE_DETAILS_ID);
-        assertExceptionRecordCreated(expectedExceptionRecord, envelope);
+        assertExceptionRecordCreated(expectedExceptionRecord, envelope, startEventResponse);
 
         verify(ccdApi).getExceptionRecordRefsByEnvelopeId(envelope.id, envelope.container);
         verify(exceptionRecordMapper).mapEnvelope(envelope);
@@ -86,28 +102,27 @@ public class ExceptionRecordCreatorTest {
         verifyNoMoreInteractions(exceptionRecordMapper);
     }
 
-    private void assertExceptionRecordCreated(ExceptionRecord expectedExceptionRecord, Envelope envelope) {
-        ArgumentCaptor<CaseDataContent> caseDataContentArgumentCaptor = ArgumentCaptor.forClass(CaseDataContent.class);
+    @SuppressWarnings("unchecked")
+    private void assertExceptionRecordCreated(
+        ExceptionRecord expectedExceptionRecord,
+        Envelope envelope,
+        StartEventResponse startEventResponse
+    ) {
+        var caseDataBuilderCaptor = ArgumentCaptor.forClass(Function.class);
         String expectedCaseTypeId = String.format("%s_ExceptionRecord", envelope.container.toUpperCase());
 
-        verify(ccdApi).submitEvent(
+        verify(ccdApi).createExceptionRecord(
             any(),
             eq(envelope.jurisdiction),
             eq(expectedCaseTypeId),
-            caseDataContentArgumentCaptor.capture()
+            eq("createException"),
+            caseDataBuilderCaptor.capture(),
+            anyString()
         );
 
-        assertThat(caseDataContentArgumentCaptor.getValue()).isNotNull();
-        assertThat(caseDataContentArgumentCaptor.getValue().getData()).isSameAs(expectedExceptionRecord);
-    }
-
-    private void setupCcdApi() {
-        given(ccdApi.startEvent(any(), any(), any(), any()))
-            .willReturn(mock(StartEventResponse.class));
-
-        CaseDetails caseDetails = mock(CaseDetails.class);
-        given(caseDetails.getId()).willReturn(CASE_DETAILS_ID);
-        given(ccdApi.submitEvent(any(), any(), any(), any()))
-            .willReturn(caseDetails);
+        assertThat(caseDataBuilderCaptor.getValue().apply(startEventResponse))
+            .isInstanceOfSatisfying(CaseDataContent.class, caseData ->
+                assertThat(caseData.getData()).isSameAs(expectedExceptionRecord)
+            );
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Orchestrator: refactor CcdCaseUpdater and its surroundings](https://tools.hmcts.net/jira/browse/BPS-1074)

### Change description ###

Second simple enough PR which follows up #1030. It is tightly dependent and cannot be merged separately - apparently attach docs tests were using exception record related methods and they were not referenced in former class :shrug: 

Marking as draft until dependent PR is merged.

Summary

```markdown
BEFORE:

- ccdApi.authenticateJurisdiction(envelope.jurisdiction)
- ccdApi.startEvent:
  - feignCcdApi.startForCaseworker
  - exception? removeFromIdamCacheIfAuthProblem(ex.status(), jurisdiction) + throw back
- ccdApi.submitEvent:
  - feignCcdApi.submitForCaseworker
  - exception? removeFromIdamCacheIfAuthProblem(ex.status(), jurisdiction) + throw back

AFTER:

- ccdApi.authenticateJurisdiction(envelope.jurisdiction)
- ccdApi.createExceptionRecord:
  - feignCcdApi.startForCaseworker
  - feignCcdApi.submitForCaseworker
  - exception? removeFromIdamCacheIfAuthProblem(ex.status(), jurisdiction) + throw back
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
