### PR TITLE
Update bulkScanEnvelopes field when attaching exception record to a case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -15,6 +15,7 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.collect.Maps.newHashMap;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SCANNED_DOCUMENTS;
@@ -49,11 +50,11 @@ public class ScannedDocumentsHelper {
     }
 
     @SuppressWarnings("unchecked")
-    public static void setExceptionRecordIdToScannedDocuments(
+    public static Map<String, Object> setExceptionRecordIdToScannedDocuments(
         ExceptionRecord exceptionRecord,
         CaseUpdateDetails caseDetails
     ) {
-        var caseData = (Map<String, Object>) caseDetails.caseData;
+        var caseData = newHashMap((Map<String, Object>)caseDetails.caseData);
         List<ScannedDocument> scannedDocuments = getScannedDocuments(caseData);
 
         List<String> exceptionRecordDcns = exceptionRecord.scannedDocuments
@@ -82,6 +83,7 @@ public class ScannedDocumentsHelper {
             })
             .collect(toList());
         caseData.put(SCANNED_DOCUMENTS, updatedScannedDocuments);
+        return caseData;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -14,6 +14,8 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.respons
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response.ClientServiceErrorResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CaseAction;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.CcdCollectionElement;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.EnvelopeReference;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CallbackException;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
@@ -254,15 +256,14 @@ public class CcdCaseUpdater {
         var updatedCaseData = newHashMap(transformedCaseData);
 
         if (envelopeReferenceHelper.serviceSupportsEnvelopeReferences(service)) {
-            var envelopeReferences = envelopeReferenceHelper.parseEnvelopeReferences(
-                (List<Map<String, Object>>) originalCaseData.get(BULK_SCAN_CASE_REFERENCE)
-            );
+            var envelopeReferences =
+                envelopeReferenceHelper
+                    .parseEnvelopeReferences(
+                        (List<Map<String, Object>>) originalCaseData.get(BULK_SCAN_CASE_REFERENCE)
+                    );
 
-            envelopeReferences.addAll(
-                envelopeReferenceHelper.singleEnvelopeReferenceList(
-                    exceptionRecord.envelopeId,
-                    CaseAction.UPDATE
-                )
+            envelopeReferences.add(
+                new CcdCollectionElement<>(new EnvelopeReference(exceptionRecord.envelopeId, CaseAction.UPDATE))
             );
 
             updatedCaseData.put(BULK_SCAN_ENVELOPES, envelopeReferences);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
@@ -125,10 +125,13 @@ class ScannedDocumentsHelperTest {
         );
 
         // when
-        ScannedDocumentsHelper.setExceptionRecordIdToScannedDocuments(exceptionRecord, caseDetails);
+        var updatedCaseData = ScannedDocumentsHelper.setExceptionRecordIdToScannedDocuments(
+            exceptionRecord,
+            caseDetails
+        );
 
         //then
-        var updatedScannedDocuments = getScannedDocuments(caseDetails);
+        var updatedScannedDocuments = getScannedDocuments(updatedCaseData);
         assertThat(updatedScannedDocuments).hasSize(3);
         assertThat(updatedScannedDocuments.get(0).controlNumber).isEqualTo("1000");
         assertThat(updatedScannedDocuments.get(0).exceptionReference).isEqualTo("1");
@@ -159,10 +162,13 @@ class ScannedDocumentsHelperTest {
         );
 
         // when
-        ScannedDocumentsHelper.setExceptionRecordIdToScannedDocuments(exceptionRecord, caseDetails);
+        var updatedCaseData = ScannedDocumentsHelper.setExceptionRecordIdToScannedDocuments(
+            exceptionRecord,
+            caseDetails
+        );
 
         //then
-        var updatedScannedDocuments = getScannedDocuments(caseDetails);
+        var updatedScannedDocuments = getScannedDocuments(updatedCaseData);
         assertThat(updatedScannedDocuments).hasSize(3);
         assertThat(updatedScannedDocuments.get(0).controlNumber).isEqualTo("1000");
         assertThat(updatedScannedDocuments.get(0).exceptionReference).isNull();
@@ -193,9 +199,8 @@ class ScannedDocumentsHelperTest {
     }
 
     private List<uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument> getScannedDocuments(
-        CaseUpdateDetails caseDetails
+        Map<String, Object> caseData
     ) {
-        var caseData = (Map<String, Object>) caseDetails.caseData;
         var scannedDocuments = (List<Map<String, Object>>) caseData.get(SCANNED_DOCUMENTS);
         return scannedDocuments.stream().map(o ->
             objectMapper.convertValue(

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -57,6 +57,7 @@ class CcdCaseUpdaterTest {
 
     @Mock private CaseUpdateClient caseUpdateClient;
     @Mock private ServiceResponseParser serviceResponseParser;
+    @Mock private EnvelopeReferenceHelper envelopeReferenceHelper;
     @Mock private AuthTokenGenerator authTokenGenerator;
     @Mock private CoreCaseDataApi coreCaseDataApi;
     @Mock private ServiceConfigItem configItem;
@@ -76,7 +77,8 @@ class CcdCaseUpdaterTest {
             authTokenGenerator,
             coreCaseDataApi,
             caseUpdateClient,
-            serviceResponseParser
+            serviceResponseParser,
+            envelopeReferenceHelper
         );
 
         caseUpdateDetails = new CaseUpdateDetails(null, new HashMap<String, String>());


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1373

### Change description ###

**The change in `CcdCaseUpdater` is not covered by unit tests, yet. We need to verify that `bulkScanEnvelopes` field is:**

- extended by the new envelope when service supports that field
- set to null otherwise

Update `bulkScanEnvelopes` field when attaching exception record to a case.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
