### PR TITLE
Added logging of feign exception content

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -302,7 +302,7 @@ public class CcdApi {
 
             throw new CcdCallException(
                 String.format(
-                    "Could not attach documents for case ref: %s, Response status: %s, CCD response: %s",
+                    "Could not attach documents for case ref: %s Error: %s, CCD response: %s",
                     caseRef,
                     e.status(),
                     e.contentUTF8()

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -301,7 +301,13 @@ public class CcdApi {
             removeFromIdamCacheIfAuthProblem(e.status(), jurisdiction);
 
             throw new CcdCallException(
-                String.format("Could not attach documents for case ref: %s Error: %s", caseRef, e.status()), e
+                String.format(
+                    "Could not attach documents for case ref: %s, Response status: %s, CCD response: %s",
+                    caseRef,
+                    e.status(),
+                    e.contentUTF8()
+                ),
+                e
             );
         }
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-278


### Change description ###
Added logging of feign exception content in order to find out what is causing 422 Unprocessable Entity response from CCD for 2034404010740_09-12-2020-15-00-32.zip.

This will supposedly be reverted after solving the issue.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
