### PR TITLE
Remove servicebus connection strings from fun tests

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -57,6 +57,8 @@ withPipeline(type, product, component) {
     env.IDAM_API_URL = 'https://idam-api.aat.platform.hmcts.net'
     env.IDAM_CLIENT_REDIRECT_URI = 'https://bulk-scan-orchestrator-aat.service.core-compute-aat.internal/oauth2/callback'
     env.QUEUE_NAMESPACE = "bulk-scan-servicebus-aat"
+    env.QUEUE_ENVELOPES_NAME = "envelopes-staging"
+    env.QUEUE_PAYMENTS_NAME = "payments-staging"
     env.QUEUE_READ_ACCESS_KEY_NAME = 'ListenSharedAccessKey'
     env.QUEUE_WRITE_ACCESS_KEY_NAME = 'SendSharedAccessKey'
   }
@@ -80,6 +82,8 @@ withPipeline(type, product, component) {
       env.ENVELOPES_QUEUE_READ_ACCESS_KEY = sbPrimaryKey
       env.PAYMENTS_QUEUE_WRITE_ACCESS_KEY = sbPrimaryKey
       env.QUEUE_NAMESPACE = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.namespaceName}")
+      env.QUEUE_ENVELOPES_NAME = "envelopes"
+      env.QUEUE_PAYMENTS_NAME = "payments"
       env.QUEUE_READ_ACCESS_KEY_NAME = 'RootManageSharedAccessKey'
       env.QUEUE_WRITE_ACCESS_KEY_NAME = 'RootManageSharedAccessKey'
     }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -22,9 +22,9 @@ def nonPrSecrets = [
     secret('idam-users-bulkscan-username', 'IDAM_USER_NAME'),
     secret('idam-users-bulkscan-password', 'IDAM_USER_PASSWORD'),
     secret('idam-client-secret', 'IDAM_CLIENT_SECRET'),
-    secret('envelopes-staging-queue-send-connection-string', 'ENVELOPES_QUEUE_WRITE_CONN_STRING'),
-    secret('envelopes-staging-queue-listen-connection-string', 'ENVELOPES_QUEUE_READ_CONN_STRING'),
-    secret('payments-staging-queue-send-connection-string', 'PAYMENTS_QUEUE_WRITE_CONN_STRING')
+    secret('envelopes-staging-queue-send-shared-access-key', 'ENVELOPES_QUEUE_WRITE_ACCESS_KEY'),
+    secret('envelopes-staging-queue-listen-shared-access-key', 'ENVELOPES_QUEUE_READ_ACCESS_KEY'),
+    secret('payments-staging-queue-send-shared-access-key', 'PAYMENTS_QUEUE_WRITE_ACCESS_KEY')
   ]
 ]
 def prSecrets = [
@@ -56,6 +56,9 @@ withPipeline(type, product, component) {
     env.CORE_CASE_DATA_API_URL = 'http://ccd-data-store-api-aat.service.core-compute-aat.internal'
     env.IDAM_API_URL = 'https://idam-api.aat.platform.hmcts.net'
     env.IDAM_CLIENT_REDIRECT_URI = 'https://bulk-scan-orchestrator-aat.service.core-compute-aat.internal/oauth2/callback'
+    env.QUEUE_NAMESPACE = "bulk-scan-servicebus-aat"
+    env.QUEUE_READ_ACCESS_KEY_NAME = 'ListenSharedAccessKey'
+    env.QUEUE_WRITE_ACCESS_KEY_NAME = 'SendSharedAccessKey'
   }
 
   before('smoketest:preview') {
@@ -72,10 +75,13 @@ withPipeline(type, product, component) {
       kubectl.login()
 
       // Get envelopes queue connection string
-      def sbConnectionStr = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.connectionString}")
-      env.ENVELOPES_QUEUE_WRITE_CONN_STRING = "${sbConnectionStr};EntityPath=envelopes"
-      env.ENVELOPES_QUEUE_READ_CONN_STRING = "${sbConnectionStr};EntityPath=envelopes"
-      env.PAYMENTS_QUEUE_WRITE_CONN_STRING = "${sbConnectionStr};EntityPath=payments"
+      def sbPrimaryKey = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.primaryKey}")
+      env.ENVELOPES_QUEUE_WRITE_ACCESS_KEY = sbPrimaryKey
+      env.ENVELOPES_QUEUE_READ_ACCESS_KEY = sbPrimaryKey
+      env.PAYMENTS_QUEUE_WRITE_ACCESS_KEY = sbPrimaryKey
+      env.QUEUE_NAMESPACE = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.namespaceName}")
+      env.QUEUE_READ_ACCESS_KEY_NAME = 'RootManageSharedAccessKey'
+      env.QUEUE_WRITE_ACCESS_KEY_NAME = 'RootManageSharedAccessKey'
     }
   }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
