### PR TITLE
Review CCD Api usage: case updater exception catches for submit

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -166,6 +166,10 @@ public class CcdCaseUpdater {
 
             log.error(msg, exception);
 
+            // Returning `ProcessResult` vs `CallbackException` is different
+            // Before combining start/submit events to CCD API it was handled differently
+            // To keep same outcome - trying to recognise which is which hence the `isStartEvent` param
+            // Can be reviewed separately once all this is nicely gone out of the game from here
             if (!isStartEvent) {
                 return new ProcessResult(emptyList(), singletonList(msg));
             } else {
@@ -200,6 +204,10 @@ public class CcdCaseUpdater {
 
             ClientServiceErrorResponse errorResponse = new ClientServiceErrorResponse(singletonList(msg), emptyList());
 
+            // Returning `ProcessResult` vs `CallbackException` is different
+            // Before combining start/submit events to CCD API it was handled differently
+            // To keep same outcome - trying to recognise which is which hence the `isStartEvent` param
+            // Can be reviewed separately once all this is nicely gone out of the game from here
             if (isStartEvent) {
                 return new ProcessResult(errorResponse.warnings, errorResponse.errors);
             } else {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -291,29 +291,26 @@ public class CcdCaseUpdater {
         CaseDetails existingCase = startEvent.getCaseDetails();
 
         final CaseDataContent caseDataContent = getCaseDataContent(exceptionRecord, caseUpdateDetails, startEvent);
-        try {
-            coreCaseDataApi.submitEventForCaseWorker(
-                idamToken,
-                s2sToken,
-                userId,
-                exceptionRecord.poBoxJurisdiction,
-                startEvent.getCaseDetails().getCaseTypeId(),
-                existingCaseId,
-                ignoreWarnings,
-                caseDataContent
-            );
 
-            log.info(
-                "Successfully updated case for service {} "
-                    + "with case Id {} "
-                    + "based on exception record ref {}",
-                service,
-                existingCase.getId(),
-                exceptionRecord.id
-            );
-        } catch (FeignException.Conflict | FeignException.UnprocessableEntity exception) {
-            throw exception;
-        }
+        coreCaseDataApi.submitEventForCaseWorker(
+            idamToken,
+            s2sToken,
+            userId,
+            exceptionRecord.poBoxJurisdiction,
+            startEvent.getCaseDetails().getCaseTypeId(),
+            existingCaseId,
+            ignoreWarnings,
+            caseDataContent
+        );
+
+        log.info(
+            "Successfully updated case for service {} "
+                + "with case Id {} "
+                + "based on exception record ref {}",
+            service,
+            existingCase.getId(),
+            exceptionRecord.id
+        );
     }
 
     private CaseDataContent getCaseDataContent(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -318,11 +318,11 @@ class CcdCaseUpdaterTest {
         );
 
         // then
-        assertThat(res.getWarnings()).containsExactlyInAnyOrder(
+        assertThat(res.getErrors()).containsExactlyInAnyOrder(
             "Failed to update case for Service service with case Id existing_case_id based on exception record 1"
                 + " - CCD could not process request"
         );
-        assertThat(res.getErrors()).isEmpty();
+        assertThat(res.getWarnings()).isEmpty();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -281,8 +281,8 @@ class CcdCaseUpdaterTest {
         // then
         assertThat(callbackException.getMessage())
             .isEqualTo("Failed to update case for Service service with case Id existing_case_id "
-                + "based on exception record 1");
-        assertThat(callbackException.getCause().getMessage()).isEqualTo("Service response: Body");
+                + "based on exception record 1. Service response: Body");
+        assertThat(callbackException.getCause().getMessage()).isEqualTo("Msg");
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Orchestrator: refactor CcdCaseUpdater and its surroundings](https://tools.hmcts.net/jira/browse/BPS-1074)

### Change description ###

#### BEFORE:

2 sets of try/catch blocks related to ccd/feign client: start event and submit event. latter one has tiny behavioural amendment

#### AFTER:

1 set of try/catch block. squashed needed amendments into individual catch statements

#### Goal

Ability to combine ccd client calls into one. In some way like #1030 and #1031 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
