### PR TITLE
Add a class for creating TransformationRequest objects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ sonarqube {
     property "sonar.projectName", "Reform :: Bulk Scan Orchestrator"
     property "sonar.coverage.jacoco.xmlReportPaths", jacocoTestReport.reports.xml.destination.path
     // TODO: remove the specific exclusions when those classes are used
-    property "sonar.coverage.exclusions", "**/config/**,**/TransformationRequest.java"
+    property "sonar.coverage.exclusions", "**/config/**"
     property "sonar.cpd.exclusions", "**/caseupdate/model/request/ExceptionRecord.java,**/TransformationRequest.java,**/internal/ExceptionRecord.java"
   }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/TransformationRequestCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/TransformationRequestCreator.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.client;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.TransformationRequest;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
+
+@Service
+public class TransformationRequestCreator {
+
+    public TransformationRequest create(ExceptionRecord exceptionRecord) {
+        return new TransformationRequest(
+            exceptionRecord.id,
+            exceptionRecord.caseTypeId,
+            exceptionRecord.envelopeId,
+            false,
+            exceptionRecord.poBox,
+            exceptionRecord.poBoxJurisdiction,
+            exceptionRecord.journeyClassification,
+            exceptionRecord.formType,
+            exceptionRecord.deliveryDate,
+            exceptionRecord.openingDate,
+            exceptionRecord.scannedDocuments,
+            exceptionRecord.ocrDataFields
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/TransformationRequestCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/TransformationRequestCreatorTest.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.client.SampleData.sampleExceptionRecord;
+
+class TransformationRequestCreatorTest {
+
+    @Test
+    void should_set_all_fields_in_the_request_correctly() {
+        // given
+        var exceptionRecord = sampleExceptionRecord();
+
+        // when
+        var transformationRequest = new TransformationRequestCreator().create(exceptionRecord);
+
+        // then
+        assertThat(transformationRequest)
+            .usingRecursiveComparison()
+            .ignoringFields("exceptionRecordCaseTypeId", "exceptionRecordId", "isAutomatedProcess")
+            .isEqualTo(exceptionRecord);
+
+        assertThat(transformationRequest.isAutomatedProcess).isFalse();
+        assertThat(transformationRequest.exceptionRecordCaseTypeId).isEqualTo(exceptionRecord.caseTypeId);
+        assertThat(transformationRequest.exceptionRecordId).isEqualTo(exceptionRecord.id);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1126

### Change description ###

Add a class for creating TransformationRequest objects. The usage of that class will come in the next PR.

This is a part of work around splitting one model into multiple models, each representing a different thing: transformation request, case update request, internal representation of exception record

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
