### PR TITLE
Fix the name of a case update request field

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/model/request/CaseUpdateDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/model/request/CaseUpdateDetails.java
@@ -36,8 +36,8 @@ public class CaseUpdateDetails {
     @JsonProperty(value = "delivery_date", required = true)
     public final LocalDateTime deliveryDate;
 
-    @JsonProperty(value = "opening_time", required = true)
-    public final LocalDateTime openingTime;
+    @JsonProperty(value = "opening_date", required = true)
+    public final LocalDateTime openingDate;
 
     @JsonProperty(value = "scanned_documents", required = true)
     public final List<ScannedDocument> scannedDocuments;
@@ -53,7 +53,7 @@ public class CaseUpdateDetails {
         this.poBoxJurisdiction = exceptionRecord.poBoxJurisdiction;
         this.formType = exceptionRecord.formType;
         this.deliveryDate = exceptionRecord.deliveryDate;
-        this.openingTime = exceptionRecord.openingDate;
+        this.openingDate = exceptionRecord.openingDate;
         this.scannedDocuments = exceptionRecord.scannedDocuments;
         this.ocrDataFields = exceptionRecord.ocrDataFields;
     }


### PR DESCRIPTION
### Change description ###

Fix the name of a field within case update request, to make it follow the spec (https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1064666568#TechnicalprerequisitesandinformationforServiceon-boardingwithPhase2Bulkscanningforcasecreation.-2.3.4Updateendpointforanexistingcase(basedonOCRdata))

The field was probably renamed by accident.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
