### PR TITLE
Introduced RequestCredentials class

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackService.java
@@ -430,8 +430,7 @@ public class AttachToCaseCallbackService {
             callBackEvent.exceptionRecord,
             serviceConfigItem,
             ignoreWarnings,
-            callBackEvent.idamToken,
-            callBackEvent.userId,
+            new RequestCredentials(callBackEvent.idamToken, callBackEvent.userId),
             targetCaseCcdRef,
             targetCase.getCaseTypeId()
         );

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackService.java
@@ -62,7 +62,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.doma
 @Service
 public class AttachToCaseCallbackService {
 
-    public static final String PAYMENT_ERROR_MSG = "Payment references cannot be processed. Please try again later";
+    private static final String PAYMENT_ERROR_MSG = "Payment references cannot be processed. Please try again later";
 
     private static final Logger log = LoggerFactory.getLogger(AttachToCaseCallbackService.class);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -59,8 +59,7 @@ public class CcdCaseUpdater {
         ExceptionRecord exceptionRecord,
         ServiceConfigItem configItem,
         boolean ignoreWarnings,
-        String idamToken,
-        String userId,
+        RequestCredentials requestCredentials,
         String existingCaseId,
         String existingCaseTypeId
     ) {
@@ -73,11 +72,12 @@ public class CcdCaseUpdater {
 
         try {
             String s2sToken = s2sTokenGenerator.generate();
+            requestCredentials.setS2sToken(s2sToken);
 
             StartEventResponse startEvent = coreCaseDataApi.startEventForCaseWorker(
-                idamToken,
-                s2sToken,
-                userId,
+                requestCredentials.idamToken,
+                requestCredentials.s2sToken,
+                requestCredentials.userId,
                 exceptionRecord.poBoxJurisdiction,
                 existingCaseTypeId,
                 existingCaseId,
@@ -136,9 +136,7 @@ public class CcdCaseUpdater {
                 Optional<String> errorMsg = updateCaseInCcd(
                     configItem.getService(),
                     ignoreWarnings,
-                    idamToken,
-                    s2sToken,
-                    userId,
+                    requestCredentials,
                     existingCaseId,
                     exceptionRecord,
                     updateResponse.caseDetails,
@@ -251,9 +249,7 @@ public class CcdCaseUpdater {
     private Optional<String> updateCaseInCcd(
         String service,
         boolean ignoreWarnings,
-        String idamToken,
-        String s2sToken,
-        String userId,
+        RequestCredentials requestCredentials,
         String existingCaseId,
         ExceptionRecord exceptionRecord,
         CaseUpdateDetails caseUpdateDetails,
@@ -264,9 +260,9 @@ public class CcdCaseUpdater {
         final CaseDataContent caseDataContent = buildCaseDataContent(exceptionRecord, caseUpdateDetails, startEvent);
         try {
             coreCaseDataApi.submitEventForCaseWorker(
-                idamToken,
-                s2sToken,
-                userId,
+                requestCredentials.idamToken,
+                requestCredentials.s2sToken,
+                requestCredentials.userId,
                 exceptionRecord.poBoxJurisdiction,
                 startEvent.getCaseDetails().getCaseTypeId(),
                 existingCaseId,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/RequestCredentials.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/RequestCredentials.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import java.util.Objects;
+
+public class RequestCredentials {
+    final String idamToken;
+    String s2sToken;
+    final String userId;
+
+    public RequestCredentials(String idamToken, String userId) {
+        this.idamToken = idamToken;
+        this.userId = userId;
+    }
+
+    void setS2sToken(String s2sToken) {
+        this.s2sToken = s2sToken;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RequestCredentials that = (RequestCredentials) o;
+        return Objects.equals(idamToken, that.idamToken)
+            && Objects.equals(s2sToken, that.s2sToken)
+            && Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idamToken, s2sToken, userId);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/RequestCredentials.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/RequestCredentials.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
-import java.util.Objects;
-
 public class RequestCredentials {
     final String idamToken;
     String s2sToken;
@@ -14,24 +12,5 @@ public class RequestCredentials {
 
     void setS2sToken(String s2sToken) {
         this.s2sToken = s2sToken;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        RequestCredentials that = (RequestCredentials) o;
-        return Objects.equals(idamToken, that.idamToken)
-            && Objects.equals(s2sToken, that.s2sToken)
-            && Objects.equals(userId, that.userId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(idamToken, s2sToken, userId);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackServiceTest.java
@@ -135,7 +135,12 @@ class AttachToCaseCallbackServiceTest {
         // given
         given(exceptionRecordValidator.mandatoryPrerequisites(any())).willReturn(Validation.valid(null));
         given(ccdCaseUpdater.updateCase(
-            exceptionRecord, configItem, true, IDAM_TOKEN, USER_ID, EXISTING_CASE_ID, EXISTING_CASE_TYPE
+            exceptionRecord,
+            configItem,
+            true,
+            new RequestCredentials(IDAM_TOKEN, USER_ID),
+            EXISTING_CASE_ID,
+            EXISTING_CASE_TYPE
         )).willReturn(new ProcessResult(emptyMap()));
 
         // when
@@ -150,7 +155,14 @@ class AttachToCaseCallbackServiceTest {
         // then
         assertThat(res.isRight()).isTrue();
         verify(ccdCaseUpdater)
-            .updateCase(exceptionRecord, configItem, true, IDAM_TOKEN, USER_ID, EXISTING_CASE_ID, EXISTING_CASE_TYPE);
+            .updateCase(
+                exceptionRecord,
+                configItem,
+                true,
+                new RequestCredentials(IDAM_TOKEN, USER_ID),
+                EXISTING_CASE_ID,
+                EXISTING_CASE_TYPE
+            );
 
         // and
         var paymentsDataCaptor = ArgumentCaptor.forClass(PaymentsHelper.class);
@@ -174,7 +186,12 @@ class AttachToCaseCallbackServiceTest {
         // given
         given(exceptionRecordValidator.mandatoryPrerequisites(any())).willReturn(Validation.valid(null));
         given(ccdCaseUpdater.updateCase(
-            exceptionRecord, configItem, true, IDAM_TOKEN, USER_ID, EXISTING_CASE_ID, EXISTING_CASE_TYPE
+            exceptionRecord,
+            configItem,
+            true,
+            new RequestCredentials(IDAM_TOKEN, USER_ID),
+            EXISTING_CASE_ID,
+            EXISTING_CASE_TYPE
         )).willReturn(new ProcessResult(asList("warning1"), asList("error1")));
 
         // when
@@ -192,7 +209,14 @@ class AttachToCaseCallbackServiceTest {
         assertThat(res.getLeft().getErrors()).isEqualTo(asList("error1"));
 
         verify(ccdCaseUpdater)
-            .updateCase(exceptionRecord, configItem, true, IDAM_TOKEN, USER_ID, EXISTING_CASE_ID, EXISTING_CASE_TYPE);
+            .updateCase(
+                exceptionRecord,
+                configItem,
+                true,
+                new RequestCredentials(IDAM_TOKEN, USER_ID),
+                EXISTING_CASE_ID,
+                EXISTING_CASE_TYPE
+            );
         verifyNoInteractions(paymentsProcessor);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackServiceTest.java
@@ -135,12 +135,12 @@ class AttachToCaseCallbackServiceTest {
         // given
         given(exceptionRecordValidator.mandatoryPrerequisites(any())).willReturn(Validation.valid(null));
         given(ccdCaseUpdater.updateCase(
-            exceptionRecord,
-            configItem,
-            true,
-            new RequestCredentials(IDAM_TOKEN, USER_ID),
-            EXISTING_CASE_ID,
-            EXISTING_CASE_TYPE
+            eq(exceptionRecord),
+            eq(configItem),
+            eq(true),
+            any(RequestCredentials.class),
+            eq(EXISTING_CASE_ID),
+            eq(EXISTING_CASE_TYPE)
         )).willReturn(new ProcessResult(emptyMap()));
 
         // when
@@ -156,12 +156,12 @@ class AttachToCaseCallbackServiceTest {
         assertThat(res.isRight()).isTrue();
         verify(ccdCaseUpdater)
             .updateCase(
-                exceptionRecord,
-                configItem,
-                true,
-                new RequestCredentials(IDAM_TOKEN, USER_ID),
-                EXISTING_CASE_ID,
-                EXISTING_CASE_TYPE
+                eq(exceptionRecord),
+                eq(configItem),
+                eq(true),
+                any(RequestCredentials.class),
+                eq(EXISTING_CASE_ID),
+                eq(EXISTING_CASE_TYPE)
             );
 
         // and
@@ -186,12 +186,12 @@ class AttachToCaseCallbackServiceTest {
         // given
         given(exceptionRecordValidator.mandatoryPrerequisites(any())).willReturn(Validation.valid(null));
         given(ccdCaseUpdater.updateCase(
-            exceptionRecord,
-            configItem,
-            true,
-            new RequestCredentials(IDAM_TOKEN, USER_ID),
-            EXISTING_CASE_ID,
-            EXISTING_CASE_TYPE
+            eq(exceptionRecord),
+            eq(configItem),
+            eq(true),
+            any(RequestCredentials.class),
+            eq(EXISTING_CASE_ID),
+            eq(EXISTING_CASE_TYPE)
         )).willReturn(new ProcessResult(asList("warning1"), asList("error1")));
 
         // when
@@ -210,12 +210,12 @@ class AttachToCaseCallbackServiceTest {
 
         verify(ccdCaseUpdater)
             .updateCase(
-                exceptionRecord,
-                configItem,
-                true,
-                new RequestCredentials(IDAM_TOKEN, USER_ID),
-                EXISTING_CASE_ID,
-                EXISTING_CASE_TYPE
+                eq(exceptionRecord),
+                eq(configItem),
+                eq(true),
+                any(RequestCredentials.class),
+                eq(EXISTING_CASE_ID),
+                eq(EXISTING_CASE_TYPE)
             );
         verifyNoInteractions(paymentsProcessor);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -105,8 +105,7 @@ class CcdCaseUpdaterTest {
             exceptionRecord,
             configItem,
             true,
-            "idamToken",
-            "userId",
+            new RequestCredentials("idamToken", "userId"),
             EXISTING_CASE_ID,
             EXISTING_CASE_TYPE_ID
         );
@@ -132,8 +131,7 @@ class CcdCaseUpdaterTest {
             exceptionRecord,
             configItem,
             true,
-            "idamToken",
-            "userId",
+            new RequestCredentials("idamToken", "userId"),
             EXISTING_CASE_ID,
             EXISTING_CASE_TYPE_ID
         );
@@ -157,8 +155,7 @@ class CcdCaseUpdaterTest {
             exceptionRecord,
             configItem,
             false,
-            "idamToken",
-            "userId",
+            new RequestCredentials("idamToken", "userId"),
             EXISTING_CASE_ID,
             EXISTING_CASE_TYPE_ID
         );
@@ -184,8 +181,7 @@ class CcdCaseUpdaterTest {
             exceptionRecord,
             configItem,
             false,
-            "idamToken",
-            "userId",
+            new RequestCredentials("idamToken", "userId"),
             EXISTING_CASE_ID,
             EXISTING_CASE_TYPE_ID
         );
@@ -211,8 +207,7 @@ class CcdCaseUpdaterTest {
             exceptionRecord,
             configItem,
             true,
-            "idamToken",
-            "userId",
+            new RequestCredentials("idamToken", "userId"),
             EXISTING_CASE_ID,
             EXISTING_CASE_TYPE_ID
         );
@@ -241,8 +236,7 @@ class CcdCaseUpdaterTest {
                     exceptionRecord,
                     configItem,
                     true,
-                    "idamToken",
-                    "userId",
+                    new RequestCredentials("idamToken", "userId"),
                     EXISTING_CASE_ID,
                     EXISTING_CASE_TYPE_ID
                 ),
@@ -274,8 +268,7 @@ class CcdCaseUpdaterTest {
             exceptionRecord,
             configItem,
             true,
-            "idamToken",
-            "userId",
+            new RequestCredentials("idamToken", "userId"),
             EXISTING_CASE_ID,
             EXISTING_CASE_TYPE_ID
         );
@@ -303,8 +296,7 @@ class CcdCaseUpdaterTest {
                     exceptionRecord,
                     configItem,
                     true,
-                    "idamToken",
-                    "userId",
+                    new RequestCredentials("idamToken", "userId"),
                     EXISTING_CASE_ID,
                     EXISTING_CASE_TYPE_ID
                 ),
@@ -338,8 +330,7 @@ class CcdCaseUpdaterTest {
                     exceptionRecord,
                     configItem,
                     true,
-                    "idamToken",
-                    "userId",
+                    new RequestCredentials("idamToken", "userId"),
                     EXISTING_CASE_ID,
                     EXISTING_CASE_TYPE_ID
                 )
@@ -378,8 +369,7 @@ class CcdCaseUpdaterTest {
                     exceptionRecord,
                     configItem,
                     true,
-                    "idamToken",
-                    "userId",
+                    new RequestCredentials("idamToken", "userId"),
                     EXISTING_CASE_ID,
                     EXISTING_CASE_TYPE_ID
                 ),
@@ -426,8 +416,7 @@ class CcdCaseUpdaterTest {
             exceptionRecord,
             configItem,
             true,
-            "idamToken",
-            "userId",
+            new RequestCredentials("idamToken", "userId"),
             EXISTING_CASE_ID,
             EXISTING_CASE_TYPE_ID
         );
@@ -457,8 +446,7 @@ class CcdCaseUpdaterTest {
                     exceptionRecord,
                     configItem,
                     true,
-                    "idamToken",
-                    "userId",
+                    new RequestCredentials("idamToken", "userId"),
                     EXISTING_CASE_ID,
                     EXISTING_CASE_TYPE_ID
                 ),
@@ -492,8 +480,7 @@ class CcdCaseUpdaterTest {
                     exceptionRecord,
                     configItem,
                     true,
-                    "idamToken",
-                    "userId",
+                    new RequestCredentials("idamToken", "userId"),
                     EXISTING_CASE_ID,
                     EXISTING_CASE_TYPE_ID
                 ),
@@ -527,8 +514,7 @@ class CcdCaseUpdaterTest {
             exceptionRecord,
             configItem,
             true,
-            "idamToken",
-            "userId",
+            new RequestCredentials("idamToken", "userId"),
             "1234123412341234",
             EXISTING_CASE_TYPE_ID
         );
@@ -557,8 +543,7 @@ class CcdCaseUpdaterTest {
             exceptionRecord,
             configItem,
             true,
-            "idamToken",
-            "userId",
+            new RequestCredentials("idamToken", "userId"),
             "1234",
             EXISTING_CASE_TYPE_ID
         );


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1329


### Change description ###
This PR goes before https://github.com/hmcts/bulk-scan-orchestrator/pull/1063 to prevent quality gateway failure due to exceeding max number of method parameters. This has been discussed with @lgonczar as a preferable approach rather than suppressing check for the number of parameters.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
