### PR TITLE
Rename case update client

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateDataClientTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateDataClientTest.java
@@ -49,12 +49,12 @@ import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 @SuppressWarnings("checkstyle:LineLength")
 @AutoConfigureWireMock(port = 0)
 @IntegrationTest
-public class CaseUpdateClientTest {
+public class CaseUpdateDataClientTest {
 
     private static final String UPDATE_CASE_URL = "/update-case";
 
     @Autowired
-    private CaseUpdateClient client;
+    private CaseUpdateDataClient client;
 
     @Value("${service-config.services[0].update-url}")
     private String updateUrl;

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateDataClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateDataClient.java
@@ -16,16 +16,19 @@ import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
 
+/**
+ * Retrieves data that should be used to update a case.
+ */
 @Component
-public class CaseUpdateClient {
+public class CaseUpdateDataClient {
 
-    private static final Logger log = LoggerFactory.getLogger(CaseUpdateClient.class);
+    private static final Logger log = LoggerFactory.getLogger(CaseUpdateDataClient.class);
 
     private final Validator validator;
     private final RestTemplate restTemplate;
     private final CaseUpdateRequestCreator requestCreator;
 
-    public CaseUpdateClient(
+    public CaseUpdateDataClient(
         Validator validator,
         RestTemplate restTemplate,
         CaseUpdateRequestCreator requestCreator

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -8,7 +8,7 @@ import org.springframework.web.client.HttpClientErrorException.UnprocessableEnti
 import org.springframework.web.client.RestClientException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.ServiceResponseParser;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.CaseUpdateClient;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.CaseUpdateDataClient;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.response.SuccessfulUpdateResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.response.ClientServiceErrorResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
@@ -39,7 +39,7 @@ public class CcdCaseUpdater {
 
     private final AuthTokenGenerator s2sTokenGenerator;
     private final CoreCaseDataApi coreCaseDataApi;
-    private final CaseUpdateClient caseUpdateClient;
+    private final CaseUpdateDataClient caseUpdateDataClient;
     private final CaseDataUpdater caseDataUpdater;
     private final EnvelopeReferenceHelper envelopeReferenceHelper;
     private final ServiceResponseParser serviceResponseParser;
@@ -47,14 +47,14 @@ public class CcdCaseUpdater {
     public CcdCaseUpdater(
         AuthTokenGenerator s2sTokenGenerator,
         CoreCaseDataApi coreCaseDataApi,
-        CaseUpdateClient caseUpdateClient,
+        CaseUpdateDataClient caseUpdateDataClient,
         CaseDataUpdater caseDataUpdater,
         EnvelopeReferenceHelper envelopeReferenceHelper,
         ServiceResponseParser serviceResponseParser
     ) {
         this.s2sTokenGenerator = s2sTokenGenerator;
         this.coreCaseDataApi = coreCaseDataApi;
-        this.caseUpdateClient = caseUpdateClient;
+        this.caseUpdateDataClient = caseUpdateDataClient;
         this.caseDataUpdater = caseDataUpdater;
         this.envelopeReferenceHelper = envelopeReferenceHelper;
         this.serviceResponseParser = serviceResponseParser;
@@ -111,7 +111,7 @@ public class CcdCaseUpdater {
                 return Optional.empty();
             }
 
-            SuccessfulUpdateResponse updateResponse = caseUpdateClient.getCaseUpdateData(
+            SuccessfulUpdateResponse updateResponse = caseUpdateDataClient.getCaseUpdateData(
                 configItem.getUpdateUrl(),
                 existingCase,
                 exceptionRecord,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateDataClientResponseValidationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateDataClientResponseValidationTest.java
@@ -31,14 +31,14 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
-class CaseUpdateClientResponseValidationTest {
+class CaseUpdateDataClientResponseValidationTest {
 
     @Mock RestTemplate restTemplate;
     @Mock CaseUpdateRequestCreator requestCreator;
 
     Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
-    CaseUpdateClient client;
+    CaseUpdateDataClient client;
 
     @BeforeEach
     void setUp() {
@@ -50,7 +50,7 @@ class CaseUpdateClientResponseValidationTest {
         );
 
         given(requestCreator.create(any(), any(), anyBoolean())).willReturn(caseUpdateRequest);
-        this.client = new CaseUpdateClient(validator, restTemplate, requestCreator);
+        this.client = new CaseUpdateDataClient(validator, restTemplate, requestCreator);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateDataClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateDataClientTest.java
@@ -28,7 +28,7 @@ import static uk.gov.hmcts.reform.bulkscan.orchestrator.client.SampleData.sample
 
 
 @ExtendWith(MockitoExtension.class)
-class CaseUpdateClientTest {
+class CaseUpdateDataClientTest {
 
     @Mock
     Validator validator;
@@ -39,11 +39,11 @@ class CaseUpdateClientTest {
     @Mock
     CaseUpdateRequestCreator requestCreator;
 
-    private CaseUpdateClient caseUpdateClient;
+    private CaseUpdateDataClient caseUpdateDataClient;
 
     @BeforeEach
     void setUp() {
-        caseUpdateClient = new CaseUpdateClient(validator, restTemplate, requestCreator);
+        caseUpdateDataClient = new CaseUpdateDataClient(validator, restTemplate, requestCreator);
     }
 
     @Test
@@ -64,7 +64,7 @@ class CaseUpdateClientTest {
         String url = "http://test-url.example.com";
 
         // when
-        caseUpdateClient.getCaseUpdateData(url, existingCase, exceptionRecord, "token");
+        caseUpdateDataClient.getCaseUpdateData(url, existingCase, exceptionRecord, "token");
 
         // then
         var requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -14,7 +14,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.ServiceResponseParser;
-import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.CaseUpdateClient;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.CaseUpdateDataClient;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.response.CaseUpdateDetails;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.response.SuccessfulUpdateResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.model.request.DocumentType;
@@ -62,7 +62,7 @@ class CcdCaseUpdaterTest {
 
     private CcdCaseUpdater ccdCaseUpdater;
 
-    @Mock private CaseUpdateClient caseUpdateClient;
+    @Mock private CaseUpdateDataClient caseUpdateDataClient;
     @Mock private ServiceResponseParser serviceResponseParser;
     @Mock private AuthTokenGenerator authTokenGenerator;
     @Mock private CoreCaseDataApi coreCaseDataApi;
@@ -85,7 +85,7 @@ class CcdCaseUpdaterTest {
         ccdCaseUpdater = new CcdCaseUpdater(
             authTokenGenerator,
             coreCaseDataApi,
-            caseUpdateClient,
+            caseUpdateDataClient,
             caseDataUpdater,
             envelopeReferenceHelper,
             serviceResponseParser
@@ -106,7 +106,7 @@ class CcdCaseUpdaterTest {
     void updateCase_should_return_no_error_or_warnings_if_no_warnings_from_updateCase() {
         // given
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.getCaseUpdateData("url", existingCase, exceptionRecord, "token"))
+        given(caseUpdateDataClient.getCaseUpdateData("url", existingCase, exceptionRecord, "token"))
             .willReturn(noWarningsUpdateResponse);
         initResponseMockData();
         initMockData();
@@ -137,7 +137,7 @@ class CcdCaseUpdaterTest {
             .willReturn(caseDataAfterDocExceptionRefUpdate);
 
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.getCaseUpdateData("url", existingCase, exceptionRecord, "token"))
+        given(caseUpdateDataClient.getCaseUpdateData("url", existingCase, exceptionRecord, "token"))
             .willReturn(noWarningsUpdateResponse);
         initResponseMockData();
         initMockData();
@@ -167,7 +167,7 @@ class CcdCaseUpdaterTest {
     void updateCase_should_return_no_error_or_warnings_if_warnings_from_updateCase_and_ignoreWarnings_is_true() {
         // given
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.getCaseUpdateData("url", existingCase, exceptionRecord, "token"))
+        given(caseUpdateDataClient.getCaseUpdateData("url", existingCase, exceptionRecord, "token"))
             .willReturn(warningsUpdateResponse);
         initResponseMockData();
         initMockData();
@@ -194,7 +194,7 @@ class CcdCaseUpdaterTest {
     void updateCase_should_return_warnings_if_warnings_from_updateCase_and_ignoreWarnings_is_false() {
         // given
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.getCaseUpdateData("url", existingCase, exceptionRecord, "token"))
+        given(caseUpdateDataClient.getCaseUpdateData("url", existingCase, exceptionRecord, "token"))
             .willReturn(warningsUpdateResponse);
         initMockData();
 
@@ -221,7 +221,7 @@ class CcdCaseUpdaterTest {
     void updateCase_should_handle_conflict_response_from_ccd_api() {
         initResponseMockData();
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
+        given(caseUpdateDataClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
             .willReturn(noWarningsUpdateResponse);
         initMockData();
         prepareMockForSubmissionEventForCaseWorker()
@@ -253,7 +253,7 @@ class CcdCaseUpdaterTest {
         // given
         initResponseMockData();
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
+        given(caseUpdateDataClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
             .willReturn(noWarningsUpdateResponse);
         initMockData();
         prepareMockForSubmissionEventForCaseWorker().willThrow(
@@ -289,7 +289,7 @@ class CcdCaseUpdaterTest {
         // given
         initResponseMockData();
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
+        given(caseUpdateDataClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
             .willReturn(noWarningsUpdateResponse);
         initMockData();
         prepareMockForSubmissionEventForCaseWorker()
@@ -331,7 +331,7 @@ class CcdCaseUpdaterTest {
         given(existingCase.getCaseTypeId()).willReturn("caseTypeId");
         given(eventResponse.getEventId()).willReturn(EventIds.ATTACH_SCANNED_DOCS_WITH_OCR);
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
+        given(caseUpdateDataClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
             .willThrow(new RestClientException("I/O error"));
         initMockData();
 
@@ -369,7 +369,7 @@ class CcdCaseUpdaterTest {
         given(existingCase.getCaseTypeId()).willReturn("caseTypeId");
         given(eventResponse.getEventId()).willReturn(EventIds.ATTACH_SCANNED_DOCS_WITH_OCR);
         given(configItem.getUpdateUrl()).willReturn("url");
-        given(caseUpdateClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
+        given(caseUpdateDataClient.getCaseUpdateData(anyString(), any(CaseDetails.class), any(ExceptionRecord.class), anyString()))
             .willThrow(new ConstraintViolationException("validation error message", emptySet()));
         initMockData();
 


### PR DESCRIPTION
As it's not updating a case, it's retrieving data that should be used to update a case.