### PR TITLE
Move verification further up

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -229,6 +229,11 @@ public class AttachCaseCallbackService {
         boolean ignoreWarnings
     ) {
         try {
+            verifyExceptionRecordIsNotAttachedToCase(
+                callBackEvent.exceptionRecordJurisdiction,
+                callBackEvent.exceptionRecordId
+            );
+
             log.info(
                 "Attaching exception record '{}' to a case by reference type '{}' and reference '{}'",
                 callBackEvent.exceptionRecordId,
@@ -385,11 +390,6 @@ public class AttachCaseCallbackService {
         String targetCaseCcdRef,
         CaseDetails exceptionRecordDetails
     ) {
-        verifyExceptionRecordIsNotAttachedToCase(
-            callBackEvent.exceptionRecordJurisdiction,
-            callBackEvent.exceptionRecordId
-        );
-
         CaseDetails theCase = ccdApi.getCase(targetCaseCcdRef, callBackEvent.exceptionRecordJurisdiction);
         List<Map<String, Object>> targetCaseDocuments = getScannedDocuments(theCase);
 
@@ -442,12 +442,6 @@ public class AttachCaseCallbackService {
         CaseDetails exceptionRecordDetails,
         boolean ignoreWarnings
     ) {
-
-        verifyExceptionRecordIsNotAttachedToCase(
-            callBackEvent.exceptionRecordJurisdiction,
-            callBackEvent.exceptionRecordId
-        );
-
         CaseDetails targetCase = ccdApi.getCase(targetCaseCcdRef, callBackEvent.exceptionRecordJurisdiction);
 
         ServiceConfigItem serviceConfigItem = getServiceConfig(exceptionRecordDetails);


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Orchestrator: refactor CcdCaseUpdater and its surroundings](https://tools.hmcts.net/jira/browse/BPS-1074)

### Change description ###

2 things:

- causing duplicate method call signature
- we can fail fast here before even beginning to try to attach case. verification throws exception which we catch and translate to error

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
