### PR TITLE
Add CaseUpdateDetailsService

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateDataClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/caseupdate/CaseUpdateDataClient.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.request.CaseUpdateRequest;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.response.SuccessfulUpdateResponse;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -38,11 +39,21 @@ public class CaseUpdateDataClient {
         this.requestCreator = requestCreator;
     }
 
+    @Deprecated
     public SuccessfulUpdateResponse getCaseUpdateData(
         String updateUrl,
         CaseDetails existingCase,
         ExceptionRecord exceptionRecord,
         String s2sToken
+    ) {
+        var caseUpdateRequest = requestCreator.create(exceptionRecord, existingCase, false);
+        return getCaseUpdateData(updateUrl, s2sToken, caseUpdateRequest);
+    }
+
+    public SuccessfulUpdateResponse getCaseUpdateData(
+        String updateUrl,
+        String s2sToken,
+        CaseUpdateRequest caseUpdateRequest
     ) {
         HttpHeaders headers = new HttpHeaders();
         headers.add("ServiceAuthorization", s2sToken);
@@ -52,8 +63,6 @@ public class CaseUpdateDataClient {
                 .fromHttpUrl(updateUrl)
                 .build()
                 .toString();
-
-        var caseUpdateRequest = requestCreator.create(exceptionRecord, existingCase, false);
 
         log.info(
             "Requesting service to update case, caseTypeId: {}, case id: {}, exception id: {}",

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/caseupdatedetails/CaseUpdateDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/caseupdatedetails/CaseUpdateDetailsService.java
@@ -30,6 +30,10 @@ public class CaseUpdateDetailsService {
 
     /**
      * Retrieves data that should be used to update given case based on given exception record.
+     *
+     * @param service         service that should be called to get the data.
+     * @param existingCase    CCD case to update.
+     * @param exceptionRecord exception record that should be used to update the case.
      */
     public SuccessfulUpdateResponse getCaseUpdateData(
         String service,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/caseupdatedetails/CaseUpdateDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/caseupdatedetails/CaseUpdateDetailsService.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.caseupdatedetails;
+
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.CaseUpdateDataClient;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.CaseUpdateRequestCreator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.request.CaseUpdateRequest;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.response.SuccessfulUpdateResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.config.ServiceConfigProvider;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+public class CaseUpdateDetailsService {
+
+    private final AuthTokenGenerator s2sTokenGenerator;
+    private final CaseUpdateDataClient caseUpdateDataClient;
+    private final CaseUpdateRequestCreator requestCreator;
+    private final ServiceConfigProvider serviceConfigProvider;
+
+    public CaseUpdateDetailsService(
+        AuthTokenGenerator s2sTokenGenerator,
+        CaseUpdateDataClient caseUpdateDataClient,
+        CaseUpdateRequestCreator requestCreator,
+        ServiceConfigProvider serviceConfigProvider
+    ) {
+        this.s2sTokenGenerator = s2sTokenGenerator;
+        this.caseUpdateDataClient = caseUpdateDataClient;
+        this.requestCreator = requestCreator;
+        this.serviceConfigProvider = serviceConfigProvider;
+    }
+
+    /**
+     * Retrieves data that should be used to update given case based on given exception record.
+     */
+    public SuccessfulUpdateResponse getCaseUpdateData(
+        String service,
+        CaseDetails existingCase,
+        ExceptionRecord exceptionRecord
+    ) {
+        String s2sToken = s2sTokenGenerator.generate();
+        String url = serviceConfigProvider.getConfig(service).getUpdateUrl();
+        CaseUpdateRequest request = requestCreator.create(exceptionRecord, existingCase, false);
+
+        return caseUpdateDataClient.getCaseUpdateData(url, s2sToken, request);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/caseupdatedetails/CaseUpdateDetailsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/caseupdatedetails/CaseUpdateDetailsServiceTest.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.caseupdatedetails;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.CaseUpdateDataClient;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.CaseUpdateRequestCreator;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.request.CaseUpdateRequest;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.client.caseupdate.model.response.SuccessfulUpdateResponse;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.config.ServiceConfigItem;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.model.internal.ExceptionRecord;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.config.ServiceConfigProvider;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.client.SampleData.sampleCaseDetails;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.client.SampleData.sampleExceptionRecord;
+
+@ExtendWith(MockitoExtension.class)
+class CaseUpdateDetailsServiceTest {
+
+    @Mock AuthTokenGenerator s2sTokenGenerator;
+    @Mock CaseUpdateDataClient caseUpdateDataClient;
+    @Mock CaseUpdateRequestCreator requestCreator;
+    @Mock ServiceConfigProvider serviceConfigProvider;
+
+    @Mock CaseUpdateRequest caseUpdateRequest;
+    @Mock SuccessfulUpdateResponse updateDataResponse;
+
+    CaseUpdateDetailsService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CaseUpdateDetailsService(
+            s2sTokenGenerator,
+            caseUpdateDataClient,
+            requestCreator,
+            serviceConfigProvider
+        );
+    }
+
+    @Test
+    void should_call_api_client_with_correct_arguments() {
+        // given
+        CaseDetails existingCase = sampleCaseDetails();
+        ExceptionRecord exceptionRecord = sampleExceptionRecord();
+
+        given(s2sTokenGenerator.generate()).willReturn("some-s2s-token");
+        given(serviceConfigProvider.getConfig("some-service")).willReturn(cfg("some-url"));
+        given(requestCreator.create(exceptionRecord, existingCase, false)).willReturn(caseUpdateRequest);
+        given(caseUpdateDataClient.getCaseUpdateData("some-url", "some-s2s-token", caseUpdateRequest))
+            .willReturn(updateDataResponse);
+
+        // when
+        var result = service.getCaseUpdateData("some-service", existingCase, exceptionRecord);
+
+        // then
+        assertThat(result).isEqualTo(updateDataResponse);
+    }
+
+    private ServiceConfigItem cfg(String updateUrl) {
+        var cfg = new ServiceConfigItem();
+        cfg.setUpdateUrl(updateUrl);
+        return cfg;
+    }
+}


### PR DESCRIPTION
New service hiding the details of urls and auth from the consumer.
This will simplify things for automatic case update.

In next PR I'll update existing code dealing with manual case update to use this new service (instead of the rest client directly)