### PR TITLE
Make method for updating scanned docs non-static

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataUpdater.java
@@ -1,0 +1,67 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
+
+import com.google.common.collect.ImmutableMap;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.Maps.newHashMap;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SCANNED_DOCUMENTS;
+
+@Component
+public class CaseDataUpdater {
+
+    public Map<String, Object> setExceptionRecordIdToScannedDocuments(
+        ExceptionRecord exceptionRecord,
+        Map<String, Object> caseData
+    ) {
+        var updatedCaseData = newHashMap(caseData);
+        List<ScannedDocument> scannedDocuments = getScannedDocuments(caseData);
+
+        List<String> exceptionRecordDcns = exceptionRecord.scannedDocuments
+            .stream()
+            .map(scannedDocument -> scannedDocument.controlNumber)
+            .collect(toList());
+
+        List<ImmutableMap<String, ScannedDocument>> updatedScannedDocuments = scannedDocuments.stream()
+            .map(scannedDocument -> {
+                if (exceptionRecordDcns.contains(scannedDocument.controlNumber)) {
+                    // set exceptionReference if the document received with the exception record
+                    return ImmutableMap.of("value", new ScannedDocument(
+                        scannedDocument.fileName,
+                        scannedDocument.controlNumber,
+                        scannedDocument.type,
+                        scannedDocument.subtype,
+                        scannedDocument.scannedDate,
+                        scannedDocument.url,
+                        scannedDocument.deliveryDate,
+                        exceptionRecord.id
+                    ));
+                } else {
+                    // do not update the document if it was received with some previous exception record
+                    return ImmutableMap.of("value", scannedDocument);
+                }
+            })
+            .collect(toList());
+
+        updatedCaseData.put(SCANNED_DOCUMENTS, updatedScannedDocuments);
+
+        return updatedCaseData;
+    }
+
+    @SuppressWarnings("unchecked")
+    static List<ScannedDocument> getScannedDocuments(Map<String, Object> caseData) {
+        var scannedDocuments = (List<Map<String, Object>>) caseData.get(SCANNED_DOCUMENTS);
+
+        return scannedDocuments == null
+            ? emptyList()
+            : scannedDocuments.stream()
+            .map(ScannedDocumentsHelper::createScannedDocumentWithCcdData)
+            .collect(toList());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelper.java
@@ -3,10 +3,8 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.StringUtils;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Document;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
@@ -14,7 +12,6 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SCANNED_DOCUMENTS;
@@ -45,55 +42,6 @@ public class ScannedDocumentsHelper {
         return scannedDocuments.stream()
             .map(ScannedDocumentsHelper::createScannedDocumentWithCcdData)
             .map(ScannedDocumentsHelper::mapScannedDocument)
-            .collect(toList());
-    }
-
-    public static Map<String, Object> setExceptionRecordIdToScannedDocuments(
-        ExceptionRecord exceptionRecord,
-        Map<String, Object> caseData
-    ) {
-        var updatedCaseData = newHashMap(caseData);
-        List<ScannedDocument> scannedDocuments = getScannedDocuments(caseData);
-
-        List<String> exceptionRecordDcns = exceptionRecord.scannedDocuments
-            .stream()
-            .map(scannedDocument -> scannedDocument.controlNumber)
-            .collect(toList());
-
-        List<ImmutableMap<String, ScannedDocument>> updatedScannedDocuments = scannedDocuments.stream()
-            .map(scannedDocument -> {
-                if (exceptionRecordDcns.contains(scannedDocument.controlNumber)) {
-                    // set exceptionReference if the document received with the exception record
-                    return ImmutableMap.of("value", new ScannedDocument(
-                        scannedDocument.fileName,
-                        scannedDocument.controlNumber,
-                        scannedDocument.type,
-                        scannedDocument.subtype,
-                        scannedDocument.scannedDate,
-                        scannedDocument.url,
-                        scannedDocument.deliveryDate,
-                        exceptionRecord.id
-                    ));
-                } else {
-                    // do not update the document if it was received with some previous exception record
-                    return ImmutableMap.of("value", scannedDocument);
-                }
-            })
-            .collect(toList());
-
-        updatedCaseData.put(SCANNED_DOCUMENTS, updatedScannedDocuments);
-
-        return updatedCaseData;
-    }
-
-    @SuppressWarnings("unchecked")
-    static List<ScannedDocument> getScannedDocuments(Map<String, Object> caseData) {
-        var scannedDocuments = (List<Map<String, Object>>) caseData.get(SCANNED_DOCUMENTS);
-
-        return scannedDocuments == null
-            ? emptyList()
-            : scannedDocuments.stream()
-            .map(ScannedDocumentsHelper::createScannedDocumentWithCcdData)
             .collect(toList());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.CaseUpdateCli
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.response.SuccessfulUpdateResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response.ClientServiceErrorResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.helper.CaseDataUpdater;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CallbackException;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
@@ -29,7 +30,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.getDocuments;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.helper.ScannedDocumentsHelper.setExceptionRecordIdToScannedDocuments;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.logging.FeignExceptionLogger.debugCcdException;
 
 @Service
@@ -39,17 +39,20 @@ public class CcdCaseUpdater {
     private final AuthTokenGenerator s2sTokenGenerator;
     private final CoreCaseDataApi coreCaseDataApi;
     private final CaseUpdateClient caseUpdateClient;
+    private final CaseDataUpdater caseDataUpdater;
     private final ServiceResponseParser serviceResponseParser;
 
     public CcdCaseUpdater(
         AuthTokenGenerator s2sTokenGenerator,
         CoreCaseDataApi coreCaseDataApi,
         CaseUpdateClient caseUpdateClient,
+        CaseDataUpdater caseDataUpdater,
         ServiceResponseParser serviceResponseParser
     ) {
         this.s2sTokenGenerator = s2sTokenGenerator;
         this.coreCaseDataApi = coreCaseDataApi;
         this.caseUpdateClient = caseUpdateClient;
+        this.caseDataUpdater = caseDataUpdater;
         this.serviceResponseParser = serviceResponseParser;
     }
 
@@ -132,7 +135,7 @@ public class CcdCaseUpdater {
             } else {
                 var caseDataAfterClientUpdate = (Map<String, Object>) updateResponse.caseDetails.caseData;
 
-                var finalCaseData = setExceptionRecordIdToScannedDocuments(
+                var finalCaseData = caseDataUpdater.setExceptionRecordIdToScannedDocuments(
                     exceptionRecord,
                     caseDataAfterClientUpdate
                 );

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataUpdaterTest.java
@@ -21,7 +21,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.objectMapper;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentType.FORM;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SCANNED_DOCUMENTS;
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "checkstyle:LineLength"})
 class CaseDataUpdaterTest {
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataUpdaterTest.java
@@ -1,0 +1,91 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.response.CaseUpdateDetails;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentUrl;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static java.time.LocalDateTime.now;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.fileContentAsBytes;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.objectMapper;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentType.FORM;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SCANNED_DOCUMENTS;
+
+@SuppressWarnings("unchecked")
+class CaseDataUpdaterTest {
+
+    @Test
+    void sets_exception_record_id_to_scanned_documents() throws Exception {
+        // given
+        var caseDataUpdater = new CaseDataUpdater();
+
+        //contains documents with control numbers 1000, 2000, 3000
+        var caseDetails = getCaseUpdateDetails("case-data/multiple-scanned-docs.json");
+        var caseData = (Map<String, Object>) caseDetails.caseData;
+        var scannedDocuments = asList(
+            getScannedDocument("1000"),
+            getScannedDocument("2000")
+        );
+        var exceptionRecord = new ExceptionRecord(
+            "123456789",
+            "caseTypeId",
+            "envelopeId123",
+            "poBox",
+            "poBoxJurisdiction",
+            Classification.EXCEPTION,
+            "formType",
+            now(),
+            now(),
+            scannedDocuments,
+            emptyList()
+        );
+
+        // when
+        var updatedCaseData = caseDataUpdater.setExceptionRecordIdToScannedDocuments(exceptionRecord, caseData);
+
+        //then
+        var updatedScannedDocuments = getScannedDocuments(updatedCaseData);
+        assertThat(updatedScannedDocuments).hasSize(3);
+        assertThat(updatedScannedDocuments.get(0).controlNumber).isEqualTo("1000");
+        assertThat(updatedScannedDocuments.get(0).exceptionReference).isEqualTo(exceptionRecord.id);
+        assertThat(updatedScannedDocuments.get(1).controlNumber).isEqualTo("2000");
+        assertThat(updatedScannedDocuments.get(1).exceptionReference).isEqualTo(exceptionRecord.id);
+        // not present in the exception record and should not be set
+        assertThat(updatedScannedDocuments.get(2).controlNumber).isEqualTo("3000");
+        assertThat(updatedScannedDocuments.get(2).exceptionReference).isNull();
+    }
+
+    private CaseUpdateDetails getCaseUpdateDetails(String resourceName) throws IOException {
+        return objectMapper.readValue(fileContentAsBytes(resourceName), CaseUpdateDetails.class);
+    }
+
+    private List<ScannedDocument> getScannedDocuments(Map<String, Object> caseData) {
+        return ((List<Map<String, Object>>) caseData.get(SCANNED_DOCUMENTS))
+            .stream()
+            .map(o -> objectMapper.convertValue(o.get("value"), ScannedDocument.class))
+            .collect(toList());
+    }
+
+    private uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ScannedDocument getScannedDocument(String controlNumber) {
+        return new uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ScannedDocument(
+            FORM,
+            "subtype",
+            new DocumentUrl("url", "binaryUrl", "fileName"),
+            controlNumber,
+            "fileName",
+            now(),
+            now()
+        );
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/ScannedDocumentsHelperTest.java
@@ -1,33 +1,19 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.helper;
 
 import org.junit.jupiter.api.Test;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.response.CaseUpdateDetails;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentUrl;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ScannedDocument;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Document;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 
-import static java.time.LocalDateTime.now;
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.fileContentAsBytes;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.objectMapper;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentType.FORM;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SCANNED_DOCUMENTS;
 
 @SuppressWarnings("unchecked")
 class ScannedDocumentsHelperTest {
-
-    private static final String EXCEPTION_REFERENCE = "1";
 
     @Test
     void getDocuments_should_extract_all_documents() throws Exception {
@@ -101,108 +87,7 @@ class ScannedDocumentsHelperTest {
         assertThat(documents.get(0)).isNull();
     }
 
-    @Test
-    void sets_exception_record_id_to_scanned_documents() throws Exception {
-        // given
-        //contains documents with control numbers 1000, 2000, 3000
-        var caseDetails = getCaseUpdateDetails("case-data/multiple-scanned-docs.json");
-        var caseData = (Map<String, Object>) caseDetails.caseData;
-        var scannedDocuments = asList(
-            getScannedDocument("1000"),
-            getScannedDocument("2000")
-        );
-        var exceptionRecord = new ExceptionRecord(
-            EXCEPTION_REFERENCE,
-            "caseTypeId",
-            "envelopeId123",
-            "poBox",
-            "poBoxJurisdiction",
-            Classification.EXCEPTION,
-            "formType",
-            now(),
-            now(),
-            scannedDocuments,
-            emptyList()
-        );
-
-        // when
-        var updatedCaseData = ScannedDocumentsHelper.setExceptionRecordIdToScannedDocuments(exceptionRecord, caseData);
-
-        //then
-        var updatedScannedDocuments = getScannedDocuments(updatedCaseData);
-        assertThat(updatedScannedDocuments).hasSize(3);
-        assertThat(updatedScannedDocuments.get(0).controlNumber).isEqualTo("1000");
-        assertThat(updatedScannedDocuments.get(0).exceptionReference).isEqualTo(exceptionRecord.id);
-        assertThat(updatedScannedDocuments.get(1).controlNumber).isEqualTo("2000");
-        assertThat(updatedScannedDocuments.get(1).exceptionReference).isEqualTo(exceptionRecord.id);
-        // not present in the exception record and should not be set
-        assertThat(updatedScannedDocuments.get(2).controlNumber).isEqualTo("3000");
-        assertThat(updatedScannedDocuments.get(2).exceptionReference).isNull();
-    }
-
-    @Test
-    void setExceptionRecordIdToScannedDocuments_should_handle_empty_scanned_documents_in_exception() throws Exception {
-        // given
-        //contains documents with control numbers 1000, 2000, 3000
-        var caseDetails = getCaseUpdateDetails("case-data/multiple-scanned-docs.json");
-        var caseData = (Map<String, Object>) caseDetails.caseData;
-        var exceptionRecord = new ExceptionRecord(
-            EXCEPTION_REFERENCE,
-            "caseTypeId",
-            "envelopeId123",
-            "poBox",
-            "poBoxJurisdiction",
-            Classification.EXCEPTION,
-            "formType",
-            now(),
-            now(),
-            emptyList(),
-            emptyList()
-        );
-
-        // when
-        var updatedCaseData = ScannedDocumentsHelper.setExceptionRecordIdToScannedDocuments(exceptionRecord, caseData);
-
-        //then
-        var updatedScannedDocuments = getScannedDocuments(updatedCaseData);
-        assertThat(updatedScannedDocuments).hasSize(3);
-        assertThat(updatedScannedDocuments.get(0).controlNumber).isEqualTo("1000");
-        assertThat(updatedScannedDocuments.get(0).exceptionReference).isNull();
-        assertThat(updatedScannedDocuments.get(1).controlNumber).isEqualTo("2000");
-        assertThat(updatedScannedDocuments.get(1).exceptionReference).isNull();
-        assertThat(updatedScannedDocuments.get(2).controlNumber).isEqualTo("3000");
-        assertThat(updatedScannedDocuments.get(2).exceptionReference).isNull();
-    }
-
-    private ScannedDocument getScannedDocument(String controlNumber) {
-        return new ScannedDocument(
-            FORM,
-            "subtype",
-            new DocumentUrl("url", "binaryUrl", "fileName"),
-            controlNumber,
-            "fileName",
-            now(),
-            now()
-        );
-    }
-
     private CaseDetails getCaseDetails(String resourceName) throws IOException {
         return objectMapper.readValue(fileContentAsBytes(resourceName), CaseDetails.class);
-    }
-
-    private CaseUpdateDetails getCaseUpdateDetails(String resourceName) throws IOException {
-        return objectMapper.readValue(fileContentAsBytes(resourceName), CaseUpdateDetails.class);
-    }
-
-    private List<uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument> getScannedDocuments(
-        Map<String, Object> caseData
-    ) {
-        var scannedDocuments = (List<Map<String, Object>>) caseData.get(SCANNED_DOCUMENTS);
-        return scannedDocuments.stream().map(o ->
-            objectMapper.convertValue(
-                o.get("value"),
-                uk.gov.hmcts.reform.bulkscan.orchestrator.model.ccd.ScannedDocument.class
-            )
-        ).collect(toList());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -305,7 +305,7 @@ class CcdCaseUpdaterTest {
                 exceptionRecord.id
             );
 
-        verifyNoInteractions(caseDataUpdater);
+        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, (Map<String, Object>) caseUpdateDetails.caseData);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentUr
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.ScannedDocument;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response.ClientServiceErrorResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.helper.CaseDataUpdater;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.callback.CallbackException;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
@@ -62,6 +63,7 @@ class CcdCaseUpdaterTest {
     @Mock private ServiceConfigItem configItem;
     @Mock private CaseDetails existingCase;
     @Mock private StartEventResponse eventResponse;
+    @Mock private CaseDataUpdater caseDataUpdater;
 
     private ExceptionRecord exceptionRecord;
 
@@ -76,6 +78,7 @@ class CcdCaseUpdaterTest {
             authTokenGenerator,
             coreCaseDataApi,
             caseUpdateClient,
+            caseDataUpdater,
             serviceResponseParser
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -29,7 +29,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import javax.validation.ConstraintViolationException;
 
@@ -46,8 +46,11 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE_WITH_OCR;
 
+@SuppressWarnings({"checkstyle:LineLength", "unchecked"})
 @ExtendWith(MockitoExtension.class)
 class CcdCaseUpdaterTest {
 
@@ -82,7 +85,7 @@ class CcdCaseUpdaterTest {
             serviceResponseParser
         );
 
-        caseUpdateDetails = new CaseUpdateDetails(null, new HashMap<String, String>());
+        caseUpdateDetails = new CaseUpdateDetails(null, Map.of("a", "b"));
         exceptionRecord = getExceptionRecord();
 
         noWarningsUpdateResponse = new SuccessfulUpdateResponse(caseUpdateDetails, emptyList());
@@ -115,6 +118,8 @@ class CcdCaseUpdaterTest {
 
         // then
         assertThat(res).isEmpty();
+
+        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, (Map<String, Object>) caseUpdateDetails.caseData);
     }
 
     @Test
@@ -140,6 +145,8 @@ class CcdCaseUpdaterTest {
 
         // then
         assertThat(res).isEmpty();
+
+        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, (Map<String, Object>) caseUpdateDetails.caseData);
     }
 
     @Test
@@ -165,6 +172,8 @@ class CcdCaseUpdaterTest {
         assertThat(res).isNotEmpty();
         assertThat(res.get().getErrors()).isEmpty();
         assertThat(res.get().getWarnings()).containsOnly("warning1");
+
+        verifyNoInteractions(caseDataUpdater);
     }
 
     @Test
@@ -190,6 +199,8 @@ class CcdCaseUpdaterTest {
 
         // then
         assertThat(res).isEmpty();
+
+        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, (Map<String, Object>) caseUpdateDetails.caseData);
     }
 
     @Test
@@ -218,6 +229,8 @@ class CcdCaseUpdaterTest {
         assertThat(res.get().getErrors()).containsExactlyInAnyOrder("Failed to update case for Service service "
             + "with case Id existing_case_id based on exception record 1 because it has been updated in the meantime");
         assertThat(res.get().getWarnings()).isEmpty();
+
+        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, (Map<String, Object>) caseUpdateDetails.caseData);
     }
 
     @Test
@@ -251,6 +264,8 @@ class CcdCaseUpdaterTest {
             .isEqualTo("Failed to update case for Service service with case Id existing_case_id "
                 + "based on exception record 1");
         assertThat(callbackException.getCause().getMessage()).isEqualTo("Service response: Body");
+
+        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, (Map<String, Object>) caseUpdateDetails.caseData);
     }
 
     @Test
@@ -289,6 +304,8 @@ class CcdCaseUpdaterTest {
                 EXISTING_CASE_ID,
                 exceptionRecord.id
             );
+
+        verifyNoInteractions(caseDataUpdater);
     }
 
     @Test
@@ -324,6 +341,8 @@ class CcdCaseUpdaterTest {
                 EXISTING_CASE_ID,
                 exceptionRecord.id
             );
+
+        verifyNoInteractions(caseDataUpdater);
     }
 
     @Test
@@ -354,6 +373,8 @@ class CcdCaseUpdaterTest {
             .isInstanceOf(CallbackException.class)
             .hasCauseInstanceOf(ConstraintViolationException.class)
             .hasMessageContaining("Invalid case-update response");
+
+        verifyNoInteractions(caseDataUpdater);
     }
 
     @Test
@@ -399,6 +420,8 @@ class CcdCaseUpdaterTest {
         assertThat(((HttpClientErrorException) callbackException.getCause()).getStatusText())
             .isEqualTo("bad request message");
         assertThat(((HttpClientErrorException) callbackException.getCause()).getRawStatusCode()).isEqualTo(400);
+
+        verifyNoInteractions(caseDataUpdater);
     }
 
     @Test
@@ -440,6 +463,8 @@ class CcdCaseUpdaterTest {
         assertThat(res).isNotEmpty();
         assertThat(res.get().getErrors()).containsExactlyInAnyOrder("error1", "error2");
         assertThat(res.get().getWarnings()).isEmpty();
+
+        verifyNoInteractions(caseDataUpdater);
     }
 
     @Test
@@ -475,6 +500,8 @@ class CcdCaseUpdaterTest {
             .isEqualTo("Failed to update case for Service service with case Id existing_case_id "
                 + "based on exception record 1. Service response: Body");
         assertThat(callbackException.getCause().getMessage()).isEqualTo("Msg");
+
+        verifyNoInteractions(caseDataUpdater);
     }
 
     @Test
@@ -507,8 +534,9 @@ class CcdCaseUpdaterTest {
 
         // then
         assertThat(callbackException.getMessage())
-            .isEqualTo("Failed to update case for Service service with case Id existing_case_id "
-                + "based on exception record 1");
+            .isEqualTo("Failed to update case for Service service with case Id existing_case_id based on exception record 1");
+
+        verifyNoInteractions(caseDataUpdater);
     }
 
     @Test
@@ -542,6 +570,8 @@ class CcdCaseUpdaterTest {
         assertThat(res).isNotEmpty();
         assertThat(res.get().getErrors()).containsOnly("No case found for case ID: 1234123412341234");
         assertThat(res.get().getWarnings()).isEmpty();
+
+        verifyNoInteractions(caseDataUpdater);
     }
 
     @Test
@@ -573,6 +603,8 @@ class CcdCaseUpdaterTest {
         assertThat(res).isNotEmpty();
         assertThat(res.get().getErrors()).containsOnly("Invalid case ID: 1234");
         assertThat(res.get().getWarnings()).isEmpty();
+
+        verifyNoInteractions(caseDataUpdater);
     }
 
     private BDDMyOngoingStubbing<CaseDetails> prepareMockForSubmissionEventForCaseWorker() {


### PR DESCRIPTION
Moving existing static method (without any changes) from `ScannedDocumentsHelper` to a new class `CaseDataUpdater`. Now it's not static.

Follow up to https://github.com/hmcts/bulk-scan-orchestrator/pull/1175