### PR TITLE
Remove case details awareness in chain of method calls

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -122,9 +122,8 @@ public class AttachCaseCallbackService {
             log.warn("Validation error {}", eventIdClassificationValidationError);
             return Either.left(ErrorsAndWarnings.withErrors(singletonList(eventIdClassificationValidationError)));
         }
-        boolean useSearchCaseReference = isSearchCaseReferenceTypePresent(exceptionRecordDetails);
 
-        return getValidation(exceptionRecordDetails, useSearchCaseReference, requesterIdamToken, requesterUserId)
+        return getValidation(exceptionRecordDetails, requesterIdamToken, requesterUserId)
             .map(callBackEvent -> tryAttachToCase(callBackEvent, exceptionRecordDetails, ignoreWarnings))
             .map(attachCaseResult ->
                 attachCaseResult.map(modifiedFields ->
@@ -135,10 +134,12 @@ public class AttachCaseCallbackService {
 
     private Validation<Seq<String>, AttachToCaseEventData> getValidation(
         CaseDetails exceptionRecord,
-        boolean useSearchCaseReference,
         String requesterIdamToken,
         String requesterUserId
     ) {
+        boolean useSearchCaseReference = exceptionRecord.getData() != null
+            && exceptionRecord.getData().get(SEARCH_CASE_REFERENCE_TYPE) != null;
+
         Validation<String, String> caseReferenceTypeValidation = useSearchCaseReference
             ? hasSearchCaseReferenceType(exceptionRecord)
             : valid(CCD_CASE_REFERENCE);
@@ -533,11 +534,6 @@ public class AttachCaseCallbackService {
             getDocumentNumbers(exceptionDocuments),
             theCase.getId()
         );
-    }
-
-    private boolean isSearchCaseReferenceTypePresent(CaseDetails exceptionRecord) {
-        return exceptionRecord.getData() != null
-            && exceptionRecord.getData().get(SEARCH_CASE_REFERENCE_TYPE) != null;
     }
 
     private Map<String, Object> mergeCaseFields(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -259,7 +259,7 @@ public class AttachCaseCallbackService {
             log.error(
                 "Failed to send update to payment processor for {} exception record {}",
                 callBackEvent.exceptionRecordJurisdiction,
-                exceptionRecordDetails.getId(),
+                callBackEvent.exceptionRecordId,
                 exception
             );
             return Either.left(ErrorsAndWarnings.withErrors(singletonList(PAYMENT_ERROR_MSG)));
@@ -426,7 +426,7 @@ public class AttachCaseCallbackService {
 
             log.info(
                 "Attached Exception Record to a case in CCD. ER ID: {}. Case ID: {}",
-                exceptionRecordDetails.getId(),
+                callBackEvent.exceptionRecordId,
                 theCase.getId()
             );
         }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -540,46 +540,6 @@ public class AttachCaseCallbackService {
             && exceptionRecord.getData().get(SEARCH_CASE_REFERENCE_TYPE) != null;
     }
 
-    /**
-     * Information received in the callback call for the attach event.
-     */
-    private static class AttachToCaseEventData {
-        public final String exceptionRecordJurisdiction;
-        public final String service;
-        public final String targetCaseRef;
-        public final String targetCaseRefType;
-        public final Long exceptionRecordId;
-        public final List<Map<String, Object>> exceptionRecordDocuments;
-        public final String idamToken;
-        public final String userId;
-        public final Classification classification;
-        public final ExceptionRecord exceptionRecord;
-
-        public AttachToCaseEventData(
-            String exceptionRecordJurisdiction,
-            String service,
-            String targetCaseRefType,
-            String targetCaseRef,
-            Long exceptionRecordId,
-            List<Map<String, Object>> exceptionRecordDocuments,
-            String idamToken,
-            String userId,
-            Classification classification,
-            ExceptionRecord exceptionRecord
-        ) {
-            this.exceptionRecordJurisdiction = exceptionRecordJurisdiction;
-            this.service = service;
-            this.targetCaseRefType = targetCaseRefType;
-            this.targetCaseRef = targetCaseRef;
-            this.exceptionRecordId = exceptionRecordId;
-            this.exceptionRecordDocuments = exceptionRecordDocuments;
-            this.idamToken = idamToken;
-            this.userId = userId;
-            this.classification = classification;
-            this.exceptionRecord = exceptionRecord;
-        }
-    }
-
     private Map<String, Object> mergeCaseFields(
         Map<String, Object> originalFields,
         Map<String, Object> modifiedFields

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -444,7 +444,7 @@ public class AttachCaseCallbackService {
     ) {
         CaseDetails targetCase = ccdApi.getCase(targetCaseCcdRef, callBackEvent.exceptionRecordJurisdiction);
 
-        ServiceConfigItem serviceConfigItem = getServiceConfig(exceptionRecordDetails);
+        ServiceConfigItem serviceConfigItem = getServiceConfig(callBackEvent.service);
         ProcessResult processResult = ccdCaseUpdater.updateCase(
             callBackEvent.exceptionRecord,
             serviceConfigItem,
@@ -552,13 +552,9 @@ public class AttachCaseCallbackService {
         return merged;
     }
 
-    private ServiceConfigItem getServiceConfig(CaseDetails caseDetails) {
-        return hasServiceNameInCaseTypeId(caseDetails).flatMap(service -> Try
-            .of(() -> serviceConfigProvider.getConfig(service))
-            .toValidation()
-            .mapError(Throwable::getMessage)
-        )
+    private ServiceConfigItem getServiceConfig(String service) {
+        return Try.of(() -> serviceConfigProvider.getConfig(service))
             .filter(item -> !Strings.isNullOrEmpty(item.getUpdateUrl()))
-            .getOrElseThrow(() -> new CallbackException("Update URL is not configured")).get();
+            .getOrElseThrow(() -> new CallbackException("Update URL is not configured"));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseEventData.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseEventData.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Information received in the callback call for the attach event.
+ */
+class AttachToCaseEventData {
+    public final String exceptionRecordJurisdiction;
+    public final String service;
+    public final String targetCaseRef;
+    public final String targetCaseRefType;
+    public final Long exceptionRecordId;
+    public final List<Map<String, Object>> exceptionRecordDocuments;
+    public final String idamToken;
+    public final String userId;
+    public final Classification classification;
+    public final ExceptionRecord exceptionRecord;
+
+    public AttachToCaseEventData(
+        String exceptionRecordJurisdiction,
+        String service,
+        String targetCaseRefType,
+        String targetCaseRef,
+        Long exceptionRecordId,
+        List<Map<String, Object>> exceptionRecordDocuments,
+        String idamToken,
+        String userId,
+        Classification classification,
+        ExceptionRecord exceptionRecord
+    ) {
+        this.exceptionRecordJurisdiction = exceptionRecordJurisdiction;
+        this.service = service;
+        this.targetCaseRefType = targetCaseRefType;
+        this.targetCaseRef = targetCaseRef;
+        this.exceptionRecordId = exceptionRecordId;
+        this.exceptionRecordDocuments = exceptionRecordDocuments;
+        this.idamToken = idamToken;
+        this.userId = userId;
+        this.classification = classification;
+        this.exceptionRecord = exceptionRecord;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -157,7 +157,7 @@ public class CcdCaseUpdater {
                 return new ProcessResult(
                     exceptionRecordFinalizer.finalizeExceptionRecord(
                         existingCase.getData(),
-                        existingCase.getId(),
+                        Long.toString(existingCase.getId()),
                         CcdCallbackType.ATTACHING_SUPPLEMENTARY_EVIDENCE
                     )
                 );

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -195,7 +195,7 @@ public class CreateCaseCallbackService {
                 return tryPublishPaymentMessageAndFinalise(
                     configItem.getService(),
                     exceptionRecordData,
-                    result.caseId
+                    Long.toString(result.caseId)
                 );
             }
         }
@@ -204,7 +204,7 @@ public class CreateCaseCallbackService {
     private ProcessResult tryPublishPaymentMessageAndFinalise(
         String serviceName,
         CaseDetails exceptionRecordData,
-        long caseId
+        String caseId
     ) {
         try {
             paymentsProcessor.updatePayments(exceptionRecordData, caseId);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/ExceptionRecordFinalizer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/ExceptionRecordFinalizer.java
@@ -20,12 +20,12 @@ public class ExceptionRecordFinalizer {
 
     public Map<String, Object> finalizeExceptionRecord(
         Map<String, Object> originalFields,
-        Long caseReference,
+        String caseReference,
         CcdCallbackType callbackType
     ) {
         Map<String, Object> fieldsToUpdate =
             ImmutableMap.<String, Object>builder()
-                .put(getCaseReferenceFieldName(callbackType), Long.toString(caseReference))
+                .put(getCaseReferenceFieldName(callbackType), caseReference)
                 .put(DISPLAY_WARNINGS, YesNoFieldValues.NO)
                 .put(OCR_DATA_VALIDATION_WARNINGS, emptyList())
                 .build();

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessor.java
@@ -52,7 +52,7 @@ public class PaymentsProcessor {
         }
     }
 
-    public void updatePayments(CaseDetails exceptionRecord, long newCaseId) {
+    public void updatePayments(CaseDetails exceptionRecord, String newCaseId) {
         boolean containsPayments =
             Objects.equals(
                 exceptionRecord.getData().get(ExceptionRecordFields.CONTAINS_PAYMENTS),
@@ -69,7 +69,7 @@ public class PaymentsProcessor {
             paymentsPublisher.send(
                 new UpdatePaymentsCommand(
                     Long.toString(exceptionRecord.getId()),
-                    Long.toString(newCaseId),
+                    newCaseId,
                     envelopeId,
                     jurisdiction
                 )

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackServiceTest.java
@@ -28,6 +28,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -119,6 +120,7 @@ class AttachCaseCallbackServiceTest {
     @Test
     void process_should_process_supplementary_evidence_with_ocr() {
         // given
+        given(exceptionRecordValidator.mandatoryPrerequisites(any())).willReturn(Validation.valid(null));
         given(ccdCaseUpdater.updateCase(
             exceptionRecord, configItem, true, IDAM_TOKEN, USER_ID, EXISTING_CASE_ID, EXISTING_CASE_TYPE
         )).willReturn(new ProcessResult(emptyMap()));
@@ -136,12 +138,13 @@ class AttachCaseCallbackServiceTest {
         assertThat(res.isRight()).isTrue();
         verify(ccdCaseUpdater)
             .updateCase(exceptionRecord, configItem, true, IDAM_TOKEN, USER_ID, EXISTING_CASE_ID, EXISTING_CASE_TYPE);
-        verify(paymentsProcessor).updatePayments(CASE_DETAILS, Long.parseLong(EXISTING_CASE_ID));
+        verify(paymentsProcessor).updatePayments(CASE_DETAILS, EXISTING_CASE_ID);
     }
 
     @Test
     void process_should_not_update_case_if_error_occurs() {
         // given
+        given(exceptionRecordValidator.mandatoryPrerequisites(any())).willReturn(Validation.valid(null));
         given(ccdCaseUpdater.updateCase(
             exceptionRecord, configItem, true, IDAM_TOKEN, USER_ID, EXISTING_CASE_ID, EXISTING_CASE_TYPE
         )).willReturn(new ProcessResult(asList("warning1"), asList("error1")));

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -43,7 +43,6 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -125,7 +124,8 @@ class CcdCaseUpdaterTest {
         initResponseMockData();
         initMockData();
         prepareMockForSubmissionEventForCaseWorker().willReturn(CaseDetails.builder().id(1L).build());
-        given(exceptionRecordFinalizer.finalizeExceptionRecord(anyMap(), anyLong(), any())).willReturn(originalFields);
+        given(exceptionRecordFinalizer.finalizeExceptionRecord(anyMap(), anyString(), any()))
+            .willReturn(originalFields);
 
         // when
         ProcessResult res = ccdCaseUpdater.updateCase(
@@ -153,7 +153,8 @@ class CcdCaseUpdaterTest {
         initResponseMockData();
         initMockData();
         prepareMockForSubmissionEventForCaseWorker().willReturn(CaseDetails.builder().id(1L).build());
-        given(exceptionRecordFinalizer.finalizeExceptionRecord(anyMap(), anyLong(), any())).willReturn(originalFields);
+        given(exceptionRecordFinalizer.finalizeExceptionRecord(anyMap(), anyString(), any()))
+            .willReturn(originalFields);
 
         // when
         ProcessResult res = ccdCaseUpdater.updateCase(
@@ -206,7 +207,8 @@ class CcdCaseUpdaterTest {
         initResponseMockData();
         initMockData();
         prepareMockForSubmissionEventForCaseWorker().willReturn(CaseDetails.builder().id(1L).build());
-        given(exceptionRecordFinalizer.finalizeExceptionRecord(anyMap(), anyLong(), any())).willReturn(originalFields);
+        given(exceptionRecordFinalizer.finalizeExceptionRecord(anyMap(), anyString(), any()))
+            .willReturn(originalFields);
 
         // when
         ProcessResult res = ccdCaseUpdater.updateCase(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -34,7 +34,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -57,7 +56,7 @@ class CreateCaseCallbackServiceTest {
     private static final String IDAM_TOKEN = "idam-token";
     private static final String USER_ID = "user-id";
     private static final String SERVICE = "service";
-    private static final long CASE_ID = 123;
+    private static final String CASE_ID = "123";
     private static final String CASE_TYPE_ID = SERVICE + "_ExceptionRecord";
     private static final ExceptionRecordValidator VALIDATOR = new ExceptionRecordValidator();
 
@@ -105,7 +104,7 @@ class CreateCaseCallbackServiceTest {
         assertThat(callbackException).hasMessage("The some event event is not supported. Please contact service team");
 
         verify(serviceConfigProvider, never()).getConfig(anyString());
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -127,7 +126,7 @@ class CreateCaseCallbackServiceTest {
         assertThat(callbackException).hasMessage("No case type ID supplied");
 
         verify(serviceConfigProvider, never()).getConfig(anyString());
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -150,7 +149,7 @@ class CreateCaseCallbackServiceTest {
         assertThat(callbackException).hasMessage("Case type ID () has invalid format");
 
         verify(serviceConfigProvider, never()).getConfig(anyString());
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -173,7 +172,7 @@ class CreateCaseCallbackServiceTest {
         assertThat(callbackException.getCause()).isNull();
         assertThat(callbackException).hasMessage("oh no");
 
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -196,7 +195,7 @@ class CreateCaseCallbackServiceTest {
         assertThat(callbackException.getCause()).isNull();
         assertThat(callbackException).hasMessage("Transformation URL is not configured");
 
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -205,7 +204,7 @@ class CreateCaseCallbackServiceTest {
         setUpTransformationUrl();
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
-            .id(CASE_ID)
+            .id(Long.valueOf(CASE_ID))
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
         );
@@ -231,7 +230,7 @@ class CreateCaseCallbackServiceTest {
         setUpTransformationUrl();
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
-            .id(CASE_ID)
+            .id(Long.valueOf(CASE_ID))
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
         );
@@ -282,7 +281,7 @@ class CreateCaseCallbackServiceTest {
             )
         );
 
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -310,7 +309,7 @@ class CreateCaseCallbackServiceTest {
             )
         );
 
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -318,11 +317,11 @@ class CreateCaseCallbackServiceTest {
         // given
         setUpTransformationUrl();
 
-        when(ccdApi.getCaseRefsByBulkScanCaseReference(Long.toString(CASE_ID), null))
+        when(ccdApi.getCaseRefsByBulkScanCaseReference(CASE_ID, null))
             .thenReturn(asList(345L));
         Map<String, Object> caseData = basicCaseData();
         Map<String, Object> finalizedCaseData = new HashMap<>();
-        when(exceptionRecordFinalizer.finalizeExceptionRecord(caseData, 345L, CASE_CREATION))
+        when(exceptionRecordFinalizer.finalizeExceptionRecord(caseData, "345", CASE_CREATION))
             .thenReturn(finalizedCaseData);
 
         // when
@@ -337,14 +336,14 @@ class CreateCaseCallbackServiceTest {
         assertThat(result.getWarnings()).isEmpty();
         assertThat(result.getErrors()).isEmpty();
 
-        verify(exceptionRecordFinalizer).finalizeExceptionRecord(caseData, 345L, CASE_CREATION);
+        verify(exceptionRecordFinalizer).finalizeExceptionRecord(caseData, "345", CASE_CREATION);
     }
 
     @Test
     void should_return_error_if_multiple_cases_exist_in_ccd_for_a_given_exception_record() throws Exception {
         setUpTransformationUrl();
 
-        when(ccdApi.getCaseRefsByBulkScanCaseReference(Long.toString(CASE_ID), null))
+        when(ccdApi.getCaseRefsByBulkScanCaseReference(CASE_ID, null))
             .thenReturn(asList(345L, 456L));
 
         assertThatThrownBy(
@@ -357,7 +356,7 @@ class CreateCaseCallbackServiceTest {
             .isInstanceOf(MultipleCasesFoundException.class)
             .hasMessage("Multiple cases (345, 456) found for the given bulk scan case reference: 123");
 
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -381,7 +380,7 @@ class CreateCaseCallbackServiceTest {
         assertThat(result.getWarnings()).isEmpty();
         assertThat(result.getErrors()).containsOnly("Missing journeyClassification");
 
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -405,7 +404,7 @@ class CreateCaseCallbackServiceTest {
             "Invalid journeyClassification. Error: No enum constant " + Classification.class.getName() + ".EXCEPTIONS"
         );
 
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -436,7 +435,7 @@ class CreateCaseCallbackServiceTest {
         data.put("scanOCRData", TestCaseBuilder.ocrDataEntry("key", "value"));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
-            .id(CASE_ID)
+            .id(Long.valueOf(CASE_ID))
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)
@@ -453,7 +452,7 @@ class CreateCaseCallbackServiceTest {
             "Invalid scannedDocuments format. Error: No enum constant " + DocumentType.class.getName() + ".OTHERS"
         );
 
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -489,7 +488,7 @@ class CreateCaseCallbackServiceTest {
         ))));
 
         CaseDetails caseDetails = TestCaseBuilder.createCaseWith(builder -> builder
-            .id(CASE_ID)
+            .id(Long.valueOf(CASE_ID))
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)
@@ -510,7 +509,7 @@ class CreateCaseCallbackServiceTest {
             .asString()
             .matches(match);
 
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -538,7 +537,7 @@ class CreateCaseCallbackServiceTest {
             .asString()
             .matches(match);
 
-        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyLong(), any());
+        verify(exceptionRecordFinalizer, never()).finalizeExceptionRecord(anyMap(), anyString(), any());
     }
 
     @Test
@@ -635,7 +634,7 @@ class CreateCaseCallbackServiceTest {
         // then
         assertThat(result.getErrors()).isEmpty();
         assertThat(result.getWarnings()).isEmpty();
-        verify(paymentsProcessor).updatePayments(any(), eq(newCaseId));
+        verify(paymentsProcessor).updatePayments(any(), eq(Long.toString(newCaseId)));
     }
 
     @Test
@@ -655,7 +654,8 @@ class CreateCaseCallbackServiceTest {
             anyString()
         )).willReturn(new CreateCaseResult(newCaseId));
 
-        willThrow(PaymentsPublishingException.class).given(paymentsProcessor).updatePayments(any(), eq(newCaseId));
+        willThrow(PaymentsPublishingException.class).given(paymentsProcessor)
+            .updatePayments(any(), eq(Long.toString(newCaseId)));
 
         // when
         ProcessResult result =
@@ -702,7 +702,7 @@ class CreateCaseCallbackServiceTest {
 
     private CaseDetails caseDetails(Map<String, Object> data) {
         return TestCaseBuilder.createCaseWith(builder -> builder
-            .id(CASE_ID)
+            .id(Long.valueOf(CASE_ID))
             .caseTypeId(CASE_TYPE_ID)
             .jurisdiction("some jurisdiction")
             .data(data)

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/ExceptionRecordFinalizerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/ExceptionRecordFinalizerTest.java
@@ -14,7 +14,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.
 
 class ExceptionRecordFinalizerTest {
 
-    private static final long CASE_ID = 100L;
+    private static final String CASE_ID = "100";
     private static final String FIELD_1 = "field1";
 
     public static final String FIELD_CASE_REFERENCE = "caseReference";
@@ -51,7 +51,7 @@ class ExceptionRecordFinalizerTest {
         );
 
         assertThat(res.get("field1")).isEqualTo("value1");
-        assertThat(res.get(FIELD_CASE_REFERENCE)).isEqualTo(Long.toString(CASE_ID));
+        assertThat(res.get(FIELD_CASE_REFERENCE)).isEqualTo(CASE_ID);
         assertThat(res.get(FIELD_DISPLAY_WARNINGS)).isEqualTo(NO);
         assertThat(res.get(FIELD_OCR_DATA_VALIDATION_WARNINGS)).isEqualTo(emptyList());
     }
@@ -80,7 +80,7 @@ class ExceptionRecordFinalizerTest {
         );
         assertThat(res.get("field1")).isEqualTo("value1");
         assertThat(res.get("field2")).isEqualTo(null);
-        assertThat(res.get(FIELD_CASE_REFERENCE)).isEqualTo(Long.toString(CASE_ID));
+        assertThat(res.get(FIELD_CASE_REFERENCE)).isEqualTo(CASE_ID);
         assertThat(res.get(FIELD_DISPLAY_WARNINGS)).isEqualTo(NO);
         assertThat(res.get(FIELD_OCR_DATA_VALIDATION_WARNINGS)).isEqualTo(emptyList());
     }
@@ -110,7 +110,7 @@ class ExceptionRecordFinalizerTest {
         );
 
         assertThat(res.get("field1")).isEqualTo("value1");
-        assertThat(res.get(FIELD_CASE_REFERENCE)).isEqualTo(Long.toString(CASE_ID));
+        assertThat(res.get(FIELD_CASE_REFERENCE)).isEqualTo(CASE_ID);
         assertThat(res.get(FIELD_DISPLAY_WARNINGS)).isEqualTo(NO);
         assertThat(res.get(FIELD_OCR_DATA_VALIDATION_WARNINGS)).isEqualTo(emptyList());
     }
@@ -128,7 +128,7 @@ class ExceptionRecordFinalizerTest {
         );
 
         // then
-        assertThat(res.get(FIELD_CASE_REFERENCE)).isEqualTo(Long.toString(CASE_ID));
+        assertThat(res.get(FIELD_CASE_REFERENCE)).isEqualTo(CASE_ID);
         assertThat(res).doesNotContainKeys(FIELD_ATTACH_TO_CASE_REFERENCE);
     }
 
@@ -145,7 +145,7 @@ class ExceptionRecordFinalizerTest {
         );
 
         // then
-        assertThat(res.get(FIELD_ATTACH_TO_CASE_REFERENCE)).isEqualTo(Long.toString(CASE_ID));
+        assertThat(res.get(FIELD_ATTACH_TO_CASE_REFERENCE)).isEqualTo(CASE_ID);
         assertThat(res).doesNotContainKeys(FIELD_CASE_REFERENCE);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessorTest.java
@@ -31,8 +31,8 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.doma
 class PaymentsProcessorTest {
     private static final long CCD_REFERENCE = 20L;
     private static final String SERVICE = "service";
-    private static final long CASE_ID = 123;
-    private static final long NEW_CASE_ID = 1L;
+    private static final String CASE_ID = "123";
+    private static final String NEW_CASE_ID = "1";
     private static final String CASE_TYPE_ID = SERVICE + "_ExceptionRecord";
 
     @Mock
@@ -127,7 +127,7 @@ class PaymentsProcessorTest {
         CaseDetails caseDetails =
             TestCaseBuilder
                 .createCaseWith(builder -> builder
-                    .id(CASE_ID)
+                    .id(Long.valueOf(CASE_ID))
                     .caseTypeId(CASE_TYPE_ID)
                     .jurisdiction("some jurisdiction")
                     .data(data)
@@ -139,8 +139,8 @@ class PaymentsProcessorTest {
         // then
         ArgumentCaptor<UpdatePaymentsCommand> cmd = ArgumentCaptor.forClass(UpdatePaymentsCommand.class);
         verify(paymentsPublisher).send(cmd.capture());
-        assertThat(cmd.getValue().exceptionRecordRef).isEqualTo(Long.toString(CASE_ID));
-        assertThat(cmd.getValue().newCaseRef).isEqualTo(Long.toString(NEW_CASE_ID));
+        assertThat(cmd.getValue().exceptionRecordRef).isEqualTo(CASE_ID);
+        assertThat(cmd.getValue().newCaseRef).isEqualTo(NEW_CASE_ID);
         assertThat(cmd.getValue().envelopeId).isEqualTo(envelopeId);
         assertThat(cmd.getValue().jurisdiction).isEqualTo(jurisdiction);
     }
@@ -167,7 +167,7 @@ class PaymentsProcessorTest {
         CaseDetails caseDetails =
             TestCaseBuilder
                 .createCaseWith(builder -> builder
-                    .id(CASE_ID)
+                    .id(Long.valueOf(CASE_ID))
                     .caseTypeId(CASE_TYPE_ID)
                     .jurisdiction("some jurisdiction")
                     .data(data)
@@ -175,7 +175,7 @@ class PaymentsProcessorTest {
 
 
         // when
-        paymentsProcessor.updatePayments(caseDetails, 1L);
+        paymentsProcessor.updatePayments(caseDetails, NEW_CASE_ID);
 
         // then
         verify(paymentsPublisher, never()).send(any());


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Orchestrator: refactor CcdCaseUpdater and its surroundings](https://tools.hmcts.net/jira/browse/BPS-1074)

### Change description ###

Through the day I tried to pick a place where to do some refactoring but everything is so much tangled up. Ended up in technological bottleneck.

At first I started shifting around related stuff (private class and more). But reverted the whole thing as got really confused. Moving out private class though serves as a bonus here.

The rest is looking around what can be re-used, reduced in jumping around for logical sequential tracking

Goal, which might not yet be completed, - get rid of nesting around case details as we already parse/validate it significantly as an initial member of method chains. This is mostly visible within the last 2 commits - move call to payments higher in the method chain as those looked like last things to execute without causing any side-affects. ~didn't move too far - would like to see how this change goes and then take another stab in all this~

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
