### PR TITLE
Add an envelope-transforming method to CaseDataTransformer

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/CaseDataTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/CaseDataTransformer.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.TransformationRequestCreator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 
 @Component
 public class CaseDataTransformer {
@@ -27,6 +28,18 @@ public class CaseDataTransformer {
         return transformationClient.transformCaseData(
             baseUrl,
             requestCreator.create(exceptionRecord),
+            s2sToken
+        );
+    }
+
+    public SuccessfulTransformationResponse transformEnvelope(
+        String baseUrl,
+        Envelope envelope,
+        String s2sToken
+    ) {
+        return transformationClient.transformCaseData(
+            baseUrl,
+            requestCreator.create(envelope),
             s2sToken
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/CaseDataTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/CaseDataTransformerTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.TransformationRequestCre
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.TransformationRequest;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -70,6 +71,46 @@ class CaseDataTransformerTest {
             caseDataTransformer.transformExceptionRecord(
                 "baseUrl1",
                 mock(ExceptionRecord.class),
+                "s2sToken1"
+            )
+        )
+            .isSameAs(expectedException);
+    }
+
+    @Test
+    void transformEnvelope_should_call_transformation_client_and_return_its_result() {
+        // given
+        Envelope envelope = mock(Envelope.class);
+
+        TransformationRequest transformationRequest = mock(TransformationRequest.class);
+        given(requestCreator.create(ArgumentMatchers.<Envelope>any())).willReturn(transformationRequest);
+
+        SuccessfulTransformationResponse expectedResponse = mock(SuccessfulTransformationResponse.class);
+        given(transformationClient.transformCaseData(any(), any(), any())).willReturn(expectedResponse);
+
+        String baseUrl = "baseUrl1";
+        String s2sToken = "s2sToken1";
+
+        // when
+        var result = caseDataTransformer.transformEnvelope(baseUrl, envelope, s2sToken);
+
+        // then
+        assertThat(result).isEqualTo(expectedResponse);
+        verify(requestCreator).create(envelope);
+        verify(transformationClient).transformCaseData(baseUrl, transformationRequest, s2sToken);
+    }
+
+    @Test
+    void transformEnvelope_should_rethrow_exception_when_client_fails() {
+        HttpClientErrorException.BadRequest expectedException = mock(HttpClientErrorException.BadRequest.class);
+
+        willThrow(expectedException).given(transformationClient).transformCaseData(any(), any(), any());
+
+        // when
+        assertThatThrownBy(() ->
+            caseDataTransformer.transformEnvelope(
+                "baseUrl1",
+                mock(Envelope.class),
                 "s2sToken1"
             )
         )


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1126

### Change description ###

Add an envelope-transforming method to CaseDataTransformer. This method is needed for automated case creation, where there's no exception records.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
