### PR TITLE
Create a class representing the result of case creation operation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseCreationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseCreationResult.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.CaseCreationResultType;
+
+public class CaseCreationResult {
+
+    public final CaseCreationResultType resultType;
+    public final Long caseCcdId;
+
+    public CaseCreationResult(CaseCreationResultType resultType, Long caseCcdId) {
+        this.resultType = resultType;
+        this.caseCcdId = caseCcdId;
+    }
+
+    public static CaseCreationResult createdCase(Long caseCcdId) {
+        return new CaseCreationResult(CaseCreationResultType.CREATED_CASE, caseCcdId);
+    }
+
+    public static CaseCreationResult caseAlreadyExists(Long caseCcdId) {
+        return new CaseCreationResult(CaseCreationResultType.CASE_ALREADY_EXISTS, caseCcdId);
+    }
+
+    public static CaseCreationResult unrecoverableFailure() {
+        return new CaseCreationResult(CaseCreationResultType.UNRECOVERABLE_FAILURE, null);
+    }
+
+    public static CaseCreationResult potentiallyRecoverableFailure() {
+        return new CaseCreationResult(CaseCreationResultType.POTENTIALLY_RECOVERABLE_FAILURE, null);
+    }
+
+    public static CaseCreationResult abortedWithoutFailure() {
+        return new CaseCreationResult(CaseCreationResultType.ABORTED_WITHOUT_FAILURE, null);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseCreationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseCreationResult.java
@@ -2,12 +2,12 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.CaseCreationResultType;
 
-public class CaseCreationResult {
+public final class CaseCreationResult {
 
     public final CaseCreationResultType resultType;
     public final Long caseCcdId;
 
-    public CaseCreationResult(CaseCreationResultType resultType, Long caseCcdId) {
+    private CaseCreationResult(CaseCreationResultType resultType, Long caseCcdId) {
         this.resultType = resultType;
         this.caseCcdId = caseCcdId;
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseCreationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseCreationResult.java
@@ -4,6 +4,15 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.CaseCreatio
 
 public final class CaseCreationResult {
 
+    private static final CaseCreationResult UNRECOVERABLE_FAILURE_RESULT =
+        new CaseCreationResult(CaseCreationResultType.UNRECOVERABLE_FAILURE, null);
+
+    private static final CaseCreationResult POTENTIALLY_RECOVERABLE_FAILURE_RESULT =
+        new CaseCreationResult(CaseCreationResultType.POTENTIALLY_RECOVERABLE_FAILURE, null);
+
+    private static final CaseCreationResult ABORTED_WITHOUT_FAILURE_RESULT =
+        new CaseCreationResult(CaseCreationResultType.ABORTED_WITHOUT_FAILURE, null);
+
     public final CaseCreationResultType resultType;
     public final Long caseCcdId;
 
@@ -12,8 +21,8 @@ public final class CaseCreationResult {
         this.caseCcdId = caseCcdId;
     }
 
-    public static CaseCreationResult createdCase(Long caseCcdId) {
-        return new CaseCreationResult(CaseCreationResultType.CREATED_CASE, caseCcdId);
+    public static CaseCreationResult caseCreated(Long caseCcdId) {
+        return new CaseCreationResult(CaseCreationResultType.CASE_CREATED, caseCcdId);
     }
 
     public static CaseCreationResult caseAlreadyExists(Long caseCcdId) {
@@ -21,14 +30,14 @@ public final class CaseCreationResult {
     }
 
     public static CaseCreationResult unrecoverableFailure() {
-        return new CaseCreationResult(CaseCreationResultType.UNRECOVERABLE_FAILURE, null);
+        return UNRECOVERABLE_FAILURE_RESULT;
     }
 
     public static CaseCreationResult potentiallyRecoverableFailure() {
-        return new CaseCreationResult(CaseCreationResultType.POTENTIALLY_RECOVERABLE_FAILURE, null);
+        return POTENTIALLY_RECOVERABLE_FAILURE_RESULT;
     }
 
     public static CaseCreationResult abortedWithoutFailure() {
-        return new CaseCreationResult(CaseCreationResultType.ABORTED_WITHOUT_FAILURE, null);
+        return ABORTED_WITHOUT_FAILURE_RESULT;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CaseCreationResultType.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CaseCreationResultType.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
+
+public enum CaseCreationResultType {
+    CREATED_CASE,
+    CASE_ALREADY_EXISTS,
+    ABORTED_WITHOUT_FAILURE,
+    UNRECOVERABLE_FAILURE,
+    POTENTIALLY_RECOVERABLE_FAILURE
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CaseCreationResultType.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/CaseCreationResultType.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
 public enum CaseCreationResultType {
-    CREATED_CASE,
+    CASE_CREATED,
     CASE_ALREADY_EXISTS,
     ABORTED_WITHOUT_FAILURE,
     UNRECOVERABLE_FAILURE,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseCreationResultTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseCreationResultTest.java
@@ -8,12 +8,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CaseCreationResultTest {
 
     @Test
-    void createdCase_returns_the_right_result() {
+    void caseCreated_returns_the_right_result() {
         long caseId = 1234L;
 
-        var result = CaseCreationResult.createdCase(caseId);
+        var result = CaseCreationResult.caseCreated(caseId);
 
-        assertThat(result.resultType).isEqualTo(CaseCreationResultType.CREATED_CASE);
+        assertThat(result.resultType).isEqualTo(CaseCreationResultType.CASE_CREATED);
         assertThat(result.caseCcdId).isEqualTo(caseId);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseCreationResultTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseCreationResultTest.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events.CaseCreationResultType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CaseCreationResultTest {
+
+    @Test
+    void createdCase_returns_the_right_result() {
+        long caseId = 1234L;
+
+        var result = CaseCreationResult.createdCase(caseId);
+
+        assertThat(result.resultType).isEqualTo(CaseCreationResultType.CREATED_CASE);
+        assertThat(result.caseCcdId).isEqualTo(caseId);
+    }
+
+    @Test
+    void caseAlreadyExists_returns_the_right_result() {
+        long caseId = 1234L;
+
+        var result = CaseCreationResult.caseAlreadyExists(caseId);
+
+        assertThat(result.resultType).isEqualTo(CaseCreationResultType.CASE_ALREADY_EXISTS);
+        assertThat(result.caseCcdId).isEqualTo(caseId);
+    }
+
+    @Test
+    void unrecoverableFailure_returns_the_right_result() {
+        var result = CaseCreationResult.abortedWithoutFailure();
+
+        assertThat(result.resultType).isEqualTo(CaseCreationResultType.ABORTED_WITHOUT_FAILURE);
+        assertThat(result.caseCcdId).isNull();
+    }
+
+    @Test
+    void potentiallyRecoverableFailure_returns_the_right_result() {
+        var result = CaseCreationResult.potentiallyRecoverableFailure();
+
+        assertThat(result.resultType).isEqualTo(CaseCreationResultType.POTENTIALLY_RECOVERABLE_FAILURE);
+        assertThat(result.caseCcdId).isNull();
+    }
+
+    @Test
+    void abortWithoutFailure_returns_the_right_result() {
+        var result = CaseCreationResult.unrecoverableFailure();
+
+        assertThat(result.resultType).isEqualTo(CaseCreationResultType.UNRECOVERABLE_FAILURE);
+        assertThat(result.caseCcdId).isNull();
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1126

### Change description ###

Create a class representing the result of case creation operation. This class is going to be used for passing information from automatic case creator (to be added) to the existing `EnvelopeHandler` class, providing it will all the information it needs in order to decide what to do next:
* fallback to creating exception record
* publish payments

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
