### PR TITLE
add event summary creator to trim long summaries

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventSummaryCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventSummaryCreator.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import java.util.List;
+
+public class EventSummaryCreator {
+
+    private static final String EVENT_SUMMARY_REPLACE = "{XX}";
+    private static final String EVENT_SUMMARY_TRIM_DOTS = "...";
+    private static String EVENT_SUMMARY_TEMP =
+        "Attaching exception record(%d) document numbers:" + EVENT_SUMMARY_REPLACE + " to case:%d";
+    private static int EVENT_SUMMARY_MAX_SIZE = 1024;
+
+    private EventSummaryCreator() {
+    }
+
+    public static String createEventSummary(
+        Long caseId,
+        Long exceptionRecordId,
+        List<String> documentNumberList
+    ) {
+
+        String eventSummary = String.format(
+            EVENT_SUMMARY_TEMP,
+            exceptionRecordId,
+            caseId
+        );
+
+        int remainingSize = EVENT_SUMMARY_MAX_SIZE - eventSummary.length();
+        String documentNumbers = documentNumberList.toString();
+        if (documentNumbers.length() > remainingSize + EVENT_SUMMARY_REPLACE.length()) {
+            documentNumbers = documentNumbers.substring(0, remainingSize) + EVENT_SUMMARY_TRIM_DOTS;
+        }
+
+        return eventSummary.replace(EVENT_SUMMARY_REPLACE, documentNumbers);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/SupplementaryEvidenceUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/SupplementaryEvidenceUpdater.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.EventSummaryCreator.createEventSummary;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.EVIDENCE_HANDLED;
 import static uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd.definition.ExceptionRecordFields.SCANNED_DOCUMENTS;
 
@@ -64,9 +65,9 @@ public class SupplementaryEvidenceUpdater {
             Map<String, Object> newCaseData = buildCaseData(newCaseDocuments, targetCaseDocuments);
 
             final String eventSummary = createEventSummary(
-                targetCase,
+                targetCase.getId(),
                 callBackEvent.exceptionRecordId,
-                newCaseDocuments
+                Documents.getDocumentNumbers(newCaseDocuments)
             );
 
             log.info(eventSummary);
@@ -127,16 +128,4 @@ public class SupplementaryEvidenceUpdater {
             .collect(toList());
     }
 
-    private String createEventSummary(
-        CaseDetails theCase,
-        Long exceptionRecordId,
-        List<Map<String, Object>> exceptionDocuments
-    ) {
-        return String.format(
-            "Attaching exception record(%d) document numbers:%s to case:%d",
-            exceptionRecordId,
-            Documents.getDocumentNumbers(exceptionDocuments),
-            theCase.getId()
-        );
-    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventSummaryCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/EventSummaryCreatorTest.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.bulkscan.orchestrator.services.ccd;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventSummaryCreatorTest {
+
+    @Test
+    void should_return_full_list_if_size_not_extends_the_limit() {
+
+        String eventSummary = EventSummaryCreator
+            .createEventSummary(21312321L, 789757575L, List.of("31321", "755756", "5665"));
+
+        assertThat(eventSummary)
+            .isEqualTo("Attaching exception record(789757575) document numbers:[31321, 755756, 5665] to case:21312321");
+        assertThat(eventSummary.length()).isLessThan(1024);
+    }
+
+    @Test
+    void should_trim_the_list_if_size_extends_the_limit() {
+
+        List<String> docList = Stream
+            .iterate(1000000000000000L, t -> t + 2)
+            .map(t -> t.toString())
+            .limit(56)
+            .collect(Collectors.toList());
+
+        String eventSummary = EventSummaryCreator
+            .createEventSummary(2131232198L, 7697173575L, docList);
+
+        assertThat(eventSummary)
+            .startsWith("Attaching exception record(7697173575) document numbers:")
+            .contains(docList.subList(0, 52))
+            .endsWith(" to case:2131232198");
+        assertThat(eventSummary.length()).isLessThan(1024);
+    }
+}


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSBPS-486

### Change description ###

add event summary creator to trim long summaries

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
