### PR TITLE
FACT-1770 - Increase Logging Clarity

### DIFF
--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -65,7 +65,7 @@
     <exclude name="UncommentedEmptyMethodBody" />
   </rule>
   <rule ref="category/java/errorprone.xml">
-    <exclude name="NonSerializableClass"/>
+    <exclude name="NonSerializableClass" />
   </rule>
   <rule ref="category/java/multithreading.xml" />
   <rule ref="category/java/performance.xml" />

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -65,7 +65,7 @@
     <exclude name="UncommentedEmptyMethodBody" />
   </rule>
   <rule ref="category/java/errorprone.xml">
-    <exclude name="BeanMembersShouldSerialize" />
+    <exclude name="NonSerializableClass"/>
   </rule>
   <rule ref="category/java/multithreading.xml" />
   <rule ref="category/java/performance.xml" />

--- a/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCaseCreator.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/bulkscan/orchestrator/helper/CcdCaseCreator.java
@@ -58,7 +58,6 @@ public class CcdCaseCreator {
         Instant deliveryDate,
         Map<String, Object> fieldsToOverwrite
     ) {
-        log.info("Creating new case");
         CcdAuthenticator authenticator = ccdAuthenticatorFactory.createForJurisdiction(JURISDICTION);
 
         StartEventResponse startEventResponse = startEventForCreateCase(authenticator);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/EnvelopeTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/EnvelopeTransformer.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.client.transformation.model.res
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.config.ServiceConfigProvider;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.envelopes.model.Envelope;
 
+import java.util.Optional;
+
 import static io.vavr.control.Either.left;
 import static io.vavr.control.Either.right;
 import static java.lang.String.format;
@@ -109,7 +111,7 @@ public class EnvelopeTransformer {
             envelope.id,
             envelope.zipFileName,
             envelope.container,
-            envelope.caseRef
+            Optional.ofNullable(envelope.caseRef).orElse("(NOT PRESENT)")
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/EnvelopeTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/client/transformation/EnvelopeTransformer.java
@@ -105,10 +105,11 @@ public class EnvelopeTransformer {
 
     private String getLoggingContext(Envelope envelope) {
         return format(
-            "Envelope ID: %s. File name: %s. Service: %s.",
+            "Envelope ID: %s. File name: %s. Service: %s. Case Reference: %s",
             envelope.id,
             envelope.zipFileName,
-            envelope.container
+            envelope.container,
+            envelope.caseRef
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessor.java
@@ -42,8 +42,9 @@ public class PaymentsProcessor {
             log.info("Finished processing payments for case with CCD reference {}", cmd.ccdReference);
         } else {
             log.info(
-                "Envelope has no payments, not sending create command. Envelope id: {}",
-                envelope.id
+                "Envelope has no payments, not sending create command. Envelope id: {}. Case reference {}",
+                envelope.id,
+                envelope.caseRef
             );
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/PaymentsProcessor.java
@@ -10,6 +10,8 @@ import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.pay
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.PaymentData;
 import uk.gov.hmcts.reform.bulkscan.orchestrator.services.servicebus.domains.payments.model.UpdatePaymentsCommand;
 
+import java.util.Optional;
+
 import static java.util.stream.Collectors.toList;
 
 @Service
@@ -44,7 +46,7 @@ public class PaymentsProcessor {
             log.info(
                 "Envelope has no payments, not sending create command. Envelope id: {}. Case reference {}",
                 envelope.id,
-                envelope.caseRef
+                Optional.ofNullable(envelope.caseRef).orElse("(NOT PRESENT)")
             );
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/envelopehandlers/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/envelopehandlers/CreateExceptionRecord.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.ccd.client.model.Event;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 @Component
 public class CreateExceptionRecord {
@@ -66,7 +67,7 @@ public class CreateExceptionRecord {
             envelope.id,
             envelope.zipFileName,
             envelope.container,
-            envelope.caseRef
+            Optional.ofNullable(envelope.caseRef).orElse("(NOT PRESENT)")
         );
         log.info("Creating exception record. {}", loggingContext);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/envelopehandlers/CreateExceptionRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/envelopehandlers/CreateExceptionRecord.java
@@ -62,10 +62,11 @@ public class CreateExceptionRecord {
 
     private Long createExceptionRecord(Envelope envelope) {
         String loggingContext = String.format(
-            "Envelope ID: %s, file name: %s, service: %s",
+            "Envelope ID: %s, file name: %s, service: %s, case reference: %s",
             envelope.id,
             envelope.zipFileName,
-            envelope.container
+            envelope.container,
+            envelope.caseRef
         );
         log.info("Creating exception record. {}", loggingContext);
 

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/envelopehandlers/SupplementaryEvidenceHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/envelopehandlers/SupplementaryEvidenceHandler.java
@@ -65,9 +65,10 @@ public class SupplementaryEvidenceHandler {
             }
         } else {
             log.info(
-                    "Case not found, zipFileName {}, envelopeId {}. Creating exception record instead",
+                    "Case not found, zipFileName {}, envelopeId {}, case reference {}. Creating exception record instead",
                     envelope.zipFileName,
-                    envelope.id
+                    envelope.id,
+                    envelope.caseRef
             );
             Long erId = exceptionRecordCreator.tryCreateFrom(envelope);
             paymentsProcessor.createPayments(envelope, erId, true);

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/envelopehandlers/SupplementaryEvidenceHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/envelopehandlers/SupplementaryEvidenceHandler.java
@@ -65,8 +65,8 @@ public class SupplementaryEvidenceHandler {
             }
         } else {
             log.info(
-                    "Case not found, zipFileName {}, envelopeId {}, case reference {}. " +
-                        "Creating exception record instead",
+                    "Case not found, zipFileName {}, envelopeId {}, case reference {}. "
+                        + "Creating exception record instead",
                     envelope.zipFileName,
                     envelope.id,
                     envelope.caseRef

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/envelopehandlers/SupplementaryEvidenceHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/envelopehandlers/SupplementaryEvidenceHandler.java
@@ -65,7 +65,8 @@ public class SupplementaryEvidenceHandler {
             }
         } else {
             log.info(
-                    "Case not found, zipFileName {}, envelopeId {}, case reference {}. Creating exception record instead",
+                    "Case not found, zipFileName {}, envelopeId {}, case reference {}. " +
+                        "Creating exception record instead",
                     envelope.zipFileName,
                     envelope.id,
                     envelope.caseRef

--- a/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/envelopehandlers/SupplementaryEvidenceHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscan/orchestrator/services/ccd/envelopehandlers/SupplementaryEvidenceHandler.java
@@ -69,7 +69,7 @@ public class SupplementaryEvidenceHandler {
                         + "Creating exception record instead",
                     envelope.zipFileName,
                     envelope.id,
-                    envelope.caseRef
+                    Optional.ofNullable(envelope.caseRef).orElse("(NOT PRESENT)")
             );
             Long erId = exceptionRecordCreator.tryCreateFrom(envelope);
             paymentsProcessor.createPayments(envelope, erId, true);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-1770

### Change description ###

- Removes a redundant log.info that says again about creating a new case
- Adds the envelope case reference to the logging context of transforming an envelope and creating an exception record
- Changes rule name to stop warning
- 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
