### PR TITLE
Use map for case data field in update response

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/model/response/CaseUpdateDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/model/response/CaseUpdateDetails.java
@@ -2,8 +2,8 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.respon
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javax.validation.constraints.NotNull;
 import java.util.Map;
+import javax.validation.constraints.NotNull;
 
 public class CaseUpdateDetails {
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/model/response/CaseUpdateDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/model/response/CaseUpdateDetails.java
@@ -3,17 +3,18 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.respon
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotNull;
+import java.util.Map;
 
 public class CaseUpdateDetails {
 
     public final String eventId;
 
     @NotNull
-    public final Object caseData;
+    public final Map<String, Object> caseData;
 
     public CaseUpdateDetails(
         @JsonProperty("event_id") String eventId,
-        @JsonProperty("case_data") Object caseData
+        @JsonProperty("case_data") Map<String, Object> caseData
     ) {
         this.eventId = eventId;
         this.caseData = caseData;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -133,7 +133,7 @@ public class CcdCaseUpdater {
                 );
                 return Optional.of(new ErrorsAndWarnings(emptyList(), updateResponse.warnings));
             } else {
-                var caseDataAfterClientUpdate = (Map<String, Object>) updateResponse.caseDetails.caseData;
+                var caseDataAfterClientUpdate = updateResponse.caseDetails.caseData;
 
                 var finalCaseData = caseDataUpdater.setExceptionRecordIdToScannedDocuments(
                     exceptionRecord,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -56,7 +56,6 @@ public class CcdCaseUpdater {
         this.serviceResponseParser = serviceResponseParser;
     }
 
-    @SuppressWarnings("unchecked")
     public Optional<ErrorsAndWarnings> updateCase(
         ExceptionRecord exceptionRecord,
         ServiceConfigItem configItem,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseDataUpdaterTest.java
@@ -31,7 +31,6 @@ class CaseDataUpdaterTest {
 
         //contains documents with control numbers 1000, 2000, 3000
         var caseDetails = getCaseUpdateDetails("case-data/multiple-scanned-docs.json");
-        var caseData = (Map<String, Object>) caseDetails.caseData;
         var scannedDocuments = asList(
             getScannedDocument("1000"),
             getScannedDocument("2000")
@@ -51,7 +50,7 @@ class CaseDataUpdaterTest {
         );
 
         // when
-        var updatedCaseData = caseDataUpdater.setExceptionRecordIdToScannedDocuments(exceptionRecord, caseData);
+        var updatedCaseData = caseDataUpdater.setExceptionRecordIdToScannedDocuments(exceptionRecord, caseDetails.caseData);
 
         //then
         var updatedScannedDocuments = getScannedDocuments(updatedCaseData);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -119,7 +119,7 @@ class CcdCaseUpdaterTest {
         // then
         assertThat(res).isEmpty();
 
-        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, (Map<String, Object>) caseUpdateDetails.caseData);
+        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, caseUpdateDetails.caseData);
     }
 
     @Test
@@ -146,7 +146,7 @@ class CcdCaseUpdaterTest {
         // then
         assertThat(res).isEmpty();
 
-        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, (Map<String, Object>) caseUpdateDetails.caseData);
+        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, caseUpdateDetails.caseData);
     }
 
     @Test
@@ -200,7 +200,7 @@ class CcdCaseUpdaterTest {
         // then
         assertThat(res).isEmpty();
 
-        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, (Map<String, Object>) caseUpdateDetails.caseData);
+        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, caseUpdateDetails.caseData);
     }
 
     @Test
@@ -230,7 +230,7 @@ class CcdCaseUpdaterTest {
             + "with case Id existing_case_id based on exception record 1 because it has been updated in the meantime");
         assertThat(res.get().getWarnings()).isEmpty();
 
-        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, (Map<String, Object>) caseUpdateDetails.caseData);
+        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, caseUpdateDetails.caseData);
     }
 
     @Test
@@ -265,7 +265,7 @@ class CcdCaseUpdaterTest {
                 + "based on exception record 1");
         assertThat(callbackException.getCause().getMessage()).isEqualTo("Service response: Body");
 
-        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, (Map<String, Object>) caseUpdateDetails.caseData);
+        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, caseUpdateDetails.caseData);
     }
 
     @Test
@@ -305,7 +305,7 @@ class CcdCaseUpdaterTest {
                 exceptionRecord.id
             );
 
-        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, (Map<String, Object>) caseUpdateDetails.caseData);
+        verify(caseDataUpdater).setExceptionRecordIdToScannedDocuments(exceptionRecord, caseUpdateDetails.caseData);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE_WITH_OCR;
 
-@SuppressWarnings({"checkstyle:LineLength", "unchecked"})
+@SuppressWarnings({"checkstyle:LineLength"})
 @ExtendWith(MockitoExtension.class)
 class CcdCaseUpdaterTest {
 


### PR DESCRIPTION
Previously `Object` but it was always casted to a map when used....