### PR TITLE
Create separate models representing an exception record

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,9 @@ sonarqube {
   properties {
     property "sonar.projectName", "Reform :: Bulk Scan Orchestrator"
     property "sonar.coverage.jacoco.xmlReportPaths", jacocoTestReport.reports.xml.destination.path
-    property "sonar.coverage.exclusions", "**/config/**"
+    // TODO: remove the specific exclusions when those classes are used
+    property "sonar.coverage.exclusions", "**/config/**,**/caseupdate/model/request/ExceptionRecord.java,**/TransformationRequest.java,**/internal/ExceptionRecord.java"
+    property "sonar.cpd.exclusions", "**/caseupdate/model/request/ExceptionRecord.java,**/TransformationRequest.java,**/internal/ExceptionRecord.java"
   }
 }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/model/request/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/model/request/ExceptionRecord.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.env
 import java.time.LocalDateTime;
 import java.util.List;
 
+@SuppressWarnings("Duplicates")
 public class ExceptionRecord {
 
     public final String id;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/model/request/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/model/request/ExceptionRecord.java
@@ -1,0 +1,65 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.OcrDataField;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ExceptionRecord {
+
+    public final String id;
+
+    @JsonProperty("case_type_id")
+    public final String caseTypeId;
+
+    @JsonProperty("po_box")
+    public final String poBox;
+
+    @JsonProperty("po_box_jurisdiction")
+    public final String poBoxJurisdiction;
+
+    @JsonProperty("journey_classification")
+    public final Classification journeyClassification;
+
+    @JsonProperty("form_type")
+    public final String formType;
+
+    @JsonProperty("delivery_date")
+    public final LocalDateTime deliveryDate;
+
+    @JsonProperty("opening_date")
+    public final LocalDateTime openingDate;
+
+    @JsonProperty("scanned_documents")
+    public final List<ScannedDocument> scannedDocuments;
+
+    @JsonProperty("ocr_data_fields")
+    public final List<OcrDataField> ocrDataFields;
+
+    public ExceptionRecord(
+        String id,
+        String caseTypeId,
+        String poBox,
+        String poBoxJurisdiction,
+        Classification journeyClassification,
+        String formType,
+        LocalDateTime deliveryDate,
+        LocalDateTime openingDate,
+        List<ScannedDocument> scannedDocuments,
+        List<OcrDataField> ocrDataFields
+    ) {
+        this.id = id;
+        this.caseTypeId = caseTypeId;
+        this.poBox = poBox;
+        this.poBoxJurisdiction = poBoxJurisdiction;
+        this.journeyClassification = journeyClassification;
+        this.formType = formType;
+        this.deliveryDate = deliveryDate;
+        this.openingDate = openingDate;
+        this.scannedDocuments = scannedDocuments;
+        this.ocrDataFields = ocrDataFields;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/request/TransformationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/request/TransformationRequest.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.env
 import java.time.LocalDateTime;
 import java.util.List;
 
+@SuppressWarnings("Duplicates")
 public class TransformationRequest {
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/request/TransformationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/model/request/TransformationRequest.java
@@ -1,0 +1,96 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.OcrDataField;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class TransformationRequest {
+
+    /**
+     * Deprecated. Use {@link #exceptionRecordId} instead.
+     */
+    @Deprecated
+    public final String id;
+
+    @JsonIgnore
+    @JsonProperty("exception_record_id")
+    public final String exceptionRecordId;
+
+    /**
+     * Deprecated. Use {@link #exceptionRecordCaseTypeId} instead.
+     */
+    @Deprecated
+    @JsonProperty("case_type_id")
+    public final String caseTypeId;
+
+    @JsonIgnore
+    @JsonProperty("exception_record_case_type_id")
+    public final String exceptionRecordCaseTypeId;
+
+    @JsonIgnore
+    @JsonProperty("envelope_id")
+    public final String envelopeId;
+
+    @JsonIgnore
+    @JsonProperty("is_automated_process")
+    public final boolean isAutomatedProcess;
+
+    @JsonProperty("po_box")
+    public final String poBox;
+
+    @JsonProperty("po_box_jurisdiction")
+    public final String poBoxJurisdiction;
+
+    @JsonProperty("journey_classification")
+    public final Classification journeyClassification;
+
+    @JsonProperty("form_type")
+    public final String formType;
+
+    @JsonProperty("delivery_date")
+    public final LocalDateTime deliveryDate;
+
+    @JsonProperty("opening_date")
+    public final LocalDateTime openingDate;
+
+    @JsonProperty("scanned_documents")
+    public final List<ScannedDocument> scannedDocuments;
+
+    @JsonProperty("ocr_data_fields")
+    public final List<OcrDataField> ocrDataFields;
+
+    public TransformationRequest(
+        String id,
+        String caseTypeId,
+        String envelopeId,
+        boolean isAutomatedProcess,
+        String poBox,
+        String poBoxJurisdiction,
+        Classification journeyClassification,
+        String formType,
+        LocalDateTime deliveryDate,
+        LocalDateTime openingDate,
+        List<ScannedDocument> scannedDocuments,
+        List<OcrDataField> ocrDataFields
+    ) {
+        this.id = id;
+        this.exceptionRecordId = id;
+        this.caseTypeId = caseTypeId;
+        this.exceptionRecordCaseTypeId = caseTypeId;
+        this.envelopeId = envelopeId;
+        this.isAutomatedProcess = isAutomatedProcess;
+        this.poBox = poBox;
+        this.poBoxJurisdiction = poBoxJurisdiction;
+        this.journeyClassification = journeyClassification;
+        this.formType = formType;
+        this.deliveryDate = deliveryDate;
+        this.openingDate = openingDate;
+        this.scannedDocuments = scannedDocuments;
+        this.ocrDataFields = ocrDataFields;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/internal/ExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/model/internal/ExceptionRecord.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal;
+
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.OcrDataField;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Internal representation of exception record.
+ */
+public class ExceptionRecord {
+
+    public final String id;
+    public final String caseTypeId;
+    public final String envelopeId;
+    public final String poBox;
+    public final String poBoxJurisdiction;
+    public final Classification journeyClassification;
+    public final String formType;
+    public final LocalDateTime deliveryDate;
+    public final LocalDateTime openingDate;
+    public final List<ScannedDocument> scannedDocuments;
+    public final List<OcrDataField> ocrDataFields;
+
+    public ExceptionRecord(
+        String id,
+        String caseTypeId,
+        String envelopeId,
+        String poBox,
+        String poBoxJurisdiction,
+        Classification journeyClassification,
+        String formType,
+        LocalDateTime deliveryDate,
+        LocalDateTime openingDate,
+        List<ScannedDocument> scannedDocuments,
+        List<OcrDataField> ocrDataFields
+    ) {
+        this.id = id;
+        this.caseTypeId = caseTypeId;
+        this.envelopeId = envelopeId;
+        this.poBox = poBox;
+        this.poBoxJurisdiction = poBoxJurisdiction;
+        this.journeyClassification = journeyClassification;
+        this.formType = formType;
+        this.deliveryDate = deliveryDate;
+        this.openingDate = openingDate;
+        this.scannedDocuments = scannedDocuments;
+        this.ocrDataFields = ocrDataFields;
+    }
+}


### PR DESCRIPTION
### Change description ###

Create separate models representing an exception record:
* one being the internal representation (validation output)
* one representing an exception record in case update request
* one representing a transformation request

These models will be used in following pull requests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
