### PR TITLE
Handling UnprocessableEntity as server error

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -208,6 +208,12 @@ public class CcdCaseUpdater {
                 "Invalid case-update response. " + errorMessage,
                 exc
             );
+        } catch (CcdCallException exception) {
+            log.error(exception.getMessage(), exception.getCause());
+            throw new CallbackException(
+                getErrorMessage(configItem.getService(), existingCaseId, exceptionRecord.id),
+                exception
+            );
         } catch (Exception exception) {
             throw new CallbackException(
                 getErrorMessage(configItem.getService(), existingCaseId, exceptionRecord.id),
@@ -244,8 +250,6 @@ public class CcdCaseUpdater {
 
     /**
      * Submits event to update the case.
-     *
-     * @return either error message in case of error or empty if no error detected
      */
     private void updateCaseInCcd(
         String service,
@@ -291,8 +295,7 @@ public class CcdCaseUpdater {
                 exceptionRecord.id,
                 exception.contentUTF8()
             );
-            log.error(msg, exception);
-            throw new RuntimeException(msg);
+            throw new CcdCallException(msg, exception);
         } catch (FeignException.Conflict exception) {
             throw exception;
         } catch (FeignException exception) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -137,9 +137,8 @@ public class CcdCaseUpdater {
 
                 updateCaseInCcd(
                     ignoreWarnings,
-                    idamToken,
-                    s2sToken,
-                    userId,
+                    new Credentials(idamToken, s2sToken, userId),
+                    existingCaseId,
                     exceptionRecord,
                     updateResponse.caseDetails,
                     startEvent
@@ -252,9 +251,8 @@ public class CcdCaseUpdater {
      */
     private void updateCaseInCcd(
         boolean ignoreWarnings,
-        String idamToken,
-        String s2sToken,
-        String userId,
+        Credentials credentials,
+        String existingCaseId,
         ExceptionRecord exceptionRecord,
         CaseUpdateDetails caseUpdateDetails,
         StartEventResponse startEvent
@@ -264,12 +262,12 @@ public class CcdCaseUpdater {
         final CaseDataContent caseDataContent = buildCaseDataContent(exceptionRecord, caseUpdateDetails, startEvent);
         try {
             coreCaseDataApi.submitEventForCaseWorker(
-                idamToken,
-                s2sToken,
-                userId,
+                credentials.idamToken,
+                credentials.s2sToken,
+                credentials.userId,
                 exceptionRecord.poBoxJurisdiction,
                 startEvent.getCaseDetails().getCaseTypeId(),
-                startEvent.getCaseDetails().getId().toString(),
+                existingCaseId,
                 ignoreWarnings,
                 caseDataContent
             );
@@ -328,4 +326,15 @@ public class CcdCaseUpdater {
             .build();
     }
 
+    class Credentials {
+        final String idamToken;
+        final String s2sToken;
+        final String userId;
+
+        Credentials(String idamToken, String s2sToken, String userId) {
+            this.idamToken = idamToken;
+            this.s2sToken = s2sToken;
+            this.userId = userId;
+        }
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -208,12 +208,6 @@ public class CcdCaseUpdater {
                 "Invalid case-update response. " + errorMessage,
                 exc
             );
-        } catch (CcdCallException exception) {
-            log.error(exception.getMessage(), exception.getCause());
-            throw new CallbackException(
-                getErrorMessage(configItem.getService(), existingCaseId, exceptionRecord.id),
-                exception
-            );
         } catch (Exception exception) {
             throw new CallbackException(
                 getErrorMessage(configItem.getService(), existingCaseId, exceptionRecord.id),

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -137,7 +137,9 @@ public class CcdCaseUpdater {
 
                 updateCaseInCcd(
                     ignoreWarnings,
-                    new Credentials(idamToken, s2sToken, userId),
+                    idamToken,
+                    s2sToken,
+                    userId,
                     existingCaseId,
                     exceptionRecord,
                     updateResponse.caseDetails,
@@ -249,9 +251,12 @@ public class CcdCaseUpdater {
     /**
      * Submits event to update the case.
      */
+    @SuppressWarnings("squid:S00107") // number of params
     private void updateCaseInCcd(
         boolean ignoreWarnings,
-        Credentials credentials,
+        String idamToken,
+        String s2sToken,
+        String userId,
         String existingCaseId,
         ExceptionRecord exceptionRecord,
         CaseUpdateDetails caseUpdateDetails,
@@ -262,9 +267,9 @@ public class CcdCaseUpdater {
         final CaseDataContent caseDataContent = buildCaseDataContent(exceptionRecord, caseUpdateDetails, startEvent);
         try {
             coreCaseDataApi.submitEventForCaseWorker(
-                credentials.idamToken,
-                credentials.s2sToken,
-                credentials.userId,
+                idamToken,
+                s2sToken,
+                userId,
                 exceptionRecord.poBoxJurisdiction,
                 startEvent.getCaseDetails().getCaseTypeId(),
                 existingCaseId,
@@ -324,17 +329,5 @@ public class CcdCaseUpdater {
             )
             .eventToken(startEvent.getToken())
             .build();
-    }
-
-    class Credentials {
-        final String idamToken;
-        final String s2sToken;
-        final String userId;
-
-        Credentials(String idamToken, String s2sToken, String userId) {
-            this.idamToken = idamToken;
-            this.s2sToken = s2sToken;
-            this.userId = userId;
-        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -295,8 +295,7 @@ public class CcdCaseUpdater {
                 exception.contentUTF8()
             );
             log.error(msg, exception);
-
-            return Optional.of(msg);
+            throw new RuntimeException();
         } catch (FeignException.Conflict exception) {
             throw exception;
         } catch (FeignException exception) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -295,7 +295,7 @@ public class CcdCaseUpdater {
                 exception.contentUTF8()
             );
             log.error(msg, exception);
-            throw new RuntimeException();
+            throw new CcdCallException(msg, exception);
         } catch (FeignException.Conflict exception) {
             throw exception;
         } catch (FeignException exception) {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -136,15 +136,20 @@ public class CcdCaseUpdater {
                 setExceptionRecordIdToScannedDocuments(exceptionRecord, updateResponse.caseDetails);
 
                 updateCaseInCcd(
-                    configItem.getService(),
                     ignoreWarnings,
                     idamToken,
                     s2sToken,
                     userId,
-                    existingCaseId,
                     exceptionRecord,
                     updateResponse.caseDetails,
                     startEvent
+                );
+
+                log.info(
+                    "Successfully updated case for service {} with case Id {} based on exception record ref {}",
+                    configItem.getService(),
+                    existingCase.getId(),
+                    exceptionRecord.id
                 );
 
                 return NO_ERRORS_OR_WARNINGS_PROCESS_RESULT;
@@ -246,12 +251,10 @@ public class CcdCaseUpdater {
      * Submits event to update the case.
      */
     private void updateCaseInCcd(
-        String service,
         boolean ignoreWarnings,
         String idamToken,
         String s2sToken,
         String userId,
-        String existingCaseId,
         ExceptionRecord exceptionRecord,
         CaseUpdateDetails caseUpdateDetails,
         StartEventResponse startEvent
@@ -266,16 +269,9 @@ public class CcdCaseUpdater {
                 userId,
                 exceptionRecord.poBoxJurisdiction,
                 startEvent.getCaseDetails().getCaseTypeId(),
-                existingCaseId,
+                startEvent.getCaseDetails().getId().toString(),
                 ignoreWarnings,
                 caseDataContent
-            );
-
-            log.info(
-                "Successfully updated case for service {} with case Id {} based on exception record ref {}",
-                service,
-                existingCase.getId(),
-                exceptionRecord.id
             );
         } catch (FeignException.UnprocessableEntity exception) {
             String msg = String.format(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -270,21 +270,28 @@ class CcdCaseUpdaterTest {
             );
 
         // when
-        ProcessResult res = ccdCaseUpdater.updateCase(
-            exceptionRecord,
-            configItem,
-            true,
-            "idamToken",
-            "userId",
-            EXISTING_CASE_ID,
-            EXISTING_CASE_TYPE_ID
+        CallbackException exception = catchThrowableOfType(() ->
+                ccdCaseUpdater.updateCase(
+                    exceptionRecord,
+                    configItem,
+                    true,
+                    "idamToken",
+                    "userId",
+                    EXISTING_CASE_ID,
+                    EXISTING_CASE_TYPE_ID
+                ),
+            CallbackException.class
         );
 
         // then
-        assertThat(res.getWarnings()).containsExactlyInAnyOrder("CCD returned 422 Unprocessable Entity response "
-            + "when trying to update case for some jurisdiction jurisdiction with case Id 0 based on exception record "
-            + "with Id 1. CCD response: Body");
-        assertThat(res.getErrors()).isEmpty();
+        assertThat(exception)
+            .hasCauseInstanceOf(RuntimeException.class)
+            .hasMessage(
+                "Failed to update case for %s service with case Id %s based on exception record %s",
+                configItem.getService(),
+                EXISTING_CASE_ID,
+                exceptionRecord.id
+            );
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1329


### Change description ###
Feign.UnprocessableEntity is handled as Server error.

It appears that Conflict is already handled as defined in the task.

Also reduced number of arguments in `updateCaseInCcd` method to pass the quality gateway.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
