### PR TITLE
Clean up `ErrorsAndWarnings`

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -128,7 +128,7 @@ public class CcdCaseUpdater {
                     existingCase.getId(),
                     exceptionRecord.id
                 );
-                return Optional.of(ErrorsAndWarnings.withErrorsAndWarnings(emptyList(), updateResponse.warnings));
+                return Optional.of(new ErrorsAndWarnings(emptyList(), updateResponse.warnings));
             } else {
                 setExceptionRecordIdToScannedDocuments(exceptionRecord, updateResponse.caseDetails);
 
@@ -152,13 +152,13 @@ public class CcdCaseUpdater {
             }
         } catch (UnprocessableEntity exception) {
             ClientServiceErrorResponse errorResponse = serviceResponseParser.parseResponseBody(exception);
-            return Optional.of(ErrorsAndWarnings.withErrorsAndWarnings(errorResponse.errors, errorResponse.warnings));
+            return Optional.of(new ErrorsAndWarnings(errorResponse.errors, errorResponse.warnings));
         } catch (FeignException.Conflict exception) {
             String msg = getErrorMessage(configItem.getService(), existingCaseId, exceptionRecord.id)
                 + " because it has been updated in the meantime";
             log.error(msg);
             ClientServiceErrorResponse errorResponse = new ClientServiceErrorResponse(singletonList(msg), emptyList());
-            return Optional.of(ErrorsAndWarnings.withErrorsAndWarnings(errorResponse.errors, errorResponse.warnings));
+            return Optional.of(new ErrorsAndWarnings(errorResponse.errors, errorResponse.warnings));
         } catch (FeignException.NotFound exception) {
             String msg = "No case found for case ID: " + existingCaseId;
             log.error(
@@ -166,7 +166,7 @@ public class CcdCaseUpdater {
                 existingCaseId, configItem.getService(), exceptionRecord.id
             );
             ClientServiceErrorResponse errorResponse = new ClientServiceErrorResponse(singletonList(msg), emptyList());
-            return Optional.of(ErrorsAndWarnings.withErrorsAndWarnings(errorResponse.errors, errorResponse.warnings));
+            return Optional.of(new ErrorsAndWarnings(errorResponse.errors, errorResponse.warnings));
         } catch (FeignException.BadRequest exception) {
             String msg = "Invalid case ID: " + existingCaseId;
             log.error(
@@ -174,7 +174,7 @@ public class CcdCaseUpdater {
                 existingCaseId, configItem.getService(), exceptionRecord.id, exception
             );
             ClientServiceErrorResponse errorResponse = new ClientServiceErrorResponse(singletonList(msg), emptyList());
-            return Optional.of(ErrorsAndWarnings.withErrorsAndWarnings(errorResponse.errors, errorResponse.warnings));
+            return Optional.of(new ErrorsAndWarnings(errorResponse.errors, errorResponse.warnings));
         } catch (FeignException exception) {
             debugCcdException(log, exception, "Failed to call 'updateCase'");
             log.error(

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/ErrorsAndWarnings.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/ErrorsAndWarnings.java
@@ -8,17 +8,13 @@ public class ErrorsAndWarnings {
     private final List<String> errors;
     private final List<String> warnings;
 
-    private ErrorsAndWarnings(List<String> errors, List<String> warnings) {
+    public ErrorsAndWarnings(List<String> errors, List<String> warnings) {
         this.errors = errors;
         this.warnings = warnings;
     }
 
     static ErrorsAndWarnings withErrors(List<String> errors) {
         return new ErrorsAndWarnings(errors, emptyList());
-    }
-
-    static ErrorsAndWarnings withErrorsAndWarnings(List<String> errors, List<String> warnings) {
-        return new ErrorsAndWarnings(errors, warnings);
     }
 
     public List<String> getErrors() {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/AttachToCaseCallbackServiceTest.java
@@ -176,7 +176,7 @@ class AttachToCaseCallbackServiceTest {
         given(ccdCaseUpdater.updateCase(
             exceptionRecord, configItem, true, IDAM_TOKEN, USER_ID, EXISTING_CASE_ID, EXISTING_CASE_TYPE
         )).willReturn(
-            Optional.of(ErrorsAndWarnings.withErrorsAndWarnings(asList("error1"), asList("warning1")))
+            Optional.of(new ErrorsAndWarnings(asList("error1"), asList("warning1")))
         );
 
         // when


### PR DESCRIPTION
making it more concise