### PR TITLE
Turn CaseDataTransformer back into ExceptionRecordTransformer

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/ExceptionRecordTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/ExceptionRecordTransformer.java
@@ -4,15 +4,14 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.TransformationRequestCreator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 
 @Component
-public class CaseDataTransformer {
+public class ExceptionRecordTransformer {
 
     private final TransformationRequestCreator requestCreator;
     private final TransformationClient transformationClient;
 
-    public CaseDataTransformer(
+    public ExceptionRecordTransformer(
         TransformationRequestCreator requestCreator,
         TransformationClient transformationClient
     ) {
@@ -27,16 +26,6 @@ public class CaseDataTransformer {
         return transformationClient.transformCaseData(
             baseUrl,
             requestCreator.create(exceptionRecord)
-        );
-    }
-
-    public SuccessfulTransformationResponse transformEnvelope(
-        String baseUrl,
-        Envelope envelope
-    ) {
-        return transformationClient.transformCaseData(
-            baseUrl,
-            requestCreator.create(envelope)
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreator.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.RestClientException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.ServiceResponseParser;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response.ClientServiceErrorResponse;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.CaseDataTransformer;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.ExceptionRecordTransformer;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.CaseCreationDetails;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
@@ -33,18 +33,18 @@ public class CcdNewCaseCreator {
 
     public static final String EXCEPTION_RECORD_REFERENCE = "bulkScanCaseReference";
 
-    private final CaseDataTransformer caseDataTransformer;
+    private final ExceptionRecordTransformer exceptionRecordTransformer;
     private final ServiceResponseParser serviceResponseParser;
     private final AuthTokenGenerator s2sTokenGenerator;
     private final CcdApi ccdApi;
 
     public CcdNewCaseCreator(
-        CaseDataTransformer caseDataTransformer,
+        ExceptionRecordTransformer exceptionRecordTransformer,
         ServiceResponseParser serviceResponseParser,
         AuthTokenGenerator s2sTokenGenerator,
         CcdApi ccdApi
     ) {
-        this.caseDataTransformer = caseDataTransformer;
+        this.exceptionRecordTransformer = exceptionRecordTransformer;
         this.serviceResponseParser = serviceResponseParser;
         this.s2sTokenGenerator = s2sTokenGenerator;
         this.ccdApi = ccdApi;
@@ -66,7 +66,7 @@ public class CcdNewCaseCreator {
 
         try {
             SuccessfulTransformationResponse transformationResponse =
-                caseDataTransformer.transformExceptionRecord(configItem.getTransformationUrl(), exceptionRecord);
+                exceptionRecordTransformer.transformExceptionRecord(configItem.getTransformationUrl(), exceptionRecord);
 
             if (!ignoreWarnings && !transformationResponse.warnings.isEmpty()) {
                 log.info(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/ExceptionRecordTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/ExceptionRecordTransformerTest.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.TransformationRequestCre
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.request.TransformationRequest;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -22,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class CaseDataTransformerTest {
+class ExceptionRecordTransformerTest {
 
     @Mock
     private TransformationRequestCreator requestCreator;
@@ -30,11 +29,11 @@ class CaseDataTransformerTest {
     @Mock
     private TransformationClient transformationClient;
 
-    private CaseDataTransformer caseDataTransformer;
+    private ExceptionRecordTransformer exceptionRecordTransformer;
 
     @BeforeEach
     void setUp() {
-        caseDataTransformer = new CaseDataTransformer(requestCreator, transformationClient);
+        exceptionRecordTransformer = new ExceptionRecordTransformer(requestCreator, transformationClient);
     }
 
     @Test
@@ -52,7 +51,7 @@ class CaseDataTransformerTest {
         String s2sToken = "s2sToken1";
 
         // when
-        var result = caseDataTransformer.transformExceptionRecord(baseUrl, exceptionRecord);
+        var result = exceptionRecordTransformer.transformExceptionRecord(baseUrl, exceptionRecord);
 
         // then
         assertThat(result).isEqualTo(expectedResponse);
@@ -68,42 +67,7 @@ class CaseDataTransformerTest {
 
         // when
         assertThatThrownBy(() ->
-            caseDataTransformer.transformExceptionRecord("baseUrl1", mock(ExceptionRecord.class))
-        )
-            .isSameAs(expectedException);
-    }
-
-    @Test
-    void transformEnvelope_should_call_transformation_client_and_return_its_result() {
-        // given
-        Envelope envelope = mock(Envelope.class);
-
-        TransformationRequest transformationRequest = mock(TransformationRequest.class);
-        given(requestCreator.create(ArgumentMatchers.<Envelope>any())).willReturn(transformationRequest);
-
-        SuccessfulTransformationResponse expectedResponse = mock(SuccessfulTransformationResponse.class);
-        given(transformationClient.transformCaseData(any(), any())).willReturn(expectedResponse);
-
-        String baseUrl = "baseUrl1";
-
-        // when
-        var result = caseDataTransformer.transformEnvelope(baseUrl, envelope);
-
-        // then
-        assertThat(result).isEqualTo(expectedResponse);
-        verify(requestCreator).create(envelope);
-        verify(transformationClient).transformCaseData(baseUrl, transformationRequest);
-    }
-
-    @Test
-    void transformEnvelope_should_rethrow_exception_when_client_fails() {
-        HttpClientErrorException.BadRequest expectedException = mock(HttpClientErrorException.BadRequest.class);
-
-        willThrow(expectedException).given(transformationClient).transformCaseData(any(), any());
-
-        // when
-        assertThatThrownBy(() ->
-            caseDataTransformer.transformEnvelope("baseUrl1", mock(Envelope.class))
+            exceptionRecordTransformer.transformExceptionRecord("baseUrl1", mock(ExceptionRecord.class))
         )
             .isSameAs(expectedException);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdNewCaseCreatorTest.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.ServiceResponseParser;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response.ClientServiceErrorResponse;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.CaseDataTransformer;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.ExceptionRecordTransformer;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.CaseCreationDetails;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.response.SuccessfulTransformationResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
@@ -49,7 +49,7 @@ class CcdNewCaseCreatorTest {
     private static final String CASE_TYPE_ID = SERVICE + "_ExceptionRecord";
 
     @Mock
-    private CaseDataTransformer caseDataTransformer;
+    private ExceptionRecordTransformer exceptionRecordTransformer;
 
     @Mock
     private ServiceResponseParser serviceResponseParser;
@@ -68,7 +68,7 @@ class CcdNewCaseCreatorTest {
     @BeforeEach
     void setUp() {
         ccdNewCaseCreator = new CcdNewCaseCreator(
-            caseDataTransformer,
+            exceptionRecordTransformer,
             serviceResponseParser,
             s2sTokenGenerator,
             ccdApi
@@ -80,7 +80,7 @@ class CcdNewCaseCreatorTest {
     void should_return_new_case_id_when_successfully_executed_all_the_steps() {
         // given
         given(s2sTokenGenerator.generate()).willReturn(randomUUID().toString());
-        given(caseDataTransformer.transformExceptionRecord(any(), any()))
+        given(exceptionRecordTransformer.transformExceptionRecord(any(), any()))
             .willReturn(
                 new SuccessfulTransformationResponse(
                     new CaseCreationDetails(
@@ -137,7 +137,7 @@ class CcdNewCaseCreatorTest {
         given(serviceResponseParser.parseResponseBody(unprocessableEntity))
             .willReturn(new ClientServiceErrorResponse(singletonList("error"), singletonList("warning")));
         doThrow(unprocessableEntity)
-            .when(caseDataTransformer)
+            .when(exceptionRecordTransformer)
             .transformExceptionRecord(anyString(), any(ExceptionRecord.class));
 
         ServiceConfigItem configItem = getConfigItem();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1126

### Change description ###

This is just code cleanup.

Turn CaseDataTransformer back to ExceptionRecordTransformer. Since `transformEnvelope` method was extracted into a separate class, `EnvelopeTransformer`, this one's only responsibility is to transform exception record data into case data.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
