### PR TITLE
Fix Instant to LocalDateTime conversion in TransformationRequestCreator

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/TransformationRequestCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/TransformationRequestCreator.java
@@ -119,6 +119,10 @@ public class TransformationRequestCreator {
     }
 
     private LocalDateTime toLocalDateTime(Instant instant) {
-        return ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()).toLocalDateTime();
+        if (instant == null) {
+            return null;
+        } else {
+            return ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()).toLocalDateTime();
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/TransformationRequestCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/TransformationRequestCreatorTest.java
@@ -183,7 +183,7 @@ class TransformationRequestCreatorTest {
                 "subtype2",
                 Instant.now().plusSeconds(2),
                 "uuid1",
-                Instant.now().plusSeconds(3)
+                null
             )
         );
     }
@@ -196,6 +196,8 @@ class TransformationRequestCreatorTest {
     }
 
     private LocalDateTime toLocalDateTime(Instant instant) {
-        return ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()).toLocalDateTime();
+        return instant == null
+            ? null
+            : ZonedDateTime.ofInstant(instant, ZoneId.systemDefault()).toLocalDateTime();
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1126

### Change description ###

Fix Instant to LocalDateTime conversion in TransformationRequestCreator. Used to fail on null input.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
