### PR TITLE
Combine ccd api calls for supplementary evidence callback

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordTestBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachExceptionRecordTestBase.java
@@ -168,7 +168,7 @@ public class AttachExceptionRecordTestBase {
             submittedScannedRecords(),
             "$.event.summary",
             WireMock.equalTo(String.format(
-                "Attaching exception record(%d) document numbers:[%s] to case:%s",
+                "Attaching exception record (%d) document numbers: [%s] to case: %s",
                 EXCEPTION_RECORD_ID,
                 EXCEPTION_RECORD_DOCUMENT_NUMBER,
                 CASE_REF


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Orchestrator: refactor CcdCaseUpdater and its surroundings](https://tools.hmcts.net/jira/browse/BPS-1074)

### Change description ###

This section was very first callback created in orchestrator. No1 exactly knew how things are going and where/why. Methods got created willy-nilly and, after few more interactions with ccd feign client - everything got overpolluted. Unifying this call similarly as in #1030, #1031 and #1037 

Summary:

```markdown
BEFORE:

- case EXCEPTION | SUPPLEMENTARY_EVIDENCE:
  - updateSupplementaryEvidence:
  - ccdApi.startAttachScannedDocs(theCase, callBackEvent.idamToken, callBackEvent.userId):
    - authenticatorFactory.createForJurisdiction(theCase.getJurisdiction())
    - feignCcdApi.startEventForCaseWorker
    - exception? -> throw new CcdCallException
  - ccdApi.attachExceptionRecord
    - authenticatorFactory.createForJurisdiction(jurisdiction)
    - feignCcdApi.submitEventForCaseWorker
    - exception? -> throw new CcdCallException

AFTER:

- case EXCEPTION | SUPPLEMENTARY_EVIDENCE:
  - updateSupplementaryEvidence:
  - ccdApi.attachSupplementaryEvidenceFromCallback:
    - authenticatorFactory.createForJurisdiction(theCase.getJurisdiction())
    - feignCcdApi.startEventForCaseWorker
    - feignCcdApi.submitEventForCaseWorker
    - exception? -> throw new CcdCallException
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
