### PR TITLE
Add SSCS case type id to service config

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -107,7 +107,8 @@ service-config:
     - service: sscs
       jurisdiction: SSCS
       transformation-url: ${TRANSFORMATION_URL_SSCS}
-      case-type-ids: []
+      case-type-ids:
+        - Benefit
       form-type-to-surname-ocr-field-mappings:
         - formType: sscs1
           ocrFields:


### PR DESCRIPTION
### Change description ###
SSCS is failing to create a case from Exception record as the CCD search case by exception record is returning 400 for missing case type ids.
https://portal.azure.com/#blade/AppInsightsExtension/DetailsV2Blade/DataModel/%7B%22eventId%22%3A%2205945d61-e621-11ea-874b-a98fca5c423d%22%2C%22timestamp%22%3A%222020-08-24T15%3A46%3A43.978Z%22%7D/ComponentId/%7B%22Name%22%3A%22bulk-scan-demo%22%2C%22ResourceGroup%22%3A%22bulk-scan-demo%22%2C%22SubscriptionId%22%3A%221c4f0704-a29e-403d-b719-b90c34ef14c9%22%7D

Added SSCS case type to fix the issue.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
