### PR TITLE
FACT-1977 - CVE and Dependency Updates September

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
   id 'org.owasp.dependencycheck' version '10.0.4'
   id 'org.springframework.boot' version '3.2.7'
   id 'com.github.ben-manes.versions' version '0.51.0'
-  id 'org.sonarqube' version '4.4.1.3373'
+  id 'org.sonarqube' version '5.0.0.4638'
   id 'info.solidsoft.pitest' version '1.15.0'
   id 'au.com.dius.pact' version '4.3.14'
   id 'org.flywaydb.flyway' version "$flywayVersion"
@@ -137,8 +137,8 @@ jacocoTestReport {
   dependsOn test, integration
   executionData(test, integration)
   reports {
-    xml.enabled = true
-    csv.enabled = false
+    xml.required = true
+    csv.required = false
     html.destination file("${buildDir}/reports/jacoco/html")
     xml.destination file("${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml")
   }
@@ -192,7 +192,6 @@ pitest {
 sonarqube {
   properties {
     property "sonar.projectName", "Reform :: Bulk Scan Orchestrator"
-    property "sonar.coverage.jacoco.xmlReportPaths", jacocoTestReport.reports.xml.destination.path
     // TODO: remove the specific exclusions when those classes are used
     property "sonar.coverage.exclusions", "**/config/**"
     property "sonar.pitest.mode", "reuseReport"

--- a/build.gradle
+++ b/build.gradle
@@ -309,7 +309,7 @@ dependencies {
   testImplementation group: 'com.typesafe', name: 'config', version: '1.4.3'
   testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.13.0'
   testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.26.3'
-  testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.2.1'
+  testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.2.2'
   testImplementation group: 'io.rest-assured', name: 'rest-assured'
 
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.6'
-  id 'org.owasp.dependencycheck' version '9.1.0'
+  id 'org.owasp.dependencycheck' version '10.0.4'
   id 'org.springframework.boot' version '3.2.7'
   id 'com.github.ben-manes.versions' version '0.51.0'
   id 'org.sonarqube' version '4.4.1.3373'
@@ -307,7 +307,7 @@ dependencies {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
   testImplementation group: 'com.typesafe', name: 'config', version: '1.4.3'
-  testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.12.0'
+  testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.13.0'
   testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.26.3'
   testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.2.1'
   testImplementation group: 'io.rest-assured', name: 'rest-assured'

--- a/build.gradle
+++ b/build.gradle
@@ -281,7 +281,7 @@ dependencies {
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.0'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.1.2'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.3'
-  implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.9.2'
+  implementation group: 'com.github.hmcts', name: 'ccd-client', version: '5.0.3'
   implementation group: 'io.github.resilience4j', name: 'resilience4j-spring-boot3', version: '2.2.0'
   //implementation group: 'io.github.openfeign', name: 'feign-httpclient', version: '13.2.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -291,7 +291,7 @@ dependencies {
 
   implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.3.1'
 
-  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.2'
+  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.3'
 
   implementation group: 'io.vavr', name: 'vavr', version: '1.0.0-alpha-4'
   implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.1.8'

--- a/build.gradle
+++ b/build.gradle
@@ -245,6 +245,7 @@ def versions = [
   springfoxSwagger  : '2.9.2',
   junit             : '5.10.3',
   junitPlatform     : '1.10.3',
+  testContainers    : '1.20.1',
   flyway            : "$flywayVersion",
   postgresql        : "$postgresqlVersion"
 ]
@@ -326,10 +327,10 @@ dependencies {
   integrationTestImplementation sourceSets.test.runtimeClasspath
   integrationTestImplementation group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '4.1.4'
   integrationTestImplementation group: 'org.apiguardian', name: 'apiguardian-api', version: '1.1.2'
-  integrationTestImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.19.7', {
+  integrationTestImplementation group: 'org.testcontainers', name: 'postgresql', version: versions.testContainers, {
     exclude group: 'junit', module: 'junit'
   }
-  integrationTestImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.19.7'
+  integrationTestImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: versions.testContainers
 
   functionalTestImplementation sourceSets.main.runtimeClasspath
   functionalTestImplementation sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,11 @@
 buildscript {
+  ext {
+    flywayVersion = '10.17.3'
+    postgresqlVersion = '42.7.4'
+  }
   dependencies {
-    classpath("org.postgresql:postgresql:42.7.3")
-    classpath("org.flywaydb:flyway-database-postgresql:10.13.0")
+    classpath("org.postgresql:postgresql:$postgresqlVersion") // must be compatible with flyway version
+    classpath("org.flywaydb:flyway-database-postgresql:$flywayVersion") // flyway dependency/plugin versions must always match
   }
 }
 plugins {
@@ -16,7 +20,7 @@ plugins {
   id 'org.sonarqube' version '4.4.1.3373'
   id 'info.solidsoft.pitest' version '1.15.0'
   id 'au.com.dius.pact' version '4.3.14'
-  id 'org.flywaydb.flyway' version '10.13.0'
+  id 'org.flywaydb.flyway' version "$flywayVersion"
 }
 
 group = 'uk.gov.hmcts.reform'
@@ -242,6 +246,8 @@ def versions = [
   springfoxSwagger  : '2.9.2',
   junit             : '5.10.3',
   junitPlatform     : '1.10.3',
+  flyway            : "$flywayVersion",
+  postgresql        : "$postgresqlVersion"
 ]
 
 configurations.all {
@@ -252,10 +258,10 @@ configurations.all {
 
 dependencies {
 
-  runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '10.13.0'
+  runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: versions.flyway
 
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
-  implementation group: 'org.flywaydb', name: 'flyway-core', version: '10.13.0'
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: versions.flyway
+  implementation group: 'org.postgresql', name: 'postgresql', version: versions.postgresql
 
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.6'
   id 'org.owasp.dependencycheck' version '10.0.4'
-  id 'org.springframework.boot' version '3.2.7'
+  id 'org.springframework.boot' version '3.3.3'
   id 'com.github.ben-manes.versions' version '0.51.0'
   id 'org.sonarqube' version '5.0.0.4638'
   id 'info.solidsoft.pitest' version '1.15.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress>
-        <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@.*$</packageUrl>
-        <cve>CVE-2023-35116</cve>
-  </suppress>
-  <suppress>
-    <notes>Wait for a version that fixes this.</notes>
-    <cve>CVE-2023-36052</cve>
-  </suppress>
 </suppressions>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-1977

### Change description ###

- Flyway and Postgres versions have been put into a buildscript property to make it easier to change version
- Gradle being updated meant some parts of the build.gradle were deprecated. Changed it to be more in line with [Send Letter Service](https://github.com/hmcts/send-letter-service/blob/f7de026a6c7c9682f7fab9981ee999cf4637cac6/build.gradle#L158) which was already using the newer version
- Removes jackson-databind and azure suppressions 

**Major Version Jump**

- Gradle to v8
- Owasp Dependency Check to v10
- Sonarqube to v5
- CCD Client to v5

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
