### PR TITLE
Create a class for transforming envelopes into case data

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/EnvelopeTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/EnvelopeTransformer.java
@@ -1,0 +1,121 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation;
+
+import io.vavr.control.Either;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.TransformationRequestCreator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.TransformationRequest;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.config.ServiceConfigProvider;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
+
+import javax.validation.ConstraintViolationException;
+
+import static io.vavr.control.Either.left;
+import static io.vavr.control.Either.right;
+import static java.lang.String.format;
+
+@Service
+public class EnvelopeTransformer {
+
+    private static final Logger log = LoggerFactory.getLogger(EnvelopeTransformer.class);
+
+    private final TransformationRequestCreator requestCreator;
+    private final TransformationClient transformationClient;
+    private final ServiceConfigProvider serviceConfigProvider;
+
+    public EnvelopeTransformer(
+        TransformationRequestCreator requestCreator,
+        TransformationClient transformationClient,
+        ServiceConfigProvider serviceConfigProvider
+    ) {
+        this.requestCreator = requestCreator;
+        this.transformationClient = transformationClient;
+        this.serviceConfigProvider = serviceConfigProvider;
+    }
+
+    public Either<TransformationFailureType, SuccessfulTransformationResponse> transformEnvelope(
+        Envelope envelope
+    ) {
+        String loggingContext = getLoggingContext(envelope);
+
+        try {
+            log.info("About to transform envelope. {}", loggingContext);
+
+            String transformationUrl = serviceConfigProvider.getConfig(envelope.container).getTransformationUrl();
+            TransformationRequest transformationRequest = requestCreator.create(envelope);
+
+            SuccessfulTransformationResponse transformationResponse =
+                transformationClient.transformCaseData(transformationUrl, transformationRequest);
+
+            log.info("Received successful transformation response for envelope. {}", loggingContext);
+
+            return right(transformationResponse);
+        } catch (ConstraintViolationException ex) {
+            logMalformedTransformationResponseError(ex, loggingContext);
+            return left(TransformationFailureType.UNRECOVERABLE);
+        } catch (HttpClientErrorException.BadRequest ex) {
+            logBadRequestTransformationResponseError(ex, loggingContext);
+            return left(TransformationFailureType.UNRECOVERABLE);
+        } catch (HttpClientErrorException.UnprocessableEntity ex) {
+            logUnprocessableEntityTransformationResponse(ex, loggingContext);
+            return left(TransformationFailureType.UNRECOVERABLE);
+        } catch (Exception ex) {
+            log.error("An error occurred when transforming envelope into case data. {}", loggingContext, ex);
+            return left(TransformationFailureType.POTENTIALLY_RECOVERABLE);
+        }
+    }
+
+    private void logUnprocessableEntityTransformationResponse(
+        HttpClientErrorException.UnprocessableEntity exception,
+        String loggingContext
+    ) {
+        log.info(
+            "Received validation error response from transformation endpoint called for envelope. {}",
+            loggingContext,
+            exception
+        );
+    }
+
+    private void logBadRequestTransformationResponseError(
+        HttpClientErrorException.BadRequest exception,
+        String loggingContext
+    ) {
+        String responseBody = exception.getResponseBodyAsString();
+        log.error(
+            "Received a response with status {} from transformation endpoint called for envelope. "
+                + "{}. Response starts with: [{}]",
+            exception.getRawStatusCode(),
+            loggingContext,
+            responseBody.substring(0, Math.min(10000, responseBody.length())),
+            exception
+        );
+    }
+
+    private void logMalformedTransformationResponseError(
+        ConstraintViolationException exception,
+        String loggingContext
+    ) {
+        log.error(
+            "Received malformed response from transformation endpoint called for envelope. {} Violations: [{}].",
+            loggingContext,
+            exception.getMessage()
+        );
+    }
+
+    private String getLoggingContext(Envelope envelope) {
+        return format(
+            "Envelope ID: %s. File name: %s. Service: %s.",
+            envelope.id,
+            envelope.zipFileName,
+            envelope.container
+        );
+    }
+
+    public enum TransformationFailureType {
+        POTENTIALLY_RECOVERABLE,
+        UNRECOVERABLE
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/EnvelopeTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/EnvelopeTransformerTest.java
@@ -1,0 +1,172 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.TransformationRequestCreator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.TransformationRequest;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.config.ServiceConfigProvider;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
+
+import java.time.Instant;
+import javax.validation.ConstraintViolationException;
+
+import static io.vavr.control.Either.left;
+import static io.vavr.control.Either.right;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class EnvelopeTransformerTest {
+
+    @Mock
+    private TransformationRequestCreator requestCreator;
+
+    @Mock
+    private TransformationClient transformationClient;
+
+    @Mock
+    private ServiceConfigProvider serviceConfigProvider;
+
+    @Mock
+    private ServiceConfigItem serviceConfigItem;
+
+    private EnvelopeTransformer envelopeTransformer;
+
+    @BeforeEach
+    void setUp() {
+        given(serviceConfigProvider.getConfig(any())).willReturn(serviceConfigItem);
+
+        envelopeTransformer = new EnvelopeTransformer(
+            requestCreator,
+            transformationClient,
+            serviceConfigProvider
+        );
+    }
+
+    @Test
+    void transformEnvelope_should_call_transformation_client_and_return_its_result() {
+        // given
+        Envelope envelope = sampleEnvelope();
+
+        TransformationRequest transformationRequest = mock(TransformationRequest.class);
+        given(requestCreator.create(ArgumentMatchers.<Envelope>any())).willReturn(transformationRequest);
+
+        SuccessfulTransformationResponse expectedResponse = mock(SuccessfulTransformationResponse.class);
+        given(transformationClient.transformCaseData(any(), any())).willReturn(expectedResponse);
+
+        String transformationUrl = "transformationUrl1";
+        given(serviceConfigItem.getTransformationUrl()).willReturn(transformationUrl);
+
+        // when
+        var result = envelopeTransformer.transformEnvelope(envelope);
+
+        // then
+        assertThat(result).isEqualTo(right(expectedResponse));
+        verify(requestCreator).create(envelope);
+        verify(transformationClient).transformCaseData(transformationUrl, transformationRequest);
+        verify(serviceConfigProvider).getConfig(envelope.container);
+    }
+
+    @Test
+    void should_return_failure_when_transformation_response_is_malformed() {
+        verifyCorrectResultIsReturnedWhenClientThrowsException(
+            new ConstraintViolationException("test", emptySet()),
+            EnvelopeTransformer.TransformationFailureType.UNRECOVERABLE
+        );
+    }
+
+    @Test
+    void should_return_failure_when_transformation_results_in_bad_request_response() {
+        verifyCorrectResultIsReturnedWhenClientThrowsException(
+            transformationErrorResponseException(HttpStatus.BAD_REQUEST),
+            EnvelopeTransformer.TransformationFailureType.UNRECOVERABLE
+        );
+    }
+
+    @Test
+    void should_return_failure_when_transformation_results_in_unprocessable_entity_response() {
+        verifyCorrectResultIsReturnedWhenClientThrowsException(
+            transformationErrorResponseException(HttpStatus.UNPROCESSABLE_ENTITY),
+            EnvelopeTransformer.TransformationFailureType.UNRECOVERABLE
+        );
+    }
+
+    @Test
+    void should_return_failure_when_transformation_results_in_other_error_response() {
+        verifyCorrectResultIsReturnedWhenClientThrowsException(
+            transformationErrorResponseException(HttpStatus.INTERNAL_SERVER_ERROR),
+            EnvelopeTransformer.TransformationFailureType.POTENTIALLY_RECOVERABLE
+        );
+    }
+
+    @Test
+    void should_return_failure_when_case_data_transformer_throws_other_exception() {
+        verifyCorrectResultIsReturnedWhenClientThrowsException(
+            new RuntimeException("test"),
+            EnvelopeTransformer.TransformationFailureType.POTENTIALLY_RECOVERABLE
+        );
+    }
+
+    private void verifyCorrectResultIsReturnedWhenClientThrowsException(
+        Exception transformationClientException,
+        EnvelopeTransformer.TransformationFailureType expectedFailureType
+    ) {
+        // given
+        given(requestCreator.create(ArgumentMatchers.<Envelope>any())).willReturn(
+            mock(TransformationRequest.class)
+        );
+
+        willThrow(transformationClientException)
+            .given(transformationClient)
+            .transformCaseData(any(), any());
+
+        // when
+        var result = envelopeTransformer.transformEnvelope(sampleEnvelope());
+
+        // then
+        assertThat(result).isEqualTo(left(expectedFailureType));
+
+        verify(transformationClient).transformCaseData(any(), any());
+    }
+
+
+    private HttpClientErrorException transformationErrorResponseException(HttpStatus status) {
+        return HttpClientErrorException.create(status, "test", HttpHeaders.EMPTY, null, null);
+    }
+
+    private Envelope sampleEnvelope() {
+        return new Envelope(
+            "envelopeId1",
+            "caseRef1",
+            "legacyCaseRef1",
+            "poBox1",
+            "jurisdiction1",
+            "service1",
+            "zipFileName1",
+            "formType1",
+            Instant.now().minusSeconds(1),
+            Instant.now(),
+            Classification.NEW_APPLICATION,
+            emptyList(),
+            emptyList(),
+            emptyList(),
+            emptyList()
+        );
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1126

### Change description ###

Create a class for transforming envelopes into case data and translating failures into the right result, based on which the caller can decide what to do with the failure - create an exception record or retry later.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
