### PR TITLE
Review GetTargetCase usage in AttachToCase callback service

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -358,20 +358,14 @@ public class AttachCaseCallbackService {
             case SUPPLEMENTARY_EVIDENCE:
                 targetCase = ccdApi.getCase(targetCaseCcdRef, callBackEvent.exceptionRecordJurisdiction);
 
-                updateSupplementaryEvidence(
-                    callBackEvent,
-                    targetCase
-                );
+                updateSupplementaryEvidence(callBackEvent, targetCase);
+
                 return Optional.empty();
 
             case SUPPLEMENTARY_EVIDENCE_WITH_OCR:
                 targetCase = ccdApi.getCase(targetCaseCcdRef, callBackEvent.exceptionRecordJurisdiction);
 
-                return updateSupplementaryEvidenceWithOcr(
-                    callBackEvent,
-                    targetCase,
-                    ignoreWarnings
-                );
+                return updateSupplementaryEvidenceWithOcr(callBackEvent, targetCase, ignoreWarnings);
 
             default:
                 throw new CallbackException("Invalid Journey Classification: " + callBackEvent.classification);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachCaseCallbackService.java
@@ -360,8 +360,7 @@ public class AttachCaseCallbackService {
 
                 updateSupplementaryEvidence(
                     callBackEvent,
-                    targetCase,
-                    targetCaseCcdRef
+                    targetCase
                 );
                 return Optional.empty();
 
@@ -371,7 +370,6 @@ public class AttachCaseCallbackService {
                 return updateSupplementaryEvidenceWithOcr(
                     callBackEvent,
                     targetCase,
-                    targetCaseCcdRef,
                     ignoreWarnings
                 );
 
@@ -382,8 +380,7 @@ public class AttachCaseCallbackService {
 
     private void updateSupplementaryEvidence(
         AttachToCaseEventData callBackEvent,
-        CaseDetails targetCase,
-        String targetCaseCcdRef
+        CaseDetails targetCase
     ) {
         List<Map<String, Object>> targetCaseDocuments = getScannedDocuments(targetCase);
 
@@ -391,7 +388,7 @@ public class AttachCaseCallbackService {
             targetCaseDocuments,
             callBackEvent.exceptionRecordDocuments,
             Long.toString(callBackEvent.exceptionRecordId),
-            targetCaseCcdRef
+            Long.toString(targetCase.getId())
         );
 
         List<Map<String, Object>> documentsToAttach = Documents.removeAlreadyAttachedDocuments(
@@ -431,7 +428,6 @@ public class AttachCaseCallbackService {
     private Optional<ErrorsAndWarnings> updateSupplementaryEvidenceWithOcr(
         AttachToCaseEventData callBackEvent,
         CaseDetails targetCase,
-        String targetCaseCcdRef,
         boolean ignoreWarnings
     ) {
         ServiceConfigItem serviceConfigItem = getServiceConfig(callBackEvent.service);
@@ -441,7 +437,7 @@ public class AttachCaseCallbackService {
             ignoreWarnings,
             callBackEvent.idamToken,
             callBackEvent.userId,
-            targetCaseCcdRef,
+            Long.toString(targetCase.getId()),
             targetCase.getCaseTypeId()
         );
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Orchestrator: refactor CcdCaseUpdater and its surroundings](https://tools.hmcts.net/jira/browse/BPS-1074)

### Change description ###

Moving case getter one method up. Will make future tracking easier and perhaps can be summarised by the looks into the switch statement. We only need to know about the target case further down the line

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