@@ -20,16 +20,25 @@ import static org.mockito.Mockito.mock;
 
 public class FunctionalQueueConfig {
 
-    @Value("${queue.envelopes.write-connection-string}")
-    private String queueWriteConnectionString;
+    @Value("${queue.envelopes.write-access-key}")
+    private String queueWriteAccessKey;
 
-    @Value("${queue.envelopes.read-connection-string}")
-    private String queueReadConnectionString;
+    @Value("${queue.envelopes.read-access-key}")
+    private String queueReadAccessKey;
+
+    @Value("${queue.read-access-key-name}")
+    private String queueReadAccessKeyName;
+
+    @Value("${queue.write-access-key-name}")
+    private String queueWriteAccessKeyName;
+
+    @Value("${queue.namespace}")
+    private String queueNamespace;
 
     @Bean
     public QueueClient testWriteClient() throws ServiceBusException, InterruptedException {
         return new QueueClient(
-            new ConnectionStringBuilder(queueWriteConnectionString),
+            new ConnectionStringBuilder(queueNamespace, "envelopes", queueWriteAccessKeyName, queueWriteAccessKey),
             ReceiveMode.PEEKLOCK
         );
     }
@@ -39,7 +48,12 @@ public class FunctionalQueueConfig {
         return () -> {
             try {
                 return ClientFactory.createMessageReceiverFromConnectionStringBuilder(
-                    new ConnectionStringBuilder(StringUtils.join(queueReadConnectionString, "/$deadletterqueue")),
+                    new ConnectionStringBuilder(
+                        queueNamespace,
+                        StringUtils.join("envelopes", "/$deadletterqueue"),
+                        queueReadAccessKeyName,
+                        queueReadAccessKey
+                    ),
                     ReceiveMode.PEEKLOCK
                 );
             } catch (InterruptedException e) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/FunctionalQueueConfig.java
@@ -20,6 +20,9 @@ import static org.mockito.Mockito.mock;
 
 public class FunctionalQueueConfig {
 
+    @Value("${queue.envelopes.name}")
+    private String queueName;
+
     @Value("${queue.envelopes.write-access-key}")
     private String queueWriteAccessKey;
 
@@ -38,7 +41,7 @@ public class FunctionalQueueConfig {
     @Bean
     public QueueClient testWriteClient() throws ServiceBusException, InterruptedException {
         return new QueueClient(
-            new ConnectionStringBuilder(queueNamespace, "envelopes", queueWriteAccessKeyName, queueWriteAccessKey),
+            new ConnectionStringBuilder(queueNamespace, queueName, queueWriteAccessKeyName, queueWriteAccessKey),
             ReceiveMode.PEEKLOCK
         );
     }
@@ -50,7 +53,7 @@ public class FunctionalQueueConfig {
                 return ClientFactory.createMessageReceiverFromConnectionStringBuilder(
                     new ConnectionStringBuilder(
                         queueNamespace,
-                        StringUtils.join("envelopes", "/$deadletterqueue"),
+                        StringUtils.join(queueName, "/$deadletterqueue"),
                         queueReadAccessKeyName,
                         queueReadAccessKey
                     ),

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -11,11 +11,14 @@ spring:
     name: Bulk Scan Orchestrator Functional Tests
 
 queue:
+  namespace: ${QUEUE_NAMESPACE}
+  read-access-key-name: ${QUEUE_READ_ACCESS_KEY_NAME}
+  write-access-key-name: ${QUEUE_WRITE_ACCESS_KEY_NAME}
   envelopes:
-    write-connection-string: ${ENVELOPES_QUEUE_WRITE_CONN_STRING}
-    read-connection-string: ${ENVELOPES_QUEUE_READ_CONN_STRING}
+    write-access-key: ${ENVELOPES_QUEUE_WRITE_ACCESS_KEY}
+    read-access-key: ${ENVELOPES_QUEUE_READ_ACCESS_KEY}
   payments:
-    write-connection-string: ${PAYMENTS_QUEUE_WRITE_CONN_STRING}
+    write-access-key: ${PAYMENTS_QUEUE_WRITE_ACCESS_KEY}
 
 # because functional tests load up SpringBootTest
 azure:

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -15,9 +15,11 @@ queue:
   read-access-key-name: ${QUEUE_READ_ACCESS_KEY_NAME}
   write-access-key-name: ${QUEUE_WRITE_ACCESS_KEY_NAME}
   envelopes:
+    name: ${QUEUE_ENVELOPES_NAME}
     write-access-key: ${ENVELOPES_QUEUE_WRITE_ACCESS_KEY}
     read-access-key: ${ENVELOPES_QUEUE_READ_ACCESS_KEY}
   payments:
+    name: ${QUEUE_PAYMENTS_NAME}
     write-access-key: ${PAYMENTS_QUEUE_WRITE_ACCESS_KEY}
 
 # because functional tests load up SpringBootTest


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Improve the way Service Bus clients are created](https://tools.hmcts.net/jira/browse/BPS-771)

### Change description ###

Noticed payments queue is not used but i'm not removing as part of this ticket - just replace conn strings.

Flux PR shortly coming - it'll need new env vars. Will not remove old to not break anything

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
