### PR TITLE
Extract supplementary evidence handler

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandler.java
@@ -1,67 +1,36 @@
 package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseFinder;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.PaymentsProcessor;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.processedenvelopes.EnvelopeProcessingResult;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
-import java.util.Optional;
-
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.processedenvelopes.EnvelopeCcdAction.AUTO_ATTACHED_TO_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.processedenvelopes.EnvelopeCcdAction.EXCEPTION_RECORD;
 
 @Service
 public class EnvelopeHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(EnvelopeHandler.class);
-
-    private final AttachDocsToSupplementaryEvidence evidenceAttacher;
     private final CreateExceptionRecord exceptionRecordCreator;
-    private final CaseFinder caseFinder;
     private final PaymentsProcessor paymentsProcessor;
     private final NewApplicationHandler newApplicationHandler;
+    private final SupplementaryEvidenceHandler supplementaryEvidenceHandler;
 
     public EnvelopeHandler(
-        AttachDocsToSupplementaryEvidence evidenceAttacher,
         CreateExceptionRecord exceptionRecordCreator,
-        CaseFinder caseFinder,
         PaymentsProcessor paymentsProcessor,
+        SupplementaryEvidenceHandler supplementaryEvidenceHandler,
         NewApplicationHandler newApplicationHandler
     ) {
-        this.evidenceAttacher = evidenceAttacher;
         this.exceptionRecordCreator = exceptionRecordCreator;
-        this.caseFinder = caseFinder;
         this.paymentsProcessor = paymentsProcessor;
+        this.supplementaryEvidenceHandler = supplementaryEvidenceHandler;
         this.newApplicationHandler = newApplicationHandler;
     }
 
     public EnvelopeProcessingResult handleEnvelope(Envelope envelope, long deliveryCount) {
         switch (envelope.classification) {
             case SUPPLEMENTARY_EVIDENCE:
-                Optional<CaseDetails> caseDetailsFound = caseFinder.findCase(envelope);
-
-                if (caseDetailsFound.isPresent()) {
-                    CaseDetails existingCase = caseDetailsFound.get();
-                    boolean docsAttached = evidenceAttacher.attach(envelope, existingCase);
-                    if (docsAttached) {
-                        paymentsProcessor.createPayments(envelope, existingCase.getId(), false);
-                        return new EnvelopeProcessingResult(existingCase.getId(), AUTO_ATTACHED_TO_CASE);
-                    } else {
-                        log.info(
-                            "Creating exception record as attaching supplementary evidence to a case failed."
-                                + "envelope: {}, case: {}",
-                            envelope.id,
-                            existingCase.getId()
-                        );
-                        return new EnvelopeProcessingResult(createExceptionRecord(envelope), EXCEPTION_RECORD);
-                    }
-                } else {
-                    return new EnvelopeProcessingResult(createExceptionRecord(envelope), EXCEPTION_RECORD);
-                }
+                return supplementaryEvidenceHandler.handle(envelope);
             case SUPPLEMENTARY_EVIDENCE_WITH_OCR:
             case EXCEPTION:
                 return new EnvelopeProcessingResult(createExceptionRecord(envelope), EXCEPTION_RECORD);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/SupplementaryEvidenceHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/SupplementaryEvidenceHandler.java
@@ -1,0 +1,65 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseFinder;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.PaymentsProcessor;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.processedenvelopes.EnvelopeProcessingResult;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.util.Optional;
+
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.processedenvelopes.EnvelopeCcdAction.AUTO_ATTACHED_TO_CASE;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.processedenvelopes.EnvelopeCcdAction.EXCEPTION_RECORD;
+
+@Service
+public class SupplementaryEvidenceHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(SupplementaryEvidenceHandler.class);
+
+    private final CaseFinder caseFinder;
+    private final AttachDocsToSupplementaryEvidence evidenceAttacher;
+    private final PaymentsProcessor paymentsProcessor;
+    private final CreateExceptionRecord exceptionRecordCreator;
+
+    public SupplementaryEvidenceHandler(
+        CaseFinder caseFinder,
+        AttachDocsToSupplementaryEvidence evidenceAttacher,
+        PaymentsProcessor paymentsProcessor,
+        CreateExceptionRecord exceptionRecordCreator
+    ) {
+        this.caseFinder = caseFinder;
+        this.evidenceAttacher = evidenceAttacher;
+        this.paymentsProcessor = paymentsProcessor;
+        this.exceptionRecordCreator = exceptionRecordCreator;
+    }
+
+    public EnvelopeProcessingResult handle(Envelope envelope) {
+        Optional<CaseDetails> caseDetailsFound = caseFinder.findCase(envelope);
+
+        if (caseDetailsFound.isPresent()) {
+            CaseDetails existingCase = caseDetailsFound.get();
+            boolean docsAttached = evidenceAttacher.attach(envelope, existingCase);
+            if (docsAttached) {
+                paymentsProcessor.createPayments(envelope, existingCase.getId(), false);
+                return new EnvelopeProcessingResult(existingCase.getId(), AUTO_ATTACHED_TO_CASE);
+            } else {
+                log.info(
+                    "Creating exception record because attaching supplementary evidence to a case failed. envelope: {}, case: {}",
+                    envelope.id,
+                    existingCase.getId()
+                );
+                Long erId = exceptionRecordCreator.tryCreateFrom(envelope);
+                paymentsProcessor.createPayments(envelope, erId, true);
+                return new EnvelopeProcessingResult(erId, EXCEPTION_RECORD);
+            }
+        } else {
+            log.info("Case not found. Creating exception record instead");
+            Long erId = exceptionRecordCreator.tryCreateFrom(envelope);
+            paymentsProcessor.createPayments(envelope, erId, true);
+            return new EnvelopeProcessingResult(erId, EXCEPTION_RECORD);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/SupplementaryEvidenceHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/SupplementaryEvidenceHandler.java
@@ -47,7 +47,8 @@ public class SupplementaryEvidenceHandler {
                 return new EnvelopeProcessingResult(existingCase.getId(), AUTO_ATTACHED_TO_CASE);
             } else {
                 log.info(
-                    "Creating exception record because attaching supplementary evidence to a case failed. envelope: {}, case: {}",
+                    "Creating exception record because attaching supplementary evidence to a case failed. "
+                        + "envelope: {}, case: {}",
                     envelope.id,
                     existingCase.getId()
                 );

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/EnvelopeHandlerTest.java
@@ -10,9 +10,6 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseFinder;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.PaymentsProcessor;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.processedenvelopes.EnvelopeProcessingResult;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -23,9 +20,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.CASE_REF;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.JURSIDICTION;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelope;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.EXCEPTION;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE_WITH_OCR;
-import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.processedenvelopes.EnvelopeCcdAction.AUTO_ATTACHED_TO_CASE;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.processedenvelopes.EnvelopeCcdAction.EXCEPTION_RECORD;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,19 +29,18 @@ class EnvelopeHandlerTest {
     @Mock private AttachDocsToSupplementaryEvidence attachDocsToSupplementaryEvidence;
     @Mock private CreateExceptionRecord createExceptionRecord;
     @Mock private CaseFinder caseFinder;
-    @Mock private CaseDetails caseDetails;
     @Mock private PaymentsProcessor paymentsProcessor;
     @Mock private NewApplicationHandler newApplicationHandler;
+    @Mock private SupplementaryEvidenceHandler supplementaryEvidenceHandler;
 
     private EnvelopeHandler envelopeHandler;
 
     @BeforeEach
     void setUp() {
         envelopeHandler = new EnvelopeHandler(
-            attachDocsToSupplementaryEvidence,
             createExceptionRecord,
-            caseFinder,
             paymentsProcessor,
+            supplementaryEvidenceHandler,
             newApplicationHandler
         );
     }
@@ -59,44 +53,6 @@ class EnvelopeHandlerTest {
             caseFinder,
             paymentsProcessor
         );
-    }
-
-    @Test
-    void should_call_AttachDocsToSupplementaryEvidence_for_supplementary_evidence_classification_when_case_exists() {
-        // given
-        Envelope envelope = envelope(SUPPLEMENTARY_EVIDENCE, JURSIDICTION, CASE_REF);
-        given(caseFinder.findCase(envelope)).willReturn(Optional.of(caseDetails));
-        given(attachDocsToSupplementaryEvidence.attach(envelope, caseDetails)).willReturn(true);
-        Long ccdId = 321394383L;
-        given(caseDetails.getId()).willReturn(ccdId);
-
-        // when
-        EnvelopeProcessingResult envelopeProcessingResult = envelopeHandler.handleEnvelope(envelope, 0);
-
-        // then
-        assertThat(AUTO_ATTACHED_TO_CASE).isEqualTo(envelopeProcessingResult.envelopeCcdAction);
-        assertThat(ccdId).isEqualTo(envelopeProcessingResult.ccdId);
-
-        verify(attachDocsToSupplementaryEvidence).attach(envelope, caseDetails);
-        verify(paymentsProcessor).createPayments(envelope, caseDetails.getId(), false);
-    }
-
-    @Test
-    void should_call_CreateExceptionRecord_for_supplementary_evidence_classification_when_case_does_not_exist() {
-        // given
-        Envelope envelope = envelope(SUPPLEMENTARY_EVIDENCE, JURSIDICTION, CASE_REF);
-        given(caseFinder.findCase(envelope)).willReturn(Optional.empty()); // case not found
-        given(createExceptionRecord.tryCreateFrom(envelope)).willReturn(CASE_ID);
-
-        // when
-        EnvelopeProcessingResult envelopeProcessingResult = envelopeHandler.handleEnvelope(envelope, 0);
-
-        // then
-        assertThat(EXCEPTION_RECORD).isEqualTo(envelopeProcessingResult.envelopeCcdAction);
-        assertThat(CASE_ID).isEqualTo(envelopeProcessingResult.ccdId);
-
-        verify(createExceptionRecord).tryCreateFrom(envelope);
-        verify(paymentsProcessor).createPayments(envelope, CASE_ID, true);
     }
 
     @Test
@@ -129,26 +85,6 @@ class EnvelopeHandlerTest {
         assertThat(EXCEPTION_RECORD).isEqualTo(envelopeProcessingResult.envelopeCcdAction);
         assertThat(CASE_ID).isEqualTo(envelopeProcessingResult.ccdId);
 
-        verify(createExceptionRecord).tryCreateFrom(envelope);
-        verify(paymentsProcessor).createPayments(envelope, CASE_ID, true);
-    }
-
-    @Test
-    void should_call_CreateExceptionRecord_when_documents_attachment_fails_for_supplementary_evidence() {
-        // given
-        Envelope envelope = envelope(SUPPLEMENTARY_EVIDENCE, JURSIDICTION, CASE_REF);
-        given(caseFinder.findCase(envelope)).willReturn(Optional.of(caseDetails));
-        given(attachDocsToSupplementaryEvidence.attach(envelope, caseDetails)).willReturn(false);
-        given(createExceptionRecord.tryCreateFrom(envelope)).willReturn(CASE_ID);
-
-        // when
-        EnvelopeProcessingResult envelopeProcessingResult = envelopeHandler.handleEnvelope(envelope, 0);
-
-        // then
-        assertThat(EXCEPTION_RECORD).isEqualTo(envelopeProcessingResult.envelopeCcdAction);
-        assertThat(CASE_ID).isEqualTo(envelopeProcessingResult.ccdId);
-
-        verify(attachDocsToSupplementaryEvidence).attach(envelope, caseDetails);
         verify(createExceptionRecord).tryCreateFrom(envelope);
         verify(paymentsProcessor).createPayments(envelope, CASE_ID, true);
     }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/SupplementaryEvidenceHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/events/SupplementaryEvidenceHandlerTest.java
@@ -1,0 +1,105 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.events;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.CaseFinder;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.PaymentsProcessor;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.CASE_ID;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.CASE_REF;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.JURSIDICTION;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.SampleData.envelope;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Classification.SUPPLEMENTARY_EVIDENCE;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.processedenvelopes.EnvelopeCcdAction.AUTO_ATTACHED_TO_CASE;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.processedenvelopes.EnvelopeCcdAction.EXCEPTION_RECORD;
+
+@ExtendWith(MockitoExtension.class)
+class SupplementaryEvidenceHandlerTest {
+
+    @Mock CaseFinder caseFinder;
+    @Mock AttachDocsToSupplementaryEvidence evidenceAttacher;
+    @Mock PaymentsProcessor paymentsProcessor;
+    @Mock CreateExceptionRecord exceptionRecordCreator;
+
+    @Mock CaseDetails caseDetails;
+
+    SupplementaryEvidenceHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new SupplementaryEvidenceHandler(
+            caseFinder,
+            evidenceAttacher,
+            paymentsProcessor,
+            exceptionRecordCreator
+        );
+    }
+
+    @Test
+    void should_call_AttachDocsToSupplementaryEvidence_when_case_exists() {
+        // given
+        Envelope envelope = envelope(SUPPLEMENTARY_EVIDENCE, JURSIDICTION, CASE_REF);
+        given(caseFinder.findCase(envelope)).willReturn(Optional.of(caseDetails));
+        given(evidenceAttacher.attach(envelope, caseDetails)).willReturn(true);
+        Long ccdId = 321394383L;
+        given(caseDetails.getId()).willReturn(ccdId);
+
+        // when
+        var result = handler.handle(envelope);
+
+        // then
+        assertThat(result.envelopeCcdAction).isEqualTo(AUTO_ATTACHED_TO_CASE);
+        assertThat(result.ccdId).isEqualTo(ccdId);
+
+        verify(evidenceAttacher).attach(envelope, caseDetails);
+        verify(paymentsProcessor).createPayments(envelope, caseDetails.getId(), false);
+    }
+
+    @Test
+    void should_call_CreateExceptionRecord_when_case_does_not_exist() {
+        // given
+        Envelope envelope = envelope(SUPPLEMENTARY_EVIDENCE, JURSIDICTION, CASE_REF);
+        given(caseFinder.findCase(envelope)).willReturn(Optional.empty()); // case not found
+        given(exceptionRecordCreator.tryCreateFrom(envelope)).willReturn(CASE_ID);
+
+        // when
+        var result = handler.handle(envelope);
+
+        // then
+        assertThat(result.envelopeCcdAction).isEqualTo(EXCEPTION_RECORD);
+        assertThat(result.ccdId).isEqualTo(CASE_ID);
+
+        verify(exceptionRecordCreator).tryCreateFrom(envelope);
+        verify(paymentsProcessor).createPayments(envelope, CASE_ID, true);
+    }
+
+    @Test
+    void should_call_CreateExceptionRecord_when_documents_attachment_fails_for_supplementary_evidence() {
+        // given
+        Envelope envelope = envelope(SUPPLEMENTARY_EVIDENCE, JURSIDICTION, CASE_REF);
+        given(caseFinder.findCase(envelope)).willReturn(Optional.of(caseDetails));
+        given(evidenceAttacher.attach(envelope, caseDetails)).willReturn(false);
+        given(exceptionRecordCreator.tryCreateFrom(envelope)).willReturn(CASE_ID);
+
+        // when
+        var result = handler.handle(envelope);
+
+        // then
+        assertThat(result.envelopeCcdAction).isEqualTo(EXCEPTION_RECORD);
+        assertThat(result.ccdId).isEqualTo(CASE_ID);
+
+        verify(evidenceAttacher).attach(envelope, caseDetails);
+        verify(exceptionRecordCreator).tryCreateFrom(envelope);
+        verify(paymentsProcessor).createPayments(envelope, CASE_ID, true);
+    }
+}


### PR DESCRIPTION
... from general `EnvelopeHandler`.
Similar to https://github.com/hmcts/bulk-scan-orchestrator/pull/1207/files

All in preparation to handling `SUPPLEMENTARY_EVIDENCE_WITH_OCR` (auto case update)