### PR TITLE
Review legacy id prefilter

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -286,7 +286,7 @@ public class AttachCaseCallbackService {
         boolean ignoreWarnings
     ) {
         String targetCaseRef = EXTERNAL_CASE_REFERENCE.equals(callBackEvent.targetCaseRefType)
-            ? attachCaseByLegacyId(callBackEvent, ignoreWarnings)
+            ? getTargetCaseRefFromLegacyId(callBackEvent, ignoreWarnings)
             : callBackEvent.targetCaseRef;
 
         return attachCaseByCcdId(callBackEvent, targetCaseRef, ignoreWarnings)
@@ -302,7 +302,7 @@ public class AttachCaseCallbackService {
             });
     }
 
-    private String attachCaseByLegacyId(
+    private String getTargetCaseRefFromLegacyId(
         AttachToCaseEventData callBackEvent,
         boolean ignoreWarnings
     ) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -309,7 +309,20 @@ public class AttachCaseCallbackService {
     private String getTargetCaseRefFromLegacyId(String targetCaseRef, String service, long exceptionRecordId) {
         List<Long> targetCaseCcdIds = ccdApi.getCaseRefsByLegacyId(targetCaseRef, service);
 
-        if (targetCaseCcdIds.size() > 1) {
+        if (targetCaseCcdIds.size() == 1) {
+            log.info(
+                "Found case with CCD ID '{}' for legacy ID '{}' (attaching exception record '{}')",
+                targetCaseCcdIds.get(0),
+                targetCaseRef,
+                exceptionRecordId
+            );
+
+            return Long.toString(targetCaseCcdIds.get(0));
+        } else if (targetCaseCcdIds.isEmpty()) {
+            throw new CaseNotFoundException(
+                String.format("No case found for legacy case reference %s", targetCaseRef)
+            );
+        } else {
             throw new MultipleCasesFoundException(
                 String.format(
                     "Multiple cases (%s) found for the given legacy case reference: %s",
@@ -317,25 +330,6 @@ public class AttachCaseCallbackService {
                     targetCaseRef
                 )
             );
-        } else {
-            return targetCaseCcdIds
-                .stream()
-                .findFirst()
-                .map(
-                    targetCaseCcdId -> {
-                        log.info(
-                            "Found case with CCD ID '{}' for legacy ID '{}' (attaching exception record '{}')",
-                            targetCaseCcdId,
-                            targetCaseRef,
-                            exceptionRecordId
-                        );
-
-                        return Long.toString(targetCaseCcdId);
-                    }
-                )
-                .orElseThrow(() -> new CaseNotFoundException(
-                    String.format("No case found for legacy case reference %s", targetCaseRef)
-                ));
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -286,7 +286,7 @@ public class AttachCaseCallbackService {
         boolean ignoreWarnings
     ) {
         String targetCaseRef = EXTERNAL_CASE_REFERENCE.equals(callBackEvent.targetCaseRefType)
-            ? getTargetCaseRefFromLegacyId(callBackEvent, ignoreWarnings)
+            ? getTargetCaseRefFromLegacyId(callBackEvent)
             : callBackEvent.targetCaseRef;
 
         return attachCaseByCcdId(callBackEvent, targetCaseRef, ignoreWarnings)
@@ -302,10 +302,7 @@ public class AttachCaseCallbackService {
             });
     }
 
-    private String getTargetCaseRefFromLegacyId(
-        AttachToCaseEventData callBackEvent,
-        boolean ignoreWarnings
-    ) {
+    private String getTargetCaseRefFromLegacyId(AttachToCaseEventData callBackEvent) {
         List<Long> targetCaseCcdIds = ccdApi.getCaseRefsByLegacyId(callBackEvent.targetCaseRef, callBackEvent.service);
 
         if (targetCaseCcdIds.size() > 1) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -240,10 +240,11 @@ public class AttachCaseCallbackService {
             );
 
             return attachToCase(callBackEvent, ignoreWarnings)
-                .peek(map -> paymentsProcessor.updatePayments(
+                .peek(attachToCaseRef -> paymentsProcessor.updatePayments(
                     exceptionRecordDetails,
-                    (String) map.get(ATTACH_TO_CASE_REFERENCE)
-                ));
+                    attachToCaseRef
+                ))
+                .map(attachToCaseRef -> ImmutableMap.of(ATTACH_TO_CASE_REFERENCE, attachToCaseRef));
         } catch (AlreadyAttachedToCaseException
             | DuplicateDocsException
             | CaseNotFoundException
@@ -279,7 +280,8 @@ public class AttachCaseCallbackService {
         }
     }
 
-    private Either<ErrorsAndWarnings, Map<String, Object>> attachToCase(
+    // target case ref on the right
+    private Either<ErrorsAndWarnings, String> attachToCase(
         AttachToCaseEventData callBackEvent,
         boolean ignoreWarnings
     ) {
@@ -300,8 +302,7 @@ public class AttachCaseCallbackService {
                 "Completed the process of attaching exception record to a case. ER ID: {}. Case ID: {}",
                 callBackEvent.exceptionRecordId,
                 targetCaseRef
-            ))
-            .map(targetCaseRef -> ImmutableMap.of(ATTACH_TO_CASE_REFERENCE, targetCaseRef));
+            ));
     }
 
     // target case ref on the right

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -286,7 +286,11 @@ public class AttachCaseCallbackService {
         boolean ignoreWarnings
     ) {
         String targetCaseRef = EXTERNAL_CASE_REFERENCE.equals(callBackEvent.targetCaseRefType)
-            ? getTargetCaseRefFromLegacyId(callBackEvent)
+            ? getTargetCaseRefFromLegacyId(
+                callBackEvent.targetCaseRef,
+                callBackEvent.service,
+                callBackEvent.exceptionRecordId
+            )
             : callBackEvent.targetCaseRef;
 
         return attachCaseByCcdId(callBackEvent, targetCaseRef, ignoreWarnings)
@@ -302,15 +306,15 @@ public class AttachCaseCallbackService {
             });
     }
 
-    private String getTargetCaseRefFromLegacyId(AttachToCaseEventData callBackEvent) {
-        List<Long> targetCaseCcdIds = ccdApi.getCaseRefsByLegacyId(callBackEvent.targetCaseRef, callBackEvent.service);
+    private String getTargetCaseRefFromLegacyId(String targetCaseRef, String service, long exceptionRecordId) {
+        List<Long> targetCaseCcdIds = ccdApi.getCaseRefsByLegacyId(targetCaseRef, service);
 
         if (targetCaseCcdIds.size() > 1) {
             throw new MultipleCasesFoundException(
                 String.format(
                     "Multiple cases (%s) found for the given legacy case reference: %s",
                     targetCaseCcdIds.stream().map(String::valueOf).collect(joining(", ")),
-                    callBackEvent.targetCaseRef
+                    targetCaseRef
                 )
             );
         } else {
@@ -322,15 +326,15 @@ public class AttachCaseCallbackService {
                         log.info(
                             "Found case with CCD ID '{}' for legacy ID '{}' (attaching exception record '{}')",
                             targetCaseCcdId,
-                            callBackEvent.targetCaseRef,
-                            callBackEvent.exceptionRecordId
+                            targetCaseRef,
+                            exceptionRecordId
                         );
 
                         return Long.toString(targetCaseCcdId);
                     }
                 )
                 .orElseThrow(() -> new CaseNotFoundException(
-                    String.format("No case found for legacy case reference %s", callBackEvent.targetCaseRef)
+                    String.format("No case found for legacy case reference %s", targetCaseRef)
                 ));
         }
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Orchestrator: refactor CcdCaseUpdater and its surroundings](https://tools.hmcts.net/jira/browse/BPS-1074)

### Change description ###

`attachCaseByCcdId` is executed in 2 places: normal process and legacy id fiddler. The latter only needs to verify about it's singleton existence and call same thing with same parameters. Moving that call one method up 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
