### PR TITLE
Show error as error

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -149,7 +149,7 @@ public class CcdCaseUpdater {
                 );
 
                 if (errorMsg.isPresent()) {
-                    return new ProcessResult(singletonList(errorMsg.get()), emptyList());
+                    return new ProcessResult(emptyList(), singletonList(errorMsg.get()));
                 } else {
                     var updatedExceptionRecordData = exceptionRecordFinalizer.finalizeExceptionRecord(
                         existingCase.getData(),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -312,10 +312,10 @@ class CcdCaseUpdaterTest {
         );
 
         // then
-        assertThat(res.getWarnings()).containsExactlyInAnyOrder("CCD returned 422 Unprocessable Entity response "
+        assertThat(res.getErrors()).containsExactlyInAnyOrder("CCD returned 422 Unprocessable Entity response "
             + "when trying to update case for some jurisdiction jurisdiction with case Id 0 based on exception record "
             + "with Id 1. CCD response: Body");
-        assertThat(res.getErrors()).isEmpty();
+        assertThat(res.getWarnings()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Currently an error in updating a case in CCD is presented to a user as a warning.
Changing to error.

(whether those details should be shown to user or not is another question...)