### PR TITLE
Clean up setting exception record id on case documents (part1)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.StringUtils;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.response.CaseUpdateDetails;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Document;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -15,6 +15,7 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.collect.Maps.newHashMap;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SCANNED_DOCUMENTS;
@@ -48,12 +49,11 @@ public class ScannedDocumentsHelper {
             .collect(toList());
     }
 
-    @SuppressWarnings("unchecked")
-    public static void setExceptionRecordIdToScannedDocuments(
+    public static Map<String, Object> setExceptionRecordIdToScannedDocuments(
         ExceptionRecord exceptionRecord,
-        CaseUpdateDetails caseDetails
+        Map<String, Object> caseData
     ) {
-        var caseData = (Map<String, Object>) caseDetails.caseData;
+        var updatedCaseData = newHashMap(caseData);
         List<ScannedDocument> scannedDocuments = getScannedDocuments(caseData);
 
         List<String> exceptionRecordDcns = exceptionRecord.scannedDocuments
@@ -81,7 +81,10 @@ public class ScannedDocumentsHelper {
                 }
             })
             .collect(toList());
-        caseData.put(SCANNED_DOCUMENTS, updatedScannedDocuments);
+
+        updatedCaseData.put(SCANNED_DOCUMENTS, updatedScannedDocuments);
+
+        return updatedCaseData;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
- return updated data instead of modifying passed parameter
- take as parameters what's required (just case data instead of the whore response from a client service)
- clearer assertions in tests

In next PR this method will be moved to a new class where it will be non-static and tests for the infamous `CaseUpdater` will be updated to verify that those operations actually happen.

Only after that, additional method for setting envelopeID on a case will be added (https://tools.hmcts.net/jira/browse/BPS-1373)