### PR TITLE
Use CaseFinder in CreateCaseCallbackService

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackService.java
@@ -42,7 +42,7 @@ public class CreateCaseCallbackService {
 
     private final ExceptionRecordValidator validator;
     private final ServiceConfigProvider serviceConfigProvider;
-    private final CcdApi ccdApi;
+    private final CaseFinder caseFinder;
     private final CcdNewCaseCreator ccdNewCaseCreator;
     private final ExceptionRecordFinalizer exceptionRecordFinalizer;
     private final PaymentsProcessor paymentsProcessor;
@@ -50,14 +50,14 @@ public class CreateCaseCallbackService {
     public CreateCaseCallbackService(
         ExceptionRecordValidator validator,
         ServiceConfigProvider serviceConfigProvider,
-        CcdApi ccdApi,
+        CaseFinder caseFinder,
         CcdNewCaseCreator ccdNewCaseCreator,
         ExceptionRecordFinalizer exceptionRecordFinalizer,
         PaymentsProcessor paymentsProcessor
     ) {
         this.validator = validator;
         this.serviceConfigProvider = serviceConfigProvider;
-        this.ccdApi = ccdApi;
+        this.caseFinder = caseFinder;
         this.ccdNewCaseCreator = ccdNewCaseCreator;
         this.exceptionRecordFinalizer = exceptionRecordFinalizer;
         this.paymentsProcessor = paymentsProcessor;
@@ -167,7 +167,7 @@ public class CreateCaseCallbackService {
         } else if (awaitsPaymentProcessing && !configItem.allowCreatingCaseBeforePaymentsAreProcessed()) {
             return new ProcessResult(emptyList(), singletonList(AWAITING_PAYMENTS_MESSAGE));
         } else {
-            List<Long> ids = ccdApi.getCaseRefsByBulkScanCaseReference(exceptionRecord.id, configItem.getService());
+            List<Long> ids = caseFinder.findCases(exceptionRecord, configItem);
             CreateCaseResult result;
 
             if (ids.isEmpty()) {

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CreateCaseCallbackServiceTest.java
@@ -57,10 +57,12 @@ class CreateCaseCallbackServiceTest {
     private static final String SERVICE = "service";
     private static final String CASE_ID = "123";
     private static final String CASE_TYPE_ID = SERVICE + "_ExceptionRecord";
+
+    // TODO: mock this!
     private static final ExceptionRecordValidator VALIDATOR = new ExceptionRecordValidator();
 
     @Mock ServiceConfigProvider serviceConfigProvider;
-    @Mock CcdApi ccdApi;
+    @Mock CaseFinder caseFinder;
     @Mock CcdNewCaseCreator ccdNewCaseCreator;
     @Mock ExceptionRecordFinalizer exceptionRecordFinalizer;
     @Mock PaymentsProcessor paymentsProcessor;
@@ -72,7 +74,7 @@ class CreateCaseCallbackServiceTest {
         service = new CreateCaseCallbackService(
             VALIDATOR,
             serviceConfigProvider,
-            ccdApi,
+            caseFinder,
             ccdNewCaseCreator,
             exceptionRecordFinalizer,
             paymentsProcessor
@@ -307,7 +309,7 @@ class CreateCaseCallbackServiceTest {
         // given
         setUpServiceConfig();
 
-        when(ccdApi.getCaseRefsByBulkScanCaseReference(CASE_ID, SERVICE))
+        when(caseFinder.findCases(any(), any()))
             .thenReturn(asList(345L));
         Map<String, Object> caseData = basicCaseData();
         Map<String, Object> finalizedCaseData = new HashMap<>();
@@ -333,7 +335,7 @@ class CreateCaseCallbackServiceTest {
     void should_return_error_if_multiple_cases_exist_in_ccd_for_a_given_exception_record() throws Exception {
         setUpServiceConfig();
 
-        when(ccdApi.getCaseRefsByBulkScanCaseReference(CASE_ID, SERVICE))
+        when(caseFinder.findCases(any(), any()))
             .thenReturn(asList(345L, 456L));
 
         assertThatThrownBy(


### PR DESCRIPTION
follow up to adding a new method to `CaseFinder` that searches by either the old or new field based on service config (https://github.com/hmcts/bulk-scan-orchestrator/pull/1089)

https://tools.hmcts.net/jira/browse/BPS-1339