### PR TITLE
CcdApi::startEventForCaseWorker

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApi.java
@@ -473,6 +473,26 @@ public class CcdApi {
         }
     }
 
+    public StartEventResponse startEventForCaseWorker(
+        String idamToken,
+        String serviceToken,
+        String userId,
+        String jurisdiction,
+        String caseTypeId,
+        String caseId,
+        String eventId
+    ) {
+        return feignCcdApi.startEventForCaseWorker(
+            idamToken,
+            serviceToken,
+            userId,
+            jurisdiction,
+            caseTypeId,
+            caseId,
+            eventId
+        );
+    }
+
     private List<Long> searchCases(
         String jurisdiction,
         String caseType,

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdater.java
@@ -37,6 +37,7 @@ public class CcdCaseUpdater {
     private static final Logger log = LoggerFactory.getLogger(CcdCaseUpdater.class);
 
     private final AuthTokenGenerator s2sTokenGenerator;
+    private final CcdApi ccdApi;
     private final CoreCaseDataApi coreCaseDataApi;
     private final CaseUpdateDetailsService caseUpdateDataService;
     private final CaseDataUpdater caseDataUpdater;
@@ -45,6 +46,7 @@ public class CcdCaseUpdater {
 
     public CcdCaseUpdater(
         AuthTokenGenerator s2sTokenGenerator,
+        CcdApi ccdApi,
         CoreCaseDataApi coreCaseDataApi,
         CaseUpdateDetailsService caseUpdateDataService,
         CaseDataUpdater caseDataUpdater,
@@ -52,6 +54,7 @@ public class CcdCaseUpdater {
         ServiceResponseParser serviceResponseParser
     ) {
         this.s2sTokenGenerator = s2sTokenGenerator;
+        this.ccdApi = ccdApi;
         this.coreCaseDataApi = coreCaseDataApi;
         this.caseUpdateDataService = caseUpdateDataService;
         this.caseDataUpdater = caseDataUpdater;
@@ -78,7 +81,7 @@ public class CcdCaseUpdater {
         try {
             String s2sToken = s2sTokenGenerator.generate();
 
-            StartEventResponse startEvent = coreCaseDataApi.startEventForCaseWorker(
+            StartEventResponse startEvent = ccdApi.startEventForCaseWorker(
                 idamToken,
                 s2sToken,
                 userId,

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApiTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdApiTest.java
@@ -1,0 +1,126 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import feign.FeignException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.bulkscan.orchestrator.services.config.ServiceConfigProvider;
+import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
+import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CcdApiTest {
+    @Mock
+    CoreCaseDataApi feignCcdApi;
+    @Mock
+    CcdAuthenticatorFactory authenticatorFactory;
+    @Mock
+    ServiceConfigProvider serviceConfigProvider;
+    @Mock
+    Function<StartEventResponse, CaseDataContent> caseDataContentBuilder;
+
+    private CcdApi ccdApi;
+
+    @BeforeEach
+    void setUp() {
+        ccdApi = new CcdApi(feignCcdApi, authenticatorFactory, serviceConfigProvider);
+    }
+
+    @Test
+    void start_event_should_start_event_with_correct_data() {
+        // given
+        var userToken = "userToken";
+        var serviceToken = "serviceToken";
+        var userId = "userId";
+        var jurisdiction = "jurisdiction1";
+        var caseTypeId = "caseTypeId1";
+        var eventId = "eventId1";
+        var caseId = "123-123-123";
+
+        var startEventResponse = StartEventResponse.builder().build();
+        given(feignCcdApi.startEventForCaseWorker(
+            userToken,
+            serviceToken,
+            userId,
+            jurisdiction,
+            caseTypeId,
+            caseId,
+            eventId
+        ))
+            .willReturn(startEventResponse);
+
+        // when
+        ccdApi.startEventForCaseWorker(
+            userToken,
+            serviceToken,
+            userId,
+            jurisdiction,
+            caseTypeId,
+            caseId,
+            eventId
+        );
+
+        // then
+        verify(feignCcdApi).startEventForCaseWorker(
+            userToken,
+            serviceToken,
+            userId,
+            jurisdiction,
+            caseTypeId,
+            caseId,
+            eventId
+        );
+    }
+
+    @Test
+    void start_event_should_rethrow_exception_when_communication_with_ccd_fails() {
+        // given
+        var userToken = "userToken";
+        var serviceToken = "serviceToken";
+        var userId = "userId";
+        var jurisdiction = "jurisdiction1";
+        var caseTypeId = "caseTypeId1";
+        var eventId = "eventId1";
+        var caseId = "123-123-123";
+
+        var ccdException = mock(FeignException.BadRequest.class);
+
+        given(feignCcdApi.startEventForCaseWorker(
+            userToken,
+            serviceToken,
+            userId,
+            jurisdiction,
+            caseTypeId,
+            caseId,
+            eventId
+        ))
+            .willThrow(ccdException);
+
+        // when
+        Throwable exc = catchThrowable(
+            () -> ccdApi.startEventForCaseWorker(
+                userToken,
+                serviceToken,
+                userId,
+                jurisdiction,
+                caseTypeId,
+                caseId,
+                eventId
+            )
+        );
+
+        // then
+        assertThat(exc).isSameAs(ccdException);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/CcdCaseUpdaterTest.java
@@ -65,6 +65,7 @@ class CcdCaseUpdaterTest {
     @Mock private CaseUpdateDetailsService caseUpdateDataService;
     @Mock private ServiceResponseParser serviceResponseParser;
     @Mock private AuthTokenGenerator authTokenGenerator;
+    @Mock private CcdApi ccdApi;
     @Mock private CoreCaseDataApi coreCaseDataApi;
     @Mock private CaseDetails existingCase;
     @Mock private StartEventResponse eventResponse;
@@ -83,6 +84,7 @@ class CcdCaseUpdaterTest {
     void setUp() {
         ccdCaseUpdater = new CcdCaseUpdater(
             authTokenGenerator,
+            ccdApi,
             coreCaseDataApi,
             caseUpdateDataService,
             caseDataUpdater,
@@ -478,7 +480,7 @@ class CcdCaseUpdaterTest {
     @Test
     void updateCase_should_handle_bad_request_from_start_event() {
         // given
-        given(coreCaseDataApi.startEventForCaseWorker(
+        given(ccdApi.startEventForCaseWorker(
             anyString(),
             anyString(),
             anyString(),
@@ -539,7 +541,7 @@ class CcdCaseUpdaterTest {
                 null,
                 null
             );
-        given(coreCaseDataApi.startEventForCaseWorker(
+        given(ccdApi.startEventForCaseWorker(
             anyString(),
             anyString(),
             anyString(),
@@ -577,7 +579,7 @@ class CcdCaseUpdaterTest {
     @Test
     void updateCase_should_handle_feign_exception_from_start_event() {
         // given
-        given(coreCaseDataApi.startEventForCaseWorker(
+        given(ccdApi.startEventForCaseWorker(
             anyString(),
             anyString(),
             anyString(),
@@ -622,7 +624,7 @@ class CcdCaseUpdaterTest {
     @Test
     void updateCase_should_handle_generic_exception() {
         // given
-        given(coreCaseDataApi.startEventForCaseWorker(
+        given(ccdApi.startEventForCaseWorker(
             anyString(),
             anyString(),
             anyString(),
@@ -662,7 +664,7 @@ class CcdCaseUpdaterTest {
     @Test
     void updateCase_should_handle_exception_when_start_event_returns_not_found_response() {
         // given
-        given(coreCaseDataApi.startEventForCaseWorker(
+        given(ccdApi.startEventForCaseWorker(
             anyString(),
             anyString(),
             anyString(),
@@ -700,7 +702,7 @@ class CcdCaseUpdaterTest {
     @Test
     void updateCase_should_handle_exception_when_start_event_returns_invalid_case_id_response() {
         // given
-        given(coreCaseDataApi.startEventForCaseWorker(
+        given(ccdApi.startEventForCaseWorker(
             anyString(),
             anyString(),
             anyString(),
@@ -749,7 +751,7 @@ class CcdCaseUpdaterTest {
 
     private void initMockData() {
         given(eventResponse.getCaseDetails()).willReturn(existingCase);
-        given(coreCaseDataApi.startEventForCaseWorker(
+        given(ccdApi.startEventForCaseWorker(
             anyString(),
             anyString(),
             anyString(),


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-378


### Change description ###
Just code move to CcdApi in order to eliminate direct call to CoreCaseDataApi.

In the next PR call to CoreCaseDataApi::submitEventForCaseWorker will be moved to CcdApi.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
