### PR TITLE
Rename method for retrieving data for updating a case

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateClientTest.java
@@ -77,7 +77,7 @@ public class CaseUpdateClientTest {
         );
 
         // when
-        SuccessfulUpdateResponse response = client.updateCase(
+        SuccessfulUpdateResponse response = client.getCaseUpdateData(
             updateUrl,
             existingCase(),
             exceptionRecordRequestData(),
@@ -104,7 +104,7 @@ public class CaseUpdateClientTest {
 
         // when
         UnprocessableEntity exception = catchThrowableOfType(
-            () -> client.updateCase(updateUrl, existingCase(), exceptionRecordRequestData(), s2sToken),
+            () -> client.getCaseUpdateData(updateUrl, existingCase(), exceptionRecordRequestData(), s2sToken),
             UnprocessableEntity.class
         );
 
@@ -126,7 +126,7 @@ public class CaseUpdateClientTest {
 
         // when
         BadRequest exception = catchThrowableOfType(
-            () -> client.updateCase(updateUrl, existingCase(), exceptionRecordRequestData(), s2sToken),
+            () -> client.getCaseUpdateData(updateUrl, existingCase(), exceptionRecordRequestData(), s2sToken),
             BadRequest.class
         );
 
@@ -146,7 +146,7 @@ public class CaseUpdateClientTest {
 
         // when
         BadRequest exception = catchThrowableOfType(
-            () -> client.updateCase(updateUrl, existingCase(), exceptionRecordRequestData(), s2sToken),
+            () -> client.getCaseUpdateData(updateUrl, existingCase(), exceptionRecordRequestData(), s2sToken),
             BadRequest.class
         );
 
@@ -164,7 +164,7 @@ public class CaseUpdateClientTest {
 
         // when
         Forbidden exception = catchThrowableOfType(
-            () -> client.updateCase(updateUrl, existingCase(), exceptionRecordRequestData(), randomUUID().toString()),
+            () -> client.getCaseUpdateData(updateUrl, existingCase(), exceptionRecordRequestData(), randomUUID().toString()),
             Forbidden.class
         );
 
@@ -182,7 +182,7 @@ public class CaseUpdateClientTest {
 
         // when
         Unauthorized exception = catchThrowableOfType(
-            () -> client.updateCase(updateUrl, existingCase(), exceptionRecordRequestData(), randomUUID().toString()),
+            () -> client.getCaseUpdateData(updateUrl, existingCase(), exceptionRecordRequestData(), randomUUID().toString()),
             Unauthorized.class
         );
 
@@ -200,7 +200,7 @@ public class CaseUpdateClientTest {
 
         // when
         InternalServerError exception = catchThrowableOfType(
-            () -> client.updateCase(updateUrl, existingCase(), exceptionRecordRequestData(), randomUUID().toString()),
+            () -> client.getCaseUpdateData(updateUrl, existingCase(), exceptionRecordRequestData(), randomUUID().toString()),
             InternalServerError.class
         );
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateClientTest.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
+@SuppressWarnings("checkstyle:LineLength")
 @AutoConfigureWireMock(port = 0)
 @IntegrationTest
 public class CaseUpdateClientTest {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateClient.java
@@ -35,7 +35,7 @@ public class CaseUpdateClient {
         this.requestCreator = requestCreator;
     }
 
-    public SuccessfulUpdateResponse updateCase(
+    public SuccessfulUpdateResponse getCaseUpdateData(
         String updateUrl,
         CaseDetails existingCase,
         ExceptionRecord exceptionRecord,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -111,7 +111,7 @@ public class CcdCaseUpdater {
                 return Optional.empty();
             }
 
-            SuccessfulUpdateResponse updateResponse = caseUpdateClient.updateCase(
+            SuccessfulUpdateResponse updateResponse = caseUpdateClient.getCaseUpdateData(
                 configItem.getUpdateUrl(),
                 existingCase,
                 exceptionRecord,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateClientResponseValidationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateClientResponseValidationTest.java
@@ -121,7 +121,7 @@ class CaseUpdateClientResponseValidationTest {
     }
 
     void callUpdateCase() {
-        client.updateCase(
+        client.getCaseUpdateData(
             "http://some-url.com/update",
             mock(CaseDetails.class),
             mock(ExceptionRecord.class),

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateClientTest.java
@@ -64,7 +64,7 @@ class CaseUpdateClientTest {
         String url = "http://test-url.example.com";
 
         // when
-        caseUpdateClient.updateCase(url, existingCase, exceptionRecord, "token");
+        caseUpdateClient.getCaseUpdateData(url, existingCase, exceptionRecord, "token");
 
         // then
         var requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -106,7 +106,7 @@ class CcdCaseUpdaterTest {
     void updateCase_should_return_no_error_or_warnings_if_no_warnings_from_updateCase() {
         // given
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.updateCase("url", existingCase, exceptionRecord, "token"))
+        given(caseUpdateClient.getCaseUpdateData("url", existingCase, exceptionRecord, "token"))
             .willReturn(noWarningsUpdateResponse);
         initResponseMockData();
         initMockData();
@@ -137,7 +137,7 @@ class CcdCaseUpdaterTest {
             .willReturn(caseDataAfterDocExceptionRefUpdate);
 
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.updateCase("url", existingCase, exceptionRecord, "token"))
+        given(caseUpdateClient.getCaseUpdateData("url", existingCase, exceptionRecord, "token"))
             .willReturn(noWarningsUpdateResponse);
         initResponseMockData();
         initMockData();
@@ -167,7 +167,7 @@ class CcdCaseUpdaterTest {
     void updateCase_should_return_no_error_or_warnings_if_warnings_from_updateCase_and_ignoreWarnings_is_true() {
         // given
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.updateCase("url", existingCase, exceptionRecord, "token"))
+        given(caseUpdateClient.getCaseUpdateData("url", existingCase, exceptionRecord, "token"))
             .willReturn(warningsUpdateResponse);
         initResponseMockData();
         initMockData();
@@ -194,7 +194,7 @@ class CcdCaseUpdaterTest {
     void updateCase_should_return_warnings_if_warnings_from_updateCase_and_ignoreWarnings_is_false() {
         // given
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.updateCase("url", existingCase, exceptionRecord, "token"))
+        given(caseUpdateClient.getCaseUpdateData("url", existingCase, exceptionRecord, "token"))
             .willReturn(warningsUpdateResponse);
         initMockData();
 
@@ -221,7 +221,7 @@ class CcdCaseUpdaterTest {
     void updateCase_should_handle_conflict_response_from_ccd_api() {
         initResponseMockData();
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.updateCase(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
+        given(caseUpdateClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
             .willReturn(noWarningsUpdateResponse);
         initMockData();
         prepareMockForSubmissionEventForCaseWorker()
@@ -253,7 +253,7 @@ class CcdCaseUpdaterTest {
         // given
         initResponseMockData();
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.updateCase(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
+        given(caseUpdateClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
             .willReturn(noWarningsUpdateResponse);
         initMockData();
         prepareMockForSubmissionEventForCaseWorker().willThrow(
@@ -289,7 +289,7 @@ class CcdCaseUpdaterTest {
         // given
         initResponseMockData();
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.updateCase(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
+        given(caseUpdateClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
             .willReturn(noWarningsUpdateResponse);
         initMockData();
         prepareMockForSubmissionEventForCaseWorker()
@@ -331,7 +331,7 @@ class CcdCaseUpdaterTest {
         given(existingCase.getCaseTypeId()).willReturn("caseTypeId");
         given(eventResponse.getEventId()).willReturn(EventIds.ATTACH_SCANNED_DOCS_WITH_OCR);
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.updateCase(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
+        given(caseUpdateClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
             .willThrow(new RestClientException("I/O error"));
         initMockData();
 
@@ -369,7 +369,7 @@ class CcdCaseUpdaterTest {
         given(existingCase.getCaseTypeId()).willReturn("caseTypeId");
         given(eventResponse.getEventId()).willReturn(EventIds.ATTACH_SCANNED_DOCS_WITH_OCR);
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.updateCase(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
+        given(caseUpdateClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
             .willThrow(new ConstraintViolationException("validation error message", emptySet()));
         initMockData();
 


### PR DESCRIPTION
To clarify what's this method (and client - to be renamed in next PR) is actually doing.
It is NOT updating a case in CCD, just getting the data that **will be used for update** later.