### PR TITLE
Split TransformationClient into two classes

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/CaseDataTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/CaseDataTransformer.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.TransformationRequestCreator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
+
+@Component
+public class CaseDataTransformer {
+
+    private final TransformationRequestCreator requestCreator;
+    private final TransformationClient transformationClient;
+
+    public CaseDataTransformer(
+        TransformationRequestCreator requestCreator,
+        TransformationClient transformationClient
+    ) {
+        this.requestCreator = requestCreator;
+        this.transformationClient = transformationClient;
+    }
+
+    public SuccessfulTransformationResponse transformExceptionRecord(
+        String baseUrl,
+        ExceptionRecord exceptionRecord,
+        String s2sToken
+    ) {
+        return transformationClient.transformCaseData(
+            baseUrl,
+            requestCreator.create(exceptionRecord),
+            s2sToken
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/TransformationClient.java
@@ -2,38 +2,31 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.TransformationRequestCreator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.TransformationRequest;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
 
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
 
-@Component
+@Service
 public class TransformationClient {
 
     private final RestTemplate restTemplate;
     private final Validator validator;
-    private final TransformationRequestCreator requestCreator;
 
-    public TransformationClient(
-        RestTemplate restTemplate,
-        Validator validator,
-        TransformationRequestCreator requestCreator
-    ) {
+    public TransformationClient(RestTemplate restTemplate, Validator validator) {
         this.restTemplate = restTemplate;
         this.validator = validator;
-        this.requestCreator = requestCreator;
     }
 
-    public SuccessfulTransformationResponse transformExceptionRecord(
+    public SuccessfulTransformationResponse transformCaseData(
         String baseUrl,
-        ExceptionRecord exceptionRecord,
+        TransformationRequest transformationRequest,
         String s2sToken
     ) {
         HttpHeaders headers = new HttpHeaders();
@@ -41,7 +34,7 @@ public class TransformationClient {
 
         SuccessfulTransformationResponse response = restTemplate.postForObject(
             getUrl(baseUrl),
-            new HttpEntity<>(requestCreator.create(exceptionRecord), headers),
+            new HttpEntity<>(transformationRequest, headers),
             SuccessfulTransformationResponse.class
         );
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.RestClientException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.ServiceResponseParser;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response.ClientServiceErrorResponse;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.TransformationClient;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.CaseDataTransformer;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.CaseCreationDetails;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
@@ -33,18 +33,18 @@ public class CcdNewCaseCreator {
 
     public static final String EXCEPTION_RECORD_REFERENCE = "bulkScanCaseReference";
 
-    private final TransformationClient transformationClient;
+    private final CaseDataTransformer caseDataTransformer;
     private final ServiceResponseParser serviceResponseParser;
     private final AuthTokenGenerator s2sTokenGenerator;
     private final CcdApi ccdApi;
 
     public CcdNewCaseCreator(
-        TransformationClient transformationClient,
+        CaseDataTransformer caseDataTransformer,
         ServiceResponseParser serviceResponseParser,
         AuthTokenGenerator s2sTokenGenerator,
         CcdApi ccdApi
     ) {
-        this.transformationClient = transformationClient;
+        this.caseDataTransformer = caseDataTransformer;
         this.serviceResponseParser = serviceResponseParser;
         this.s2sTokenGenerator = s2sTokenGenerator;
         this.ccdApi = ccdApi;
@@ -67,7 +67,7 @@ public class CcdNewCaseCreator {
         try {
             String s2sToken = s2sTokenGenerator.generate();
 
-            SuccessfulTransformationResponse transformationResponse = transformationClient.transformExceptionRecord(
+            SuccessfulTransformationResponse transformationResponse = caseDataTransformer.transformExceptionRecord(
                 configItem.getTransformationUrl(),
                 exceptionRecord,
                 s2sToken

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/CaseDataTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/CaseDataTransformerTest.java
@@ -1,0 +1,78 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.HttpClientErrorException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.TransformationRequestCreator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.TransformationRequest;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CaseDataTransformerTest {
+
+    @Mock
+    private TransformationRequestCreator requestCreator;
+
+    @Mock
+    private TransformationClient transformationClient;
+
+    private CaseDataTransformer caseDataTransformer;
+
+    @BeforeEach
+    void setUp() {
+        caseDataTransformer = new CaseDataTransformer(requestCreator, transformationClient);
+    }
+
+    @Test
+    void transformExceptionRecord_should_call_transformation_client_and_return_its_result() {
+        // given
+        ExceptionRecord exceptionRecord = mock(ExceptionRecord.class);
+        TransformationRequest transformationRequest = mock(TransformationRequest.class);
+
+        given(requestCreator.create(ArgumentMatchers.<ExceptionRecord>any())).willReturn(transformationRequest);
+
+        SuccessfulTransformationResponse expectedResponse = mock(SuccessfulTransformationResponse.class);
+        given(transformationClient.transformCaseData(any(), any(), any())).willReturn(expectedResponse);
+
+        String baseUrl = "baseUrl1";
+        String s2sToken = "s2sToken1";
+
+        // when
+        var result = caseDataTransformer.transformExceptionRecord(baseUrl, exceptionRecord, s2sToken);
+
+        // then
+        assertThat(result).isEqualTo(expectedResponse);
+        verify(requestCreator).create(exceptionRecord);
+        verify(transformationClient).transformCaseData(baseUrl, transformationRequest, s2sToken);
+    }
+
+    @Test
+    void transformExceptionRecord_should_rethrow_exception_when_client_fails() {
+        HttpClientErrorException.BadRequest expectedException = mock(HttpClientErrorException.BadRequest.class);
+
+        willThrow(expectedException).given(transformationClient).transformCaseData(any(), any(), any());
+
+        // when
+        assertThatThrownBy(() ->
+            caseDataTransformer.transformExceptionRecord(
+                "baseUrl1",
+                mock(ExceptionRecord.class),
+                "s2sToken1"
+            )
+        )
+            .isSameAs(expectedException);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.ServiceResponseParser;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response.ClientServiceErrorResponse;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.TransformationClient;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.CaseDataTransformer;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.CaseCreationDetails;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
@@ -50,7 +50,7 @@ class CcdNewCaseCreatorTest {
     private static final String CASE_TYPE_ID = SERVICE + "_ExceptionRecord";
 
     @Mock
-    private TransformationClient transformationClient;
+    private CaseDataTransformer caseDataTransformer;
 
     @Mock
     private ServiceResponseParser serviceResponseParser;
@@ -69,7 +69,7 @@ class CcdNewCaseCreatorTest {
     @BeforeEach
     void setUp() {
         ccdNewCaseCreator = new CcdNewCaseCreator(
-            transformationClient,
+            caseDataTransformer,
             serviceResponseParser,
             s2sTokenGenerator,
             ccdApi
@@ -81,7 +81,7 @@ class CcdNewCaseCreatorTest {
     void should_return_new_case_id_when_successfully_executed_all_the_steps() {
         // given
         given(s2sTokenGenerator.generate()).willReturn(randomUUID().toString());
-        given(transformationClient.transformExceptionRecord(any(), any(), any()))
+        given(caseDataTransformer.transformExceptionRecord(any(), any(), any()))
             .willReturn(
                 new SuccessfulTransformationResponse(
                     new CaseCreationDetails(
@@ -139,7 +139,7 @@ class CcdNewCaseCreatorTest {
         given(serviceResponseParser.parseResponseBody(unprocessableEntity))
             .willReturn(new ClientServiceErrorResponse(singletonList("error"), singletonList("warning")));
         doThrow(unprocessableEntity)
-            .when(transformationClient)
+            .when(caseDataTransformer)
             .transformExceptionRecord(anyString(), any(ExceptionRecord.class), anyString());
 
         ServiceConfigItem configItem = getConfigItem();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1126

### Change description ###

Split `TransformationClient` into:
* higher-level `CaseDataTransformer`, responsible for transforming exception records (and envelopes soon)
* lower-level `TransformationClient`, focused on calling transformation API and parsing the response. 

The reason behind this split is the addition (in the next PR) of calling transformation with envelope data. If the new method was added to `TransformationClient` without this split of responsibilities, that would result in adding a lot of tests (this is what it would look like: https://github.com/hmcts/bulk-scan-orchestrator/pull/1124/files), which can be avoided.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
