### PR TITLE
Simplify model for storing IDAM user id

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordToExistingCaseTest.java
@@ -332,7 +332,7 @@ class AttachExceptionRecordToExistingCaseTest {
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .header(SyntheticHeaders.SYNTHETIC_TEST_SOURCE, "Bulk Scan Orchestrator Functional test")
             .header(AUTHORIZATION, ccdAuthenticator.getUserToken())
-            .header(CcdCallbackController.USER_ID, ccdAuthenticator.getUserDetails().getId())
+            .header(CcdCallbackController.USER_ID, ccdAuthenticator.getUserId())
             .body(callbackRequest)
             .when()
             .post("/callback/attach_case?ignore-warning=true");

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordWithOcrToExistingCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/AttachExceptionRecordWithOcrToExistingCaseTest.java
@@ -182,7 +182,7 @@ class AttachExceptionRecordWithOcrToExistingCaseTest {
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .header(SyntheticHeaders.SYNTHETIC_TEST_SOURCE, "Bulk Scan Orchestrator Functional test")
             .header(HttpHeaders.AUTHORIZATION, ccdAuthenticator.getUserToken())
-            .header(CcdCallbackController.USER_ID, ccdAuthenticator.getUserDetails().getId())
+            .header(CcdCallbackController.USER_ID, ccdAuthenticator.getUserId())
             .body(request)
             .when()
             .post("/callback/attach_case?ignore-warning=true");

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/CreateCaseTest.java
@@ -157,7 +157,7 @@ class CreateCaseTest {
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .header(SyntheticHeaders.SYNTHETIC_TEST_SOURCE, "Bulk Scan Orchestrator Functional test")
             .header(AUTHORIZATION, ccdAuthenticator.getUserToken())
-            .header(CcdCallbackController.USER_ID, ccdAuthenticator.getUserDetails().getId())
+            .header(CcdCallbackController.USER_ID, ccdAuthenticator.getUserId())
             .body(
                 CallbackRequest
                     .builder()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ReclassifyCallbackTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/ReclassifyCallbackTest.java
@@ -72,7 +72,7 @@ public class ReclassifyCallbackTest {
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .header(SyntheticHeaders.SYNTHETIC_TEST_SOURCE, "Bulk Scan Orchestrator Functional test")
             .header(AUTHORIZATION, ccdAuthenticator.getUserToken())
-            .header(CcdCallbackController.USER_ID, ccdAuthenticator.getUserDetails().getId())
+            .header(CcdCallbackController.USER_ID, ccdAuthenticator.getUserId())
             .body(callbackRequest)
             .when()
             .post("/callback/reclassify-exception-record?ignore-warning=true")

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/dm/DocumentManagementUploadService.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/dm/DocumentManagementUploadService.java
@@ -52,7 +52,7 @@ public class DocumentManagementUploadService {
         UploadResponse uploadResponse = documentUploadClientApi.upload(
             authenticator.getUserToken(),
             authenticator.getServiceToken(),
-            authenticator.getUserDetails().getId(),
+            authenticator.getUserId(),
             singletonList(file)
         );
         log.info("{} uploaded to DM store", displayName);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseSearcher.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CaseSearcher.java
@@ -51,7 +51,7 @@ public class CaseSearcher {
         return coreCaseDataApi.searchForCaseworker(
             authenticator.getUserToken(),
             authenticator.getServiceToken(),
-            authenticator.getUserDetails().getId(),
+            authenticator.getUserId(),
             jurisdiction,
             caseTypeId,
             searchCriteria

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCaseCreator.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCaseCreator.java
@@ -109,7 +109,7 @@ public class CcdCaseCreator {
         return coreCaseDataApi.startForCaseworker(
             authenticator.getUserToken(),
             authenticator.getServiceToken(),
-            authenticator.getUserDetails().getId(),
+            authenticator.getUserId(),
             JURISDICTION,
             CASE_TYPE_ID,
             CREATE_CASE_EVENT_TYPE_ID
@@ -124,7 +124,7 @@ public class CcdCaseCreator {
         return coreCaseDataApi.submitForCaseworker(
             authenticator.getUserToken(),
             authenticator.getServiceToken(),
-            authenticator.getUserDetails().getId(),
+            authenticator.getUserId(),
             JURISDICTION,
             CASE_TYPE_ID,
             true,

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrievalTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CaseRetrievalTest.java
@@ -59,7 +59,7 @@ class CaseRetrievalTest {
     private static final CcdAuthenticator CCD_AUTHENTICATOR =
         new CcdAuthenticator(
             () -> "service_token",
-            new UserDetails("12", "forname", "", null, null),
+            "12",
             "ey_token"
         );
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -228,7 +228,7 @@ public class CcdApi {
             StartEventResponse eventResponse = feignCcdApi.startForCaseworker(
                 authenticator.getUserToken(),
                 authenticator.getServiceToken(),
-                authenticator.getUserDetails().getId(),
+                authenticator.getUserId(),
                 jurisdiction,
                 caseTypeId,
                 eventTypeId
@@ -241,7 +241,7 @@ public class CcdApi {
             return feignCcdApi.submitForCaseworker(
                 authenticator.getUserToken(),
                 authenticator.getServiceToken(),
-                authenticator.getUserDetails().getId(),
+                authenticator.getUserId(),
                 jurisdiction,
                 caseTypeId,
                 true,
@@ -268,7 +268,7 @@ public class CcdApi {
             StartEventResponse eventResponse = feignCcdApi.startEventForCaseWorker(
                 authenticator.getUserToken(),
                 authenticator.getServiceToken(),
-                authenticator.getUserDetails().getId(),
+                authenticator.getUserId(),
                 jurisdiction,
                 caseTypeId,
                 caseRef,
@@ -282,7 +282,7 @@ public class CcdApi {
             feignCcdApi.submitEventForCaseWorker(
                 authenticator.getUserToken(),
                 authenticator.getServiceToken(),
-                authenticator.getUserDetails().getId(),
+                authenticator.getUserId(),
                 jurisdiction,
                 caseTypeId,
                 caseRef,
@@ -318,7 +318,7 @@ public class CcdApi {
         return createCase(
             ccdAuthenticator.getUserToken(),
             ccdAuthenticator.getServiceToken(),
-            ccdAuthenticator.getUserDetails().getId(),
+            ccdAuthenticator.getUserId(),
             jurisdiction,
             caseTypeId,
             eventId,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticator.java
@@ -1,22 +1,20 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
 
-import uk.gov.hmcts.reform.idam.client.models.UserDetails;
-
 import java.util.function.Supplier;
 
 public class CcdAuthenticator {
 
-    private final UserDetails userDetails;
+    private final String userId;
     private final Supplier<String> serviceTokenSupplier;
     private final String userToken;
 
     public CcdAuthenticator(
         Supplier<String> serviceTokenSupplier,
-        UserDetails userDetails,
+        String userId,
         String userToken
     ) {
         this.serviceTokenSupplier = serviceTokenSupplier;
-        this.userDetails = userDetails;
+        this.userId = userId;
         this.userToken = userToken;
     }
 
@@ -28,7 +26,7 @@ public class CcdAuthenticator {
         return this.serviceTokenSupplier.get();
     }
 
-    public UserDetails getUserDetails() {
-        return this.userDetails;
+    public String getUserId() {
+        return this.userId;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticatorFactory.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticatorFactory.java
@@ -24,7 +24,7 @@ public class CcdAuthenticatorFactory {
 
         return new CcdAuthenticator(
             s2sTokenGenerator::generate,
-            idamCredentials.userDetails,
+            idamCredentials.userId,
             idamCredentials.accessToken
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/CachedIdamCredential.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/CachedIdamCredential.java
@@ -1,16 +1,14 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.cache;
 
-import uk.gov.hmcts.reform.idam.client.models.UserDetails;
-
 public class CachedIdamCredential {
 
     public final String accessToken;
-    public final UserDetails userDetails;
+    public final String userId;
     public final long expiresIn;
 
-    public CachedIdamCredential(String accessToken, UserDetails userDetails, long expiresIn) {
+    public CachedIdamCredential(String accessToken, String userId, long expiresIn) {
         this.accessToken = accessToken;
-        this.userDetails = userDetails;
+        this.userId = userId;
         this.expiresIn = expiresIn;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClient.java
@@ -62,7 +62,7 @@ public class IdamCachedClient {
 
         String tokenWithBearer = BEARER_AUTH_TYPE + tokenResponse.accessToken;
         UserDetails userDetails = idamClient.getUserDetails(tokenWithBearer);
-        return new CachedIdamCredential(tokenWithBearer, userDetails, Long.valueOf(tokenResponse.expiresIn));
+        return new CachedIdamCredential(tokenWithBearer, userDetails.getId(), Long.valueOf(tokenResponse.expiresIn));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/SampleData.java
@@ -46,14 +46,10 @@ public class SampleData {
     public static final long CASE_ID = 23L;
     public static final String EXAMPLE_JSON_FILE = "envelopes/example.json";
     public static final String BULK_SCANNED_CASE_TYPE = "Bulk_Scanned";
-
-    public static final UserDetails USER_DETAILS = new UserDetails(USER_ID,
-        null, null, null, emptyList()
-    );
     public static final Credential USER_CREDS = new Credential(USER_NAME, PASSWORD);
     public static final CcdAuthenticator AUTH_DETAILS = new CcdAuthenticator(
         () -> SERVICE_TOKEN,
-        USER_DETAILS,
+        USER_ID,
         USER_TOKEN
     );
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApiCreateCaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApiCreateCaseTest.java
@@ -74,7 +74,7 @@ public class CcdApiCreateCaseTest {
         verify(feignCcdApi).startForCaseworker(
             ccdAuthenticator.getUserToken(),
             ccdAuthenticator.getServiceToken(),
-            ccdAuthenticator.getUserDetails().getId(),
+            ccdAuthenticator.getUserId(),
             jurisdiction,
             caseTypeId,
             eventId
@@ -83,7 +83,7 @@ public class CcdApiCreateCaseTest {
         verify(feignCcdApi).submitForCaseworker(
             ccdAuthenticator.getUserToken(),
             ccdAuthenticator.getServiceToken(),
-            ccdAuthenticator.getUserDetails().getId(),
+            ccdAuthenticator.getUserId(),
             jurisdiction,
             caseTypeId,
             true,
@@ -171,13 +171,7 @@ public class CcdApiCreateCaseTest {
     private CcdAuthenticator sampleCcdAuthenticator() {
         return new CcdAuthenticator(
             () -> "serviceToken1",
-            new UserDetails(
-                "userId1",
-                "email1",
-                "forename1",
-                "surname1",
-                asList("role1", "role2")
-            ),
+            "userId1",
             "userToken1"
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticatorFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdAuthenticatorFactoryTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.BDDMockito.given;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.JURSIDICTION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.SERVICE_TOKEN;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_DETAILS;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_ID;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_TOKEN;
 
@@ -36,7 +35,7 @@ class CcdAuthenticatorFactoryTest {
     void should_sucessfully_return_authInfo() {
         CachedIdamCredential cachedIdamCredential = new CachedIdamCredential(
             USER_TOKEN,
-            USER_DETAILS,
+            USER_ID,
             28800L
         );
 
@@ -47,7 +46,7 @@ class CcdAuthenticatorFactoryTest {
 
         assertThat(authenticator.getServiceToken()).isEqualTo(SERVICE_TOKEN);
         assertThat(authenticator.getUserToken()).isEqualTo(USER_TOKEN);
-        assertThat(authenticator.getUserDetails().getId()).isEqualTo(USER_ID);
+        assertThat(authenticator.getUserId()).isEqualTo(USER_ID);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationCheckerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/AuthenticationCheckerTest.java
@@ -26,7 +26,7 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_DETAILS;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_ID;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.USER_TOKEN;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,7 +53,7 @@ class AuthenticationCheckerTest {
 
     private static final CachedIdamCredential CACHED_IDAM_CREDENTIAL = new CachedIdamCredential(
         USER_TOKEN,
-        USER_DETAILS,
+        USER_ID,
         28800L
     );
 

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCacheExpiryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCacheExpiryTest.java
@@ -2,9 +2,7 @@ package uk.gov.hmcts.reform.bulkscan.orchestrator.services.idam.cache;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,13 +11,7 @@ class IdamCacheExpiryTest {
 
     private IdamCacheExpiry idamCacheExpiry = new IdamCacheExpiry(20);
 
-    private static final UserDetails USER_DETAILS = new UserDetails(
-        "12",
-        "q@a.com",
-        "name_x",
-        "surname_y",
-        Arrays.asList("role1, role2", "role3")
-    );
+    private static final String USER_ID = "12";
 
     @ParameterizedTest
     @CsvSource({
@@ -28,7 +20,7 @@ class IdamCacheExpiryTest {
         "22, 0, 2000000000"
     })
     void expireAfterCreate(long expireIn, long currentTime, long result) {
-        CachedIdamCredential cachedIdamCredential = new CachedIdamCredential("token", USER_DETAILS, expireIn);
+        CachedIdamCredential cachedIdamCredential = new CachedIdamCredential("token", USER_ID, expireIn);
         long remainingTime = idamCacheExpiry.expireAfterCreate(
             "key_9090",
             cachedIdamCredential,
@@ -51,7 +43,7 @@ class IdamCacheExpiryTest {
         long expectedSecondsLeft
     ) {
         // given
-        CachedIdamCredential newCreds = new CachedIdamCredential("token", USER_DETAILS, expireIn);
+        CachedIdamCredential newCreds = new CachedIdamCredential("token", USER_ID, expireIn);
 
         // when
         long remainingTimeNanos = idamCacheExpiry.expireAfterUpdate(
@@ -72,7 +64,7 @@ class IdamCacheExpiryTest {
         "22, 0, 120, 120"
     })
     void expireAfterRead(long expireIn, long currentTime, long currentDuration, long result) {
-        CachedIdamCredential cachedIdamCredential = new CachedIdamCredential("token", USER_DETAILS, expireIn);
+        CachedIdamCredential cachedIdamCredential = new CachedIdamCredential("token", USER_ID, expireIn);
 
         long remainingTime = idamCacheExpiry.expireAfterRead(
             "21321",

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/idam/cache/IdamCachedClientTest.java
@@ -91,8 +91,7 @@ class IdamCachedClientTest {
             idamCachedClient.getIdamCredentials(jurisdiction);
 
         assertThat(cachedIdamCredential.accessToken).isEqualTo(JWT_WITH_BEARER_1);
-        assertThat(cachedIdamCredential.userDetails).usingRecursiveComparison()
-            .isEqualTo(USER_DETAILS);
+        assertThat(cachedIdamCredential.userId).isEqualTo(USER_DETAILS.getId());
         verify(users).getUser(jurisdiction);
         verify(idamApi).getAccessTokenResponse(USERNAME, PASSWORD);
         verify(idamApi).getUserDetails(JWT_WITH_BEARER_1);
@@ -119,9 +118,9 @@ class IdamCachedClientTest {
             idamCachedClient.getIdamCredentials(jurisdiction2);
 
         assertThat(cachedIdamCredential1.accessToken).isEqualTo(JWT_WITH_BEARER_1);
-        assertThat(cachedIdamCredential1.userDetails).isEqualTo(expectedUserDetails1);
+        assertThat(cachedIdamCredential1.userId).isEqualTo(expectedUserDetails1.getId());
         assertThat(cachedIdamCredential2.accessToken).isEqualTo(JWT_WITH_BEARER_2);
-        assertThat(cachedIdamCredential2.userDetails).isEqualTo(expectedUserDetails2);
+        assertThat(cachedIdamCredential2.userId).isEqualTo(expectedUserDetails2.getId());
 
         verify(users, times(2)).getUser(any());
         verify(idamApi, times(2)).getAccessTokenResponse(any(), any());
@@ -181,9 +180,9 @@ class IdamCachedClientTest {
             idamCachedClientQuickExpiry.getIdamCredentials(jurisdiction);
 
         assertThat(cachedIdamCredential1.accessToken).isEqualTo(JWT_WITH_BEARER_1);
-        assertThat(cachedIdamCredential1.userDetails).isEqualTo(expectedUserDetails1);
+        assertThat(cachedIdamCredential1.userId).isEqualTo(expectedUserDetails1.getId());
         assertThat(cachedIdamCredential2.accessToken).isEqualTo(JWT_WITH_BEARER_2);
-        assertThat(cachedIdamCredential2.userDetails).isEqualTo(expectedUserDetails2);
+        assertThat(cachedIdamCredential2.userId).isEqualTo(expectedUserDetails2.getId());
 
         assertThat(cachedIdamCredential1).isNotEqualTo(cachedIdamCredential2);
         verify(users, times(2)).getUser(any());
@@ -210,9 +209,9 @@ class IdamCachedClientTest {
         CachedIdamCredential cachedIdamCredential2 = idamCachedClient.getIdamCredentials(jurisdiction);
 
         assertThat(cachedIdamCredential1.accessToken).isEqualTo(JWT_WITH_BEARER_1);
-        assertThat(cachedIdamCredential1.userDetails).isEqualTo(expectedUserDetails1);
+        assertThat(cachedIdamCredential1.userId).isEqualTo(expectedUserDetails1.getId());
         assertThat(cachedIdamCredential2.accessToken).isEqualTo(JWT_WITH_BEARER_2);
-        assertThat(cachedIdamCredential2.userDetails).isEqualTo(expectedUserDetails2);
+        assertThat(cachedIdamCredential2.userId).isEqualTo(expectedUserDetails2.getId());
 
         verify(users, times(2)).getUser(any());
         verify(idamApi, times(2)).getAccessTokenResponse(any(), any());


### PR DESCRIPTION
All we ever use from `UserDetails` is the ID.
Storing just the ID now.

This will also simplify migrating to the new IDAM endpoint (which returns `UserInfo`)