### PR TITLE
Add more logging to CcdApi case creation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -302,7 +302,7 @@ public class CcdApi {
         }
     }
 
-    public long createNewCaseFromCallback(
+    public long createCase(
         String idamToken,
         String s2sToken,
         String userId,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -322,9 +322,14 @@ public class CcdApi {
                 eventId
             );
 
-            log.info("Started event in CCD. Event: {}, case type: {}. {}", eventId, caseTypeId, logContext);
+            log.info(
+                "Started case-creating event in CCD. Event: {}, case type: {}. {}",
+                eventId,
+                caseTypeId,
+                logContext
+            );
 
-            return feignCcdApi.submitForCaseworker(
+            long caseId = feignCcdApi.submitForCaseworker(
                 idamToken,
                 s2sToken,
                 userId,
@@ -332,7 +337,18 @@ public class CcdApi {
                 caseTypeId,
                 true,
                 caseDataContentBuilder.apply(eventResponse)
-            ).getId();
+            )
+                .getId();
+
+            log.info(
+                "Submitted case-creating event in CCD. Event: {}, case type: {}, case ID: {}. {}",
+                eventId,
+                caseTypeId,
+                caseId,
+                logContext
+            );
+
+            return caseId;
         } catch (FeignException exception) {
             debugCcdException(log, exception, "Failed to call 'createNewCaseFromCallback'");
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -323,7 +323,7 @@ public class CcdApi {
             );
 
             log.info(
-                "Started case-creating event in CCD. Event: {}, case type: {}. {}",
+                "Started case-creation event in CCD. Event: {}, case type: {}. {}",
                 eventId,
                 caseTypeId,
                 logContext
@@ -341,7 +341,7 @@ public class CcdApi {
                 .getId();
 
             log.info(
-                "Submitted case-creating event in CCD. Event: {}, case type: {}, case ID: {}. {}",
+                "Submitted case-creation event in CCD. Event: {}, case type: {}, case ID: {}. {}",
                 eventId,
                 caseTypeId,
                 caseId,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
@@ -167,7 +167,7 @@ public class CcdNewCaseCreator {
             exceptionRecord.formType
         );
 
-        return ccdApi.createNewCaseFromCallback(
+        return ccdApi.createCase(
             ccdRequestCredentials.idamToken,
             ccdRequestCredentials.s2sToken,
             ccdRequestCredentials.userId,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
@@ -95,7 +95,7 @@ class CcdNewCaseCreatorTest {
 
         StartEventResponse startCcdEventResp = mock(StartEventResponse.class);
 
-        given(ccdApi.createNewCaseFromCallback(
+        given(ccdApi.createCase(
             anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any(), anyString()
         )).willReturn(CASE_ID);
 
@@ -118,7 +118,7 @@ class CcdNewCaseCreatorTest {
 
         // and
         var caseDetailsBuilderCaptor = ArgumentCaptor.forClass(Function.class);
-        verify(ccdApi).createNewCaseFromCallback(
+        verify(ccdApi).createCase(
             eq(IDAM_TOKEN),
             anyString(),
             eq(USER_ID),


### PR DESCRIPTION
### Change description ###

Add more logging to CcdApi case creation. Also, rename `createNewCaseFromCallback` method, as it's got nothing to do with callbacks and is going to be reused in automatic case creation.

Next:
* create an override of this method, but without authentication details, as CcdApi typically manages them
* add missing tests for this code, as it's not covered by unit tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
