### PR TITLE
Fix attach-to-case names

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.in.CcdCallbackRequest;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.AttachCaseCallbackService;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.AttachToCaseCallbackService;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CreateCaseCallbackService;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.ErrorsAndWarnings;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.ReclassifyCallbackService;
@@ -24,7 +24,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @RequestMapping(path = "/callback", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 public class CcdCallbackController {
 
-    private final AttachCaseCallbackService attachCaseCallbackService;
+    private final AttachToCaseCallbackService attachToCaseCallbackService;
     private final CreateCaseCallbackService createCaseCallbackService;
     private final ReclassifyCallbackService reclassifyCallbackService;
 
@@ -32,11 +32,11 @@ public class CcdCallbackController {
 
     @Autowired
     public CcdCallbackController(
-        AttachCaseCallbackService attachCaseCallbackService,
+        AttachToCaseCallbackService attachToCaseCallbackService,
         CreateCaseCallbackService createCaseCallbackService,
         ReclassifyCallbackService reclassifyCallbackService
     ) {
-        this.attachCaseCallbackService = attachCaseCallbackService;
+        this.attachToCaseCallbackService = attachToCaseCallbackService;
         this.createCaseCallbackService = createCaseCallbackService;
         this.reclassifyCallbackService = reclassifyCallbackService;
     }
@@ -49,7 +49,7 @@ public class CcdCallbackController {
     ) {
         if (callback != null && callback.getCaseDetails() != null) {
 
-            return attachCaseCallbackService
+            return attachToCaseCallbackService
                 .process(
                     callback.getCaseDetails(),
                     idamToken,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackService.java
@@ -61,25 +61,20 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE_WITH_OCR;
 
 @Service
-public class AttachCaseCallbackService {
+public class AttachToCaseCallbackService {
 
     public static final String PAYMENT_ERROR_MSG = "Payment references cannot be processed. Please try again later";
 
-    private static final Logger log = LoggerFactory.getLogger(AttachCaseCallbackService.class);
+    private static final Logger log = LoggerFactory.getLogger(AttachToCaseCallbackService.class);
 
     private final ServiceConfigProvider serviceConfigProvider;
-
     private final CcdApi ccdApi;
-
     private final ExceptionRecordValidator exceptionRecordValidator;
-
     private final CcdCaseUpdater ccdCaseUpdater;
-
     private final PaymentsProcessor paymentsProcessor;
-
     private final AttachScannedDocumentsValidator scannedDocumentsValidator;
 
-    public AttachCaseCallbackService(
+    public AttachToCaseCallbackService(
         ServiceConfigProvider serviceConfigProvider,
         CcdApi ccdApi,
         ExceptionRecordValidator exceptionRecordValidator,
@@ -123,8 +118,8 @@ public class AttachCaseCallbackService {
 
         return getValidation(exceptionRecordDetails, requesterIdamToken, requesterUserId)
             .map(callBackEvent -> tryAttachToCase(callBackEvent, exceptionRecordDetails, ignoreWarnings))
-            .map(attachCaseResult ->
-                attachCaseResult.map(modifiedFields ->
+            .map(attachToCaseResult ->
+                attachToCaseResult.map(modifiedFields ->
                     mergeCaseFields(exceptionRecordDetails.getData(), modifiedFields))
             )
             .getOrElseGet(errors -> Either.left(ErrorsAndWarnings.withErrors(errors.toJavaList())));
@@ -296,7 +291,7 @@ public class AttachCaseCallbackService {
             )
             : callBackEvent.targetCaseRef;
 
-        return attachCaseByCcdId(callBackEvent, targetCaseRef, ignoreWarnings)
+        return attachToCaseByCcdId(callBackEvent, targetCaseRef, ignoreWarnings)
             .map(Either::<ErrorsAndWarnings, String>left)
             .orElseGet(() -> {
                 log.info(
@@ -336,7 +331,7 @@ public class AttachCaseCallbackService {
         }
     }
 
-    private Optional<ErrorsAndWarnings> attachCaseByCcdId(
+    private Optional<ErrorsAndWarnings> attachToCaseByCcdId(
         AttachToCaseEventData callBackEvent,
         String targetCaseCcdRef,
         boolean ignoreWarnings

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackControllerAttachToCaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackControllerAttachToCaseTest.java
@@ -6,7 +6,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.AttachCaseCallbackService;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.AttachToCaseCallbackService;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CreateCaseCallbackService;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.ReclassifyCallbackService;
 
@@ -21,7 +21,7 @@ class CcdCallbackControllerAttachToCaseTest {
 
     @Autowired MockMvc mvc;
 
-    @MockBean AttachCaseCallbackService attachService;
+    @MockBean AttachToCaseCallbackService attachService;
     @MockBean CreateCaseCallbackService createService;
     @MockBean ReclassifyCallbackService reclassifyCallbackService;
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackControllerReclassifyTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/controllers/CcdCallbackControllerReclassifyTest.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.AttachCaseCallbackService;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.AttachToCaseCallbackService;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CreateCaseCallbackService;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.ReclassifyCallbackService;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.ProcessResult;
@@ -30,7 +30,7 @@ public class CcdCallbackControllerReclassifyTest {
     MockMvc mvc;
 
     @MockBean
-    AttachCaseCallbackService attachService;
+    AttachToCaseCallbackService attachService;
     @MockBean
     CreateCaseCallbackService createService;
     @MockBean

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackServiceTest.java
@@ -47,9 +47,9 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE_WITH_OCR;
 
 @ExtendWith(MockitoExtension.class)
-class AttachCaseCallbackServiceTest {
+class AttachToCaseCallbackServiceTest {
 
-    private AttachCaseCallbackService attachCaseCallbackService;
+    private AttachToCaseCallbackService attachToCaseCallbackService;
 
     @Mock
     private ServiceConfigProvider serviceConfigProvider;
@@ -109,7 +109,7 @@ class AttachCaseCallbackServiceTest {
 
     @BeforeEach
     void setUp() {
-        attachCaseCallbackService = new AttachCaseCallbackService(
+        attachToCaseCallbackService = new AttachToCaseCallbackService(
             serviceConfigProvider,
             ccdApi,
             exceptionRecordValidator,
@@ -135,7 +135,7 @@ class AttachCaseCallbackServiceTest {
         )).willReturn(new ProcessResult(emptyMap()));
 
         // when
-        Either<ErrorsAndWarnings, Map<String, Object>> res = attachCaseCallbackService.process(
+        Either<ErrorsAndWarnings, Map<String, Object>> res = attachToCaseCallbackService.process(
             CASE_DETAILS,
             IDAM_TOKEN,
             USER_ID,
@@ -167,7 +167,7 @@ class AttachCaseCallbackServiceTest {
         )).willReturn(new ProcessResult(asList("warning1"), asList("error1")));
 
         // when
-        Either<ErrorsAndWarnings, Map<String, Object>> res = attachCaseCallbackService.process(
+        Either<ErrorsAndWarnings, Map<String, Object>> res = attachToCaseCallbackService.process(
             CASE_DETAILS,
             IDAM_TOKEN,
             USER_ID,


### PR DESCRIPTION
Rename classes/variables from `attachCase` to `attachToCase` (as we're attaching exception recored to a case).

Those now match things like `AttachToCaseEventData` model and `attachToCase` method in callback controller.