### PR TITLE
Remove validation on attachToCaseReference field

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordWithOcrToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordWithOcrToExistingCaseTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.empty;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.CaseDataExtractor.getScannedDocuments;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.ATTACH_TO_CASE_REFERENCE;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SEARCH_CASE_REFERENCE;
 
 @SpringBootTest
 @ActiveProfiles("nosb")
@@ -123,7 +123,7 @@ class AttachExceptionRecordWithOcrToExistingCaseTest {
 
     private Response invokeAttachWithOcrEndpoint(CaseDetails exceptionRecord, String targetCaseId) {
         Map<String, Object> data = new HashMap<>(exceptionRecord.getData());
-        data.put(ATTACH_TO_CASE_REFERENCE, targetCaseId);
+        data.put(SEARCH_CASE_REFERENCE, targetCaseId);
 
         CallbackRequest request = CallbackRequest
             .builder()

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/AttachExceptionRecordWithOcrTest.java
@@ -64,6 +64,7 @@ class AttachExceptionRecordWithOcrTest {
     private static final String CASE_ID = "1539007368674134";
     private static final String SUPPLEMENTARY_EVIDENCE_WITH_OCR = "SUPPLEMENTARY_EVIDENCE_WITH_OCR";
     private static final String ATTACH_TO_CASE_REFERENCE_FIELD_NAME = "attachToCaseReference";
+    private static final String SEARCH_CASE_REFERENCE_FIELD_NAME = "searchCaseReference";
     private static final String JOURNEY_CLASSIFICATION = "journeyClassification";
 
     @LocalServerPort
@@ -235,7 +236,7 @@ class AttachExceptionRecordWithOcrTest {
         caseData.put("poBox", "PO 12345");
         caseData.put(JOURNEY_CLASSIFICATION, SUPPLEMENTARY_EVIDENCE_WITH_OCR);
         caseData.put("formType", "B123");
-        caseData.put(ATTACH_TO_CASE_REFERENCE_FIELD_NAME, CASE_ID);
+        caseData.put(SEARCH_CASE_REFERENCE_FIELD_NAME, CASE_ID);
         return caseData;
     }
 
@@ -348,13 +349,13 @@ class AttachExceptionRecordWithOcrTest {
         return getFileContents("/request/", filename);
     }
 
-    private byte[] getRequestBodyWithAttachToCaseRef(String filename, String attachToCaseReference) throws Exception {
+    private byte[] getRequestBodyWithAttachToCaseRef(String filename, String searchCaseReference) throws Exception {
         String fileContent = new String(getFileContents("/request/", filename));
         JSONObject json = new JSONObject(fileContent);
         JSONObject caseData = json
             .getJSONObject("case_details")
             .getJSONObject("case_data");
-        caseData.put("attachToCaseReference", attachToCaseReference);
+        caseData.put(SEARCH_CASE_REFERENCE_FIELD_NAME, searchCaseReference);
         return json.toString().getBytes();
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordTestBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordTestBase.java
@@ -286,9 +286,8 @@ public class AttachExceptionRecordTestBase {
 
     CallbackRequest exceptionRecordCallbackRequestWithPayment() {
         return exceptionRecordCallbackRequest(
+            null,
             CASE_REF,
-            null,
-            null,
             CASE_TYPE_EXCEPTION_RECORD,
             EXCEPTION_RECORD_DOC,
             true
@@ -297,9 +296,8 @@ public class AttachExceptionRecordTestBase {
 
     CallbackRequest exceptionRecordCallbackRequest(String caseReference) {
         return exceptionRecordCallbackRequest(
+            null,
             caseReference,
-            null,
-            null,
             CASE_TYPE_EXCEPTION_RECORD,
             EXCEPTION_RECORD_DOC,
             false
@@ -307,13 +305,11 @@ public class AttachExceptionRecordTestBase {
     }
 
     CallbackRequest exceptionRecordCallbackRequest(
-        String attachToCaseReference,
         String searchCaseReferenceType,
         String searchCaseReference,
         String caseTypeId
     ) {
         return exceptionRecordCallbackRequest(
-            attachToCaseReference,
             searchCaseReferenceType,
             searchCaseReference,
             caseTypeId,
@@ -323,7 +319,6 @@ public class AttachExceptionRecordTestBase {
     }
 
     CallbackRequest exceptionRecordCallbackRequest(
-        String attachToCaseReference,
         String searchCaseReferenceType,
         String searchCaseReference,
         String caseTypeId,
@@ -334,7 +329,7 @@ public class AttachExceptionRecordTestBase {
             .builder()
             .caseDetails(
                 exceptionRecord(
-                    attachToCaseReference,
+                    null,
                     searchCaseReferenceType,
                     searchCaseReference,
                     caseTypeId,
@@ -386,7 +381,7 @@ public class AttachExceptionRecordTestBase {
         }
 
         caseData.put("scannedDocuments", ImmutableList.of(EXCEPTION_RECORD_DOC));
-        caseData.put("attachToCaseReference", CASE_REF);
+        caseData.put("searchCaseReference", CASE_REF);
         return caseData;
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordToExistingCaseTest.java
@@ -43,7 +43,7 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
 
     @DisplayName("Should successfully callback with correct information")
     @Test
-    void should_callback_with_correct_information_when_attaching_by_attachToCaseReference() {
+    void should_callback_with_correct_information_when_attaching_without_search_case_reference_type() {
         CallbackRequest callbackRequest = exceptionRecordCallbackRequest(CASE_REF);
 
         ValidatableResponse response =
@@ -61,7 +61,6 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
     @Test
     void should_callback_with_correct_information_when_attaching_by_ccd_search_case_reference() {
         CallbackRequest callbackRequest = exceptionRecordCallbackRequest(
-            null,
             CASE_REFERENCE_TYPE_CCD,
             CASE_REF,
             CASE_TYPE_EXCEPTION_RECORD
@@ -94,7 +93,6 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
         );
 
         CallbackRequest callbackRequest = exceptionRecordCallbackRequest(
-            null,
             CASE_REFERENCE_TYPE_EXTERNAL,
             legacyId,
             CASE_TYPE_EXCEPTION_RECORD
@@ -114,7 +112,7 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
 
     @Test
     void should_callback_with_correct_information_when_all_documents_have_already_been_attached() {
-        CallbackRequest callbackRequest = attachToCaseRequest(CASE_REF, null, null, EXISTING_DOC);
+        CallbackRequest callbackRequest = attachToCaseRequest(null, CASE_REF, EXISTING_DOC);
 
         ValidatableResponse response = given()
             .body(callbackRequest)
@@ -126,27 +124,6 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
         verifySuccessResponse(response, callbackRequest);
         verify(exactly(0), startEventRequest());
         verify(exactly(0), submittedScannedRecords());
-    }
-
-    @Test
-    void should_callback_with_search_case_reference_when_attaching_without_search_case_reference_type() {
-        CallbackRequest callbackRequest = exceptionRecordCallbackRequest(
-            null,
-            null,
-            CASE_REF,
-            CASE_TYPE_EXCEPTION_RECORD
-        );
-
-        ValidatableResponse response =
-            given()
-                .body(callbackRequest)
-                .headers(userHeaders())
-                .post(CALLBACK_ATTACH_CASE_PATH)
-                .then()
-                .statusCode(200);
-
-        verifySuccessResponse(response, callbackRequest);
-        verifyRequestedAttachingToCase();
     }
 
     @DisplayName("Should fail with the correct error when submit api call fails")
@@ -187,9 +164,9 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
                     .data(
                         exceptionDataWithDoc(
                             ImmutableList.of(EXISTING_DOC, EXCEPTION_RECORD_DOC),
+                            null,
+                            null,
                             CASE_REF,
-                            null,
-                            null,
                             false
                         )
                     ).build()
@@ -230,9 +207,9 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
                     .data(
                         exceptionDataWithDoc(
                             ImmutableList.of(EXISTING_DOC),
+                            null,
+                            null,
                             CASE_REF,
-                            null,
-                            null,
                             false
                         )
                     ).build()
@@ -278,7 +255,6 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
         given()
             .body(
                 exceptionRecordCallbackRequest(
-                    null,
                     CASE_REFERENCE_TYPE_CCD,
                     nonExistingCaseRef,
                     CASE_TYPE_EXCEPTION_RECORD
@@ -305,7 +281,6 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
         given()
             .body(
                 exceptionRecordCallbackRequest(
-                    null,
                     CASE_REFERENCE_TYPE_EXTERNAL,
                     nonExistingLegacyId,
                     CASE_TYPE_EXCEPTION_RECORD
@@ -336,7 +311,6 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
         given()
             .body(
                 exceptionRecordCallbackRequest(
-                    null,
                     CASE_REFERENCE_TYPE_EXTERNAL,
                     legacyId,
                     CASE_TYPE_EXCEPTION_RECORD
@@ -366,9 +340,8 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
         given()
             .body(
                 exceptionRecordCallbackRequest(
+                    null,
                     CASE_REF,
-                    null,
-                    null,
                     "invalid-case-type"
                 )
             )
@@ -384,7 +357,7 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
         given()
             .body(
                 exceptionRecordCallbackRequest(
-                    null, "invalid-reference-type",
+                    "invalid-reference-type",
                     "search-case-reference",
                     CASE_TYPE_EXCEPTION_RECORD
                 )
@@ -401,7 +374,6 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
         given()
             .body(
                 exceptionRecordCallbackRequest(
-                    null,
                     CASE_REFERENCE_TYPE_CCD,
                     "invalid-ccd-reference",
                     CASE_TYPE_EXCEPTION_RECORD
@@ -606,18 +578,16 @@ class AttachExceptionRecordToExistingCaseTest extends AttachExceptionRecordTestB
             .build();
     }
 
-    private CallbackRequest attachToCaseRequest(String attachToCaseReference) {
-        return attachToCaseRequest(attachToCaseReference, null, null, EXCEPTION_RECORD_DOC);
+    private CallbackRequest attachToCaseRequest(String searchCaseReference) {
+        return attachToCaseRequest(null, searchCaseReference, EXCEPTION_RECORD_DOC);
     }
 
     private CallbackRequest attachToCaseRequest(
-        String attachToCaseReference,
         String searchCaseReferenceType,
         String searchCaseReference,
         Map<String, Object> document
     ) {
         return exceptionRecordCallbackRequest(
-            attachToCaseReference,
             searchCaseReferenceType,
             searchCaseReference,
             CASE_TYPE_EXCEPTION_RECORD,

--- a/src/integrationTest/resources/ccd/callback/attach/request/valid-supplementary-evidence-with-ocr.json
+++ b/src/integrationTest/resources/ccd/callback/attach/request/valid-supplementary-evidence-with-ocr.json
@@ -15,7 +15,7 @@
       "formType": "B123",
       "deliveryDate": "2018-01-02T12:34:56.123Z",
       "openingDate": "2018-01-03T12:34:56.123Z",
-      "attachToCaseReference": "1539007368674134",
+      "searchCaseReference": "1539007368674134",
       "scannedDocuments": [
         {
           "value": {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseReferenceValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseReferenceValidator.java
@@ -14,7 +14,6 @@ import static io.vavr.control.Validation.invalid;
 import static java.lang.String.format;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes.CCD_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.CaseReferenceTypes.EXTERNAL_CASE_REFERENCE;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.ATTACH_TO_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SEARCH_CASE_REFERENCE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SEARCH_CASE_REFERENCE_TYPE;
 
@@ -26,17 +25,10 @@ class CaseReferenceValidator {
     );
 
     @Nonnull
-    Validation<String, String> validateAttachToCaseReference(CaseDetails theCase) {
-        return getCaseRef(theCase, ATTACH_TO_CASE_REFERENCE)
-            .map(this::validateCcdCaseRef)
-            .orElseGet(() -> invalid("No case reference supplied"));
-    }
-
-    @Nonnull
     Validation<String, String> validateTargetCaseReference(CaseDetails theCase) {
         return getCaseRef(theCase, SEARCH_CASE_REFERENCE)
             .map(this::validateCcdCaseRef)
-            .orElse(validateAttachToCaseReference(theCase));
+            .orElseGet(() -> invalid("No case reference supplied"));
     }
 
     @Nonnull

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CallbackValidationsTest.java
@@ -19,7 +19,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.TestCaseBuilder.caseWithAttachReference;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.TestCaseBuilder.caseWithAwaitingPaymentsAndClassification;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.TestCaseBuilder.caseWithCcdSearchCaseReference;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.TestCaseBuilder.caseWithDocument;
@@ -48,23 +47,19 @@ class CallbackValidationsTest {
     private static Object[][] attachToCaseReferenceTestParams() {
         String noReferenceSupplied = "No case reference supplied";
         return new Object[][]{
-            {"generic non number removal", caseWithAttachReference("£1234234393"), true, "1234234393"},
-            {"- removal", caseWithAttachReference("1234-234-393"), true, "1234234393"},
-            {"space removal", caseWithAttachReference("1234 234 393"), true, "1234234393"},
-            {"prefix and post fix spaces removal", caseWithAttachReference("  AH 234 393 "), true, "234393"},
-            {"No numbers supplied", caseWithAttachReference("#"), false, "Invalid case reference: '#'"},
-            {"empty string", caseWithAttachReference(""), false, "Invalid case reference: ''"},
+            {"generic non number removal", caseWithTargetReference("£1234234393"), true, "1234234393"},
+            {"- removal", caseWithTargetReference("1234-234-393"), true, "1234234393"},
+            {"space removal", caseWithTargetReference("1234 234 393"), true, "1234234393"},
+            {"prefix and post fix spaces removal", caseWithTargetReference("  AH 234 393 "), true, "234393"},
+            {"No numbers supplied", caseWithTargetReference("#"), false, "Invalid case reference: '#'"},
+            {"empty string", caseWithTargetReference(""), false, "Invalid case reference: ''"},
             {"null case details", null, false, noReferenceSupplied},
             {"null data", createCaseWith(b -> b.data(null)), false, noReferenceSupplied},
             {"empty data", createCaseWith(b -> b.data(ImmutableMap.of())), false, noReferenceSupplied},
-            {"null case reference", caseWithAttachReference(null), false, noReferenceSupplied},
-            {"invalid type List", caseWithAttachReference(ImmutableList.of()), false, "Invalid case reference: '[]'"},
-            {"invalid type Integer", caseWithAttachReference(5), false, "Invalid case reference: '5'"},
-            {"valid search case reference", caseWithTargetReference(null, "1234 234 393"), true, "1234234393"},
-            {"both search case reference and attach to case reference are null", caseWithTargetReference(null, null), false, "No case reference supplied"},
-            {"valid attach to case reference", caseWithTargetReference("1234 234 393", null), true, "1234234393"},
-            {"invalid search case ref and attach to case ref null", caseWithTargetReference(null, 56), false, "Invalid case reference: '56'"},
-            {"ignore attach to case ref when search case ref exists", caseWithTargetReference(56, "1234234393"), true, "1234234393"},
+            {"null case reference", caseWithTargetReference(null), false, noReferenceSupplied},
+            {"invalid type List", caseWithTargetReference(ImmutableList.of()), false, "Invalid case reference: '[]'"},
+            {"invalid type Integer", caseWithTargetReference(5), false, "Invalid case reference: '5'"},
+            {"valid search case reference", caseWithTargetReference("1234 234 393"), true, "1234234393"},
         };
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/TestCaseBuilder.java
@@ -27,9 +27,8 @@ class TestCaseBuilder {
         return createCaseWith(b -> b.data(data));
     }
 
-    static CaseDetails caseWithTargetReference(Object attachToCaseReference, Object searchCaseReference) {
+    static CaseDetails caseWithTargetReference(Object searchCaseReference) {
         Map<String, Object> data = new HashMap<>();
-        data.put("attachToCaseReference", attachToCaseReference);
         data.put("searchCaseReference", searchCaseReference);
         return createCaseWith(b -> b.data(data));
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1275


### Change description ###
When attaching the Exception Record to the case, the Callback request contains the target case reference value set to `searchCaseReference` field. So, `attachToCaseReference` field call back request validation is no longer required. 

We still validation to check if Exception Record is already attached (using `attachToCasereference` field).

- Removed validation on `attachToCaseReference` field. 
- Updated tests to set target case reference to `searchCaseReference` field 
- Removed no longer valid tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
