### PR TITLE
Replace direct usage of feign client to built-in ccd api

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
@@ -107,8 +107,11 @@ class CreateCaseTest {
         // the same case is returned
         assertThat(caseCcdId2).isEqualTo(caseCcdId);
         List<Long> caseIds2 = ccdApi.getCaseRefsByBulkScanCaseReference(bulkScanCaseReference, "bulkscan");
-        assertThat(caseIds2.size()).isEqualTo(1);
-        assertThat(caseIds2.get(0)).isEqualTo(createdCase.getId());
+        assertThat(caseIds2)
+            .as("Should return same case for '%s' bulkscan case", bulkScanCaseReference)
+            .hasSize(1)
+            .first()
+            .isEqualTo(createdCase.getId());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.HttpClientErrorException;
@@ -17,12 +18,12 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CreateCaseResult;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.YesNoFieldValues;
-import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 import static java.time.LocalDateTime.now;
 import static java.util.Collections.emptyList;
@@ -30,12 +31,12 @@ import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.EXCEPTION;
 
@@ -58,7 +59,7 @@ class CcdNewCaseCreatorTest {
     private AuthTokenGenerator s2sTokenGenerator;
 
     @Mock
-    private CoreCaseDataApi coreCaseDataApi;
+    private CcdApi ccdApi;
 
     private CcdNewCaseCreator ccdNewCaseCreator;
 
@@ -71,13 +72,15 @@ class CcdNewCaseCreatorTest {
             transformationClient,
             serviceResponseParser,
             s2sTokenGenerator,
-            coreCaseDataApi
+            ccdApi
         );
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void should_return_new_case_id_when_successfully_executed_all_the_steps() {
         // given
+        given(s2sTokenGenerator.generate()).willReturn(randomUUID().toString());
         given(transformationClient.transformExceptionRecord(any(), any(), any()))
             .willReturn(
                 new SuccessfulTransformationResponse(
@@ -92,14 +95,9 @@ class CcdNewCaseCreatorTest {
 
         StartEventResponse startCcdEventResp = mock(StartEventResponse.class);
 
-        given(coreCaseDataApi.startForCaseworker(any(), any(), any(), any(), any(), any()))
-            .willReturn(startCcdEventResp);
-
-        CaseDetails newCaseDetails = mock(CaseDetails.class);
-        doReturn(CASE_ID).when(newCaseDetails).getId();
-
-        given(coreCaseDataApi.submitForCaseworker(any(), any(), any(), any(), any(), anyBoolean(), any()))
-            .willReturn(newCaseDetails);
+        given(ccdApi.createNewCaseFromCallback(
+            anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any(), anyString()
+        )).willReturn(CASE_ID);
 
         ServiceConfigItem configItem = getConfigItem();
         ExceptionRecord exceptionRecord = getExceptionRecord();
@@ -117,6 +115,21 @@ class CcdNewCaseCreatorTest {
 
         // then
         assertThat(result.caseId).isEqualTo(CASE_ID);
+
+        // and
+        var caseDetailsBuilderCaptor = ArgumentCaptor.forClass(Function.class);
+        verify(ccdApi).createNewCaseFromCallback(
+            eq(IDAM_TOKEN),
+            anyString(),
+            eq(USER_ID),
+            eq(exceptionRecord.poBoxJurisdiction),
+            anyString(),
+            anyString(),
+            caseDetailsBuilderCaptor.capture(),
+            anyString()
+        );
+        assertThat(caseDetailsBuilderCaptor.getValue().apply(startCcdEventResp))
+            .isInstanceOf(CaseDataContent.class);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Orchestrator: refactor CcdCaseUpdater and its surroundings](https://tools.hmcts.net/jira/browse/BPS-1074)

### Change description ###

For new case creation callback the dependencies were farely split in the first place. But in order to unify all ccd interactions in one place it would be nice all elements do play their part. During this implementation this #1036 occurred. Raised as a helper PR. Now the leftovers

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
